### PR TITLE
InputResponse add ancestor, fix error GenericArguments[0], 'Adyen.Eco…

### DIFF
--- a/Adyen.EcommLibrary/Model/Nexo/InputResponse.cs
+++ b/Adyen.EcommLibrary/Model/Nexo/InputResponse.cs
@@ -1,11 +1,13 @@
-﻿namespace Adyen.EcommLibrary.Model.Nexo
+﻿using Adyen.EcommLibrary.CloudApiSerialization;
+
+namespace Adyen.EcommLibrary.Model.Nexo
 {
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.6.1055.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    public partial class InputResponse
+    public partial class InputResponse : IMessagePayload
     {
 
         /// <remarks/>


### PR DESCRIPTION
…mmLibrary.Model.Nexo.InputResponse', on 'Adyen.EcommLibrary.CloudApiSerialization.MessagePayloadSerializer`1[T]' violates the constraint of type 'T'.