### PR TITLE
Remove ServicePointManager.SecurityProtocol

### DIFF
--- a/Adyen.EcommLibrary/HttpClient/HttpURLConnectionClient.cs
+++ b/Adyen.EcommLibrary/HttpClient/HttpURLConnectionClient.cs
@@ -18,9 +18,7 @@ namespace Adyen.EcommLibrary.HttpClient
         public string Request(string endpoint, string json, Config config, bool isApiKeyRequired)
         {
             string responseText = null;
-            //Set security protocol. Only TLS1.2
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-
+         
             var httpWebRequest = GetHttpWebRequest(endpoint, config, isApiKeyRequired);
 
             using (var streamWriter = new StreamWriter(httpWebRequest.GetRequestStream()))


### PR DESCRIPTION
Remove the ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
Setting the SecurityProtocol all the application is affected. In case of other modules in the application using different security level the calls are blocked. 
https://docs.microsoft.com/en-us/dotnet/api/system.net.servicepointmanager.securityprotocol?view=netstandard-2.0