### PR TITLE
Added exception for invalid usage of live client constructor generation

### DIFF
--- a/Adyen.Test/CheckoutTest.cs
+++ b/Adyen.Test/CheckoutTest.cs
@@ -11,14 +11,42 @@ namespace Adyen.Test
     [TestClass]
     public class CheckoutTest : BaseTest
     {
+        /// <summary>
+        /// Tests successful checkout client Test URL generation.
+        /// </summary>
         [TestMethod]
-        public void CheckoutEndpointTest()
+        public void CheckoutEndpointTestEnvironmentSuccessTest()
+        {
+            var config = new Config();
+            var client = new Client(config);
+            client.SetEnviroment(Model.Enum.Environment.Test, "companyUrl");
+            Assert.AreEqual(config.CheckoutEndpoint, @"https://checkout-test.adyen.com");
+            Assert.AreEqual(config.Endpoint, @"https://pal-test.adyen.com");
+        }
+
+        /// <summary>
+        /// Tests successful checkout client Live URL generation.
+        /// </summary>
+        [TestMethod]
+        public void CheckoutEndpointLiveEnvironmentSuccessTest()
         {
             var config = new Config();
             var client = new Client(config);
             client.SetEnviroment(Model.Enum.Environment.Live, "companyUrl");
             Assert.AreEqual(config.CheckoutEndpoint, @"https://companyUrl-checkout-live.adyenpayments.com/checkout");
             Assert.AreEqual(config.Endpoint, @"https://companyUrl-pal-live.adyenpayments.com");
+        }
+
+        /// <summary>
+        /// Tests unsuccessful checkout client Live URL generation.
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException), "Missing liveEndpointUrlPrefix for endpoint generation")]
+        public void CheckoutEndpointLiveErrorTest()
+        {
+            var config = new Config();
+            var client = new Client(config);
+            client.SetEnviroment(Model.Enum.Environment.Live);
         }
 
         /// <summary>

--- a/Adyen/Client.cs
+++ b/Adyen/Client.cs
@@ -1,8 +1,9 @@
-﻿using Adyen.Constants;
+﻿using System;
+using Adyen.Constants;
 using Adyen.HttpClient.Interfaces;
 using Adyen.HttpClient;
-using Adyen.Model.Enum;
-using System.Net.Security;
+using Adyen.Exceptions;
+using Environment = Adyen.Model.Enum.Environment;
 
 namespace Adyen
 {
@@ -70,15 +71,15 @@ namespace Adyen
                     Config.CheckoutEndpoint = ClientConfig.CheckoutEndpointTest;
                     break;
                 case Environment.Live:
-                    Config.Endpoint = ClientConfig.EndpointLive;
+                    if (string.IsNullOrEmpty(liveEndpointUrlPrefix))
+                    {
+                        throw new InvalidOperationException(ExceptionMessages.MissingLiveEndpointUrlPrefix);
+                    }
+
+                    Config.Endpoint = ClientConfig.EndpointProtocol + liveEndpointUrlPrefix + ClientConfig.EndpointLiveSuffix;
                     Config.HppEndpoint = ClientConfig.HppLive;
                     Config.CloudApiEndPoint = ClientConfig.CloudApiEndPointLive;
-                    //set live endpoint for checkout api
-                    if (!string.IsNullOrEmpty(liveEndpointUrlPrefix))
-                    {
-                        Config.Endpoint = ClientConfig.EndpointProtocol + liveEndpointUrlPrefix + ClientConfig.EndpointLiveSuffix;
-                        Config.CheckoutEndpoint = ClientConfig.EndpointProtocol + liveEndpointUrlPrefix + ClientConfig.CheckoutEndpointLiveSuffix;
-                    }
+                    Config.CheckoutEndpoint = ClientConfig.EndpointProtocol + liveEndpointUrlPrefix + ClientConfig.CheckoutEndpointLiveSuffix;
                     break;
             }
         }

--- a/Adyen/Exceptions/ExceptionMessages.cs
+++ b/Adyen/Exceptions/ExceptionMessages.cs
@@ -11,5 +11,6 @@ namespace Adyen.Exceptions
         internal const string InvalidMessageType = "Invalid Message Type for the message: {0}";
         internal const string TerminalErrorResponse = "Terminal Error Response: {0}";
         internal const string ExceptionDuringDeserialization = "Exception during deserialization of object: {0}, Exception Message: {1}";
+        internal const string MissingLiveEndpointUrlPrefix = "Missing liveEndpointUrlPrefix for endpoint generation";
     }
 }


### PR DESCRIPTION
Not 100% sure if you're happy with this change, basically made it throw an `InvalidOperationException` if `liveEndpointUrlPrefix` is empty when setting/generating the live URLs in the Client constructor. I'm going under the assumption that it should always be populated for Live environments.

-Added 2 unit tests.
-Edited 1 unit test.
-Throw an `InvalidOperationException` if `liveEndpointUrlPrefix` is empty on Live environment.