### PR TITLE
Add decorator to AbstractPaymentRequest Metadata property

### DIFF
--- a/Adyen.EcommLibrary/Model/AbstractPaymentRequest.cs
+++ b/Adyen.EcommLibrary/Model/AbstractPaymentRequest.cs
@@ -72,7 +72,9 @@ namespace Adyen.EcommLibrary.Model
         [DataMember(Name = "telephoneNumber", EmitDefaultValue = false)]
         public string TelephoneNumber { get; set; }
         public string Mcc = null;
-        public KeyValuePair<string, string> Metadata { get; set; }
+
+        [DataMember(Name = "metadata", EmitDefaultValue = false)]
+        public Dictionary<string, string> Metadata { get; set; }
 
         [DataMember(Name = "applicationInfo", EmitDefaultValue = false)]
         public ApplicationInformation.ApplicationInfo ApplicationInfo { get;set; }

--- a/Adyen.EcommLibrary/Model/AbstractPaymentRequest.cs
+++ b/Adyen.EcommLibrary/Model/AbstractPaymentRequest.cs
@@ -71,7 +71,8 @@ namespace Adyen.EcommLibrary.Model
         public DateTime DateOfBirth { get; set; }
         [DataMember(Name = "telephoneNumber", EmitDefaultValue = false)]
         public string TelephoneNumber { get; set; }
-        public string Mcc = null;
+        [DataMember(Name="mcc", EmitDefaultValue = false)]
+        public string Mcc { get; set; }
 
         [DataMember(Name = "metadata", EmitDefaultValue = false)]
         public Dictionary<string, string> Metadata { get; set; }


### PR DESCRIPTION
Add decorator to ensure the `Metadata` property is serialized correctly for classes derived from `AbstractPaymentRequest`