### PR TITLE
Fix receipts

### DIFF
--- a/Adyen/Model/Nexo/OutputText.cs
+++ b/Adyen/Model/Nexo/OutputText.cs
@@ -71,7 +71,7 @@
 
         /// <remarks/>
         [System.Xml.Serialization.XmlTextAttribute()]
-        public string Value;
+        public string Text;
 
         public OutputText()
         {


### PR DESCRIPTION
The OutputContent.OutputFormat.Text variable is named Text in the Adyen webservice, but Value in Adyen.Model.Nexo.OutputText. This causes incorrect serialization. Easiest solution is to change the variable name of Adyen.Model.Nexo.OutputText.Value to Text. 
The incorrect serialization caused the content values of the receipts in  PaymentResponse.PaymentReceipt[] to be all set to null, which means no receipt could be parsed from the data.