### PR TITLE
Remove header http expect. It is added by .net

### DIFF
--- a/Adyen.EcommLibrary/HttpClient/HttpURLConnectionClient.cs
+++ b/Adyen.EcommLibrary/HttpClient/HttpURLConnectionClient.cs
@@ -117,9 +117,8 @@ namespace Adyen.EcommLibrary.HttpClient
             httpWebRequest.ContentType = "application/json";
             httpWebRequest.Headers.Add("Accept-Charset", "UTF-8");
             httpWebRequest.Headers.Add("Cache-Control", "no-cache");
-            httpWebRequest.Headers.Add("Expect", "100-continue");
             httpWebRequest.UserAgent = $"{config.ApplicationName} {ClientConfig.UserAgentSuffix}{ClientConfig.LibVersion}";
-
+         
             if (config.SkipCertValidation)
             {
                 httpWebRequest.ServerCertificateValidationCallback = delegate { return true; };


### PR DESCRIPTION
Remove header http expect as it is added by the .net standard. Adding it is causing issues with .net framework 4.6.1. 