### PR TITLE
convert library to .net standard library

### DIFF
--- a/Adyen.EcommLibrary/Adyen.EcommLibrary.csproj
+++ b/Adyen.EcommLibrary/Adyen.EcommLibrary.csproj
@@ -1,15 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Copyright>Adyen</Copyright>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="log4net" Version="2.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />
   </ItemGroup>
-
+  
+  <!-- .NET 4.5 references, compilation flags and build options -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Web" />
+  </ItemGroup>
+  
 </Project>

--- a/AdyenEcommLibrarySolution.sln
+++ b/AdyenEcommLibrarySolution.sln
@@ -1,11 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27004.2006
+VisualStudioVersion = 15.0.26730.16
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Adyen.EcommLibrary", "Adyen.EcommLibrary\Adyen.EcommLibrary.csproj", "{B006B36C-B8B9-4B21-9A3A-3F4FF8879BA4}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Adyen.EcommLibrary.Test", "Adyen.EcommLibrary.Test\Adyen.EcommLibrary.Test.csproj", "{8AC1D1BC-1B6A-4DE4-93C2-91C845EC31D9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Adyen.EcommLibrary", "Adyen.EcommLibrary\Adyen.EcommLibrary.csproj", "{88D8217F-83CC-46D8-94AF-1F570E2A4F68}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -13,14 +13,14 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{B006B36C-B8B9-4B21-9A3A-3F4FF8879BA4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B006B36C-B8B9-4B21-9A3A-3F4FF8879BA4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B006B36C-B8B9-4B21-9A3A-3F4FF8879BA4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B006B36C-B8B9-4B21-9A3A-3F4FF8879BA4}.Release|Any CPU.Build.0 = Release|Any CPU
 		{8AC1D1BC-1B6A-4DE4-93C2-91C845EC31D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8AC1D1BC-1B6A-4DE4-93C2-91C845EC31D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8AC1D1BC-1B6A-4DE4-93C2-91C845EC31D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8AC1D1BC-1B6A-4DE4-93C2-91C845EC31D9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{88D8217F-83CC-46D8-94AF-1F570E2A4F68}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{88D8217F-83CC-46D8-94AF-1F570E2A4F68}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{88D8217F-83CC-46D8-94AF-1F570E2A4F68}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{88D8217F-83CC-46D8-94AF-1F570E2A4F68}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Converted the adyen library to a .net standard library to enable to target more .net platforms and versions.
For a a complete overview of the multi targeting capabilities , please refer to 
* https://docs.microsoft.com/en-us/dotnet/standard/net-standard

TLDR Now with these changes, anyone using the library can use it from .net 4.5 and upwards for the .net framework and .net core 2.0