### PR TITLE
Deriving from IMessagePayload is necessary to prevent the MessagePayl…

### DIFF
--- a/Adyen/Model/Nexo/LoginResponse.cs
+++ b/Adyen/Model/Nexo/LoginResponse.cs
@@ -1,11 +1,13 @@
-﻿namespace Adyen.Model.Nexo
+﻿using Adyen.CloudApiSerialization;
+
+namespace Adyen.Model.Nexo
 {
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.6.1055.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    public partial class LoginResponse
+    public partial class LoginResponse : IMessagePayload
     {
 
         /// <remarks/>

--- a/Adyen/Model/Nexo/LogoutResponse.cs
+++ b/Adyen/Model/Nexo/LogoutResponse.cs
@@ -1,11 +1,13 @@
-﻿namespace Adyen.Model.Nexo
+﻿using Adyen.CloudApiSerialization;
+
+namespace Adyen.Model.Nexo
 {
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.6.1055.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    public partial class LogoutResponse
+    public partial class LogoutResponse : IMessagePayload
     {
 
         /// <remarks/>

--- a/Adyen/Model/Nexo/LoyaltyResponse.cs
+++ b/Adyen/Model/Nexo/LoyaltyResponse.cs
@@ -1,11 +1,13 @@
-﻿namespace Adyen.Model.Nexo
+﻿using Adyen.CloudApiSerialization;
+
+namespace Adyen.Model.Nexo
 {
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.6.1055.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    public partial class LoyaltyResponse
+    public partial class LoyaltyResponse : IMessagePayload
     {
 
         /// <remarks/>

--- a/Adyen/Model/Nexo/ReconciliationResponse.cs
+++ b/Adyen/Model/Nexo/ReconciliationResponse.cs
@@ -1,11 +1,13 @@
-﻿namespace Adyen.Model.Nexo
+﻿using Adyen.CloudApiSerialization;
+
+namespace Adyen.Model.Nexo
 {
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.6.1055.0")]
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    public partial class ReconciliationResponse
+    public partial class ReconciliationResponse : IMessagePayload
     {
 
         /// <remarks/>

--- a/Adyen/Model/Nexo/RepeatedResponseMessageBody.cs
+++ b/Adyen/Model/Nexo/RepeatedResponseMessageBody.cs
@@ -1,4 +1,6 @@
-﻿namespace Adyen.Model.Nexo
+﻿using Adyen.CloudApiSerialization;
+
+namespace Adyen.Model.Nexo
 {
     /// <remarks/>
     [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.6.1055.0")]
@@ -7,7 +9,7 @@
     [System.ComponentModel.DesignerCategoryAttribute("code")]
     [System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true)]
     [System.Xml.Serialization.XmlRootAttribute(Namespace = "", IsNullable = false)]
-    public partial class RepeatedResponseMessageBody
+    public partial class RepeatedResponseMessageBody : IMessagePayload
     {
         [System.Xml.Serialization.XmlElementAttribute("CardAcquisitionResponse", typeof(CardAcquisitionResponse), Form = System.Xml.Schema.XmlSchemaForm.Unqualified)]
         [System.Xml.Serialization.XmlElementAttribute("CardReaderAPDUResponse", typeof(CardReaderAPDUResponse), Form = System.Xml.Schema.XmlSchemaForm.Unqualified)]


### PR DESCRIPTION
Deriving from IMessagePayload is necessary to prevent the MessagePayloadSerializer in Adyen.CloudApiSerialization.MessagePayloadSerializer to give a T constraint violation. Has crashed on LoginResponse and LogoutResponse before, and this code has proven to fix it.


