### PR TITLE
Update from net45 to net 461

### DIFF
--- a/Adyen.EcommLibrary/Adyen.EcommLibrary.csproj
+++ b/Adyen.EcommLibrary/Adyen.EcommLibrary.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Copyright>Adyen</Copyright>
     <Version>1.1.2</Version>
@@ -31,7 +31,7 @@
   </ItemGroup>
   
   <!-- .NET 4.5 references, compilation flags and build options -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Web" />


### PR DESCRIPTION
Remove the .net framework 4.5. The reason is that it was preventing the library to run on unix based systems and docker container. Based on the following matrix .net standard supports .net 4.6.1 and above. https://github.com/dotnet/standard/blob/master/docs/versions.md
