### PR TITLE
Reorder ShopperInteraction Enum and correct default

### DIFF
--- a/Adyen.EcommLibrary.Test/MockPaymentData.cs
+++ b/Adyen.EcommLibrary.Test/MockPaymentData.cs
@@ -1,7 +1,6 @@
 ﻿using Adyen.EcommLibrary.Model;
 using System;
 using System.Collections.Generic;
-using Adyen.EcommLibrary.Model.ApplicationInformation;
 using Environment = Adyen.EcommLibrary.Model.Enum.Environment;
 
 namespace Adyen.EcommLibrary.Test
@@ -31,7 +30,7 @@ namespace Adyen.EcommLibrary.Test
                 XApiKey = "AQEyhmfxK....LAG84XwzP5pSpVd"//mock api key
             };
         }
-        
+
         public static PaymentRequest CreateFullPaymentRequest()
         {
             var paymentRequest = new PaymentRequest
@@ -42,6 +41,13 @@ namespace Adyen.EcommLibrary.Test
                 Reference = "payment - " + DateTime.Now.ToString("yyyyMMdd"),
                 AdditionalData = CreateAdditionalData()
             };
+            return paymentRequest;
+        }
+
+        public static PaymentRequest CreateFullPaymentRequestWithShopperInteraction(Model.Enum.ShopperInteraction shopperInteraction)
+        {
+            var paymentRequest = CreateFullPaymentRequest();
+            paymentRequest.ShopperInteraction = shopperInteraction;
             return paymentRequest;
         }
 
@@ -91,7 +97,7 @@ namespace Adyen.EcommLibrary.Test
             return "8514836072314693";
         }
 
-       
+
 
         #endregion
     }

--- a/Adyen.EcommLibrary.Test/UtilTest.cs
+++ b/Adyen.EcommLibrary.Test/UtilTest.cs
@@ -39,5 +39,21 @@ namespace Adyen.EcommLibrary.Test
             var ecnrypted = hmacValidator.CalculateHmac(data, key);
             Assert.IsTrue(string.Equals(ecnrypted, "34oR8T1whkQWTv9P+SzKyp8zhusf9n0dpqrm9nsqSJs="));
         }
+
+        [TestMethod]
+        public void TestSerializationShopperInteractionDefault()
+        {
+            var paymentRequest = MockPaymentData.CreateFullPaymentRequestWithShopperInteraction(default(Model.Enum.ShopperInteraction));
+            var serializedPaymentRequest = JsonOperation.SerializeRequest(paymentRequest);
+            Assert.IsFalse(serializedPaymentRequest.Contains("shopperInteraction"));
+        }
+
+        [TestMethod]
+        public void TestSerializationShopperInteractionMoto()
+        {
+            var paymentRequest = MockPaymentData.CreateFullPaymentRequestWithShopperInteraction(Model.Enum.ShopperInteraction.Moto);
+            var serializedPaymentRequest = JsonOperation.SerializeRequest(paymentRequest);
+            StringAssert.Contains(serializedPaymentRequest, nameof(Model.Enum.ShopperInteraction.Moto));
+        }
     }
 }

--- a/Adyen.EcommLibrary/Model/Enum/ShopperInteraction.cs
+++ b/Adyen.EcommLibrary/Model/Enum/ShopperInteraction.cs
@@ -2,6 +2,8 @@
 {
     public enum ShopperInteraction
     {
-        Moto, Ecommerce, ContAuth
+        Ecommerce = 0,
+        Moto = 1,
+        ContAuth = 2
     }
 }


### PR DESCRIPTION
The default value for the ShopperInteraction is Ecommerce according
to the docs https://docs.adyen.com/api-explorer/#/Payment/v40/authorise.
However the default value for an Enum is 0 which, if no
values are specified, corresponds to the first enum value
https://stackoverflow.com/questions/529929/choosing-the-default-value-of-an-enum-type-without-having-to-change-values/529937.
This along with the EmitDefaultValue = false means that if ShopperInteraction.Moto
was passed in the PaymentRequest object it would be seen as default value
and left out of the serialization. When the API call is made the lack of
a ShopperInteraction means the actual default value is used which is Ecommerce.
Thus all Moto payments actually get processed as Ecommerce.

Reordered ShopperInteraction so Ecommerce is the default.
Added tests to confirm that reordering enum allows ShopperInteraction.Moto
to be correctly serialized.