### PR TITLE
Change ShopperInteraction to allow Moto PaymentRequests

### DIFF
--- a/Adyen.EcommLibrary/Model/AbstractPaymentRequest.cs
+++ b/Adyen.EcommLibrary/Model/AbstractPaymentRequest.cs
@@ -26,7 +26,7 @@ namespace Adyen.EcommLibrary.Model
         public BrowserInfo BrowserInfo { get; set; }
         [DataMember(Name = "shopperInteraction", EmitDefaultValue = false)]
         [JsonConverter(typeof(StringEnumConverter))]
-        public ShopperInteraction ShopperInteraction { get; set; }
+        public ShopperInteraction? ShopperInteraction { get; set; }
         [DataMember(Name = "shopperEmail", EmitDefaultValue = false)]
         public string ShopperEmail { get; set; }
         [DataMember(Name = "shopperReference", EmitDefaultValue = false)]


### PR DESCRIPTION
Changed the ShopperInteraction property to be nullable enabling moto
payment requests to be serialized by StringEnumConverter correctly.

This PR is only the fix change. I have a unit test on another branch here (https://github.com/Pearson0123/adyen-dotnet-api-library/blob/shopperInteractionTest/Adyen.EcommLibrary.Test/PaymentTest.cs) if that is required.

To reproduce this issue you can run the unit test (TestShopperInteractionSerialization) on develop.