### PR TITLE
Added properties to enable usage of ApplePay and GooglePay tokens via the dotnet API library

### DIFF
--- a/Adyen.Test/BaseTest.cs
+++ b/Adyen.Test/BaseTest.cs
@@ -119,6 +119,54 @@ namespace Adyen.Test
         }
 
         /// <summary>
+        /// Check out Apple Pay payment request
+        /// </summary>
+        /// <returns></returns>
+        public Model.Checkout.PaymentRequest CreateApplePayPaymentRequestCheckout()
+        {
+            var amount = new Model.Checkout.Amount("USD", 1000);
+            var applePay = new Model.Checkout.DefaultPaymentMethodDetails()
+            {
+                Type = "applepay",
+                ApplePayToken = "VNRWtuNlNEWkRCSm1xWndjMDFFbktkQU..."
+            };
+            var paymentsRequest = new Model.Checkout.PaymentRequest
+            {
+                Amount = amount,
+                Reference = "Your order number ",
+                ReturnUrl = @"https://your-company.com/...",
+                MerchantAccount = "MerchantAccount",
+                PaymentMethod = applePay
+            };
+
+            return paymentsRequest;
+        }
+
+        /// <summary>
+        /// Check out Google Pay payment request
+        /// </summary>
+        /// <returns></returns>
+        public Model.Checkout.PaymentRequest CreateGooglePayPaymentRequestCheckout()
+        {
+            var amount = new Model.Checkout.Amount("USD", 1000);
+            var googlePay = new Model.Checkout.DefaultPaymentMethodDetails()
+            {
+                Type = "paywithgoogle",
+                GooglePayToken = "==Payload as retrieved from Google Pay response=="
+            };
+            var paymentsRequest = new Model.Checkout.PaymentRequest
+            {
+                Amount = amount,
+                Reference = "Your order number ",
+                ReturnUrl = @"https://your-company.com/...",
+                MerchantAccount = "MerchantAccount",
+                PaymentMethod = googlePay
+            };
+
+            return paymentsRequest;
+        }
+
+        /// <summary>
         /// 3DS2 payments request
         /// </summary>
         /// <returns></returns>

--- a/Adyen.Test/CheckoutTest.cs
+++ b/Adyen.Test/CheckoutTest.cs
@@ -74,6 +74,37 @@ namespace Adyen.Test
             Assert.AreEqual("visa", paymentResponse.AdditionalData["cardPaymentMethod"]);
             Assert.AreEqual("NL", paymentResponse.AdditionalData["cardIssuingCountry"]);
         }
+
+        /// <summary>
+        /// Test success flow for Apple Pay
+        /// POST /payments
+        /// </summary>
+        [TestMethod]
+        public void PaymentsApplePayTest()
+        {
+            var paymentRequest = CreateApplePayPaymentRequestCheckout();
+            var client = CreateMockTestClientApiKeyBasedRequest("Mocks/checkout/payments-applepay-success.json");
+            var checkout = new Checkout(client);
+            var paymentResponse = checkout.Payments(paymentRequest);
+            Assert.AreEqual("9035798957043214", paymentResponse.PspReference);
+            Assert.AreEqual(ResultCodeEnum.Authorised, paymentResponse.ResultCode);
+        }
+
+        /// <summary>
+        /// Test success flow for Google Pay
+        /// POST /payments
+        /// </summary>
+        [TestMethod]
+        public void PaymentsGooglePayTest()
+        {
+            var paymentRequest = CreateGooglePayPaymentRequestCheckout();
+            var client = CreateMockTestClientApiKeyBasedRequest("Mocks/checkout/payments-googlepay-success.json");
+            var checkout = new Checkout(client);
+            var paymentResponse = checkout.Payments(paymentRequest);
+            Assert.AreEqual("9035798960987345", paymentResponse.PspReference);
+            Assert.AreEqual(ResultCodeEnum.Authorised, paymentResponse.ResultCode);
+        }
+
         /// <summary>
         /// Test success flow for 3DS2
         /// POST /payments

--- a/Adyen.Test/MockPaymentData.cs
+++ b/Adyen.Test/MockPaymentData.cs
@@ -97,6 +97,22 @@ namespace Adyen.Test
             return paymentRequest;
         }
 
+        public static Adyen.Model.Checkout.PaymentRequest CreateApplePayPaymentRequest()
+        {
+            var paymentRequest = new Adyen.Model.Checkout.PaymentRequest
+            {
+                MerchantAccount = "MerchantAccount",
+                Reference = "payment - " + DateTime.Now.ToString("yyyyMMdd"),
+                PaymentMethod = new DefaultPaymentMethodDetails
+                {
+                    Type = "applepay",
+                    ApplePayToken = "ApplePayToken"
+                }
+            };
+            
+            return paymentRequest;
+        }
+
         public static BrowserInfo CreateMockBrowserInfo()
         {
             return new BrowserInfo

--- a/Adyen.Test/Mocks/checkout/payments-applepay-success.json
+++ b/Adyen.Test/Mocks/checkout/payments-applepay-success.json
@@ -1,0 +1,4 @@
+{
+  "pspReference": "9035798957043214",
+  "resultCode": "Authorised"
+}

--- a/Adyen.Test/Mocks/checkout/payments-googlepay-success.json
+++ b/Adyen.Test/Mocks/checkout/payments-googlepay-success.json
@@ -1,0 +1,4 @@
+﻿{
+  "pspReference": "9035798960987345",
+  "resultCode": "Authorised"
+}

--- a/Adyen/Model/Checkout/DefaultPaymentMethodDetails.cs
+++ b/Adyen/Model/Checkout/DefaultPaymentMethodDetails.cs
@@ -51,9 +51,12 @@ namespace Adyen.Model.Checkout
         public string SepaOwnerName { get; set; }
         [DataMember(Name = "sepa.ibanNumber", EmitDefaultValue = false)]
         public string SepaIbanNumber { get; set; }
-
         [DataMember(Name = "bankAccount", EmitDefaultValue = false)]
         public BankAccount BankAccount { get; set; }
+        [DataMember(Name = "additionalData.applepay.token", EmitDefaultValue = false)]
+        public string ApplePayToken { get; set; }
+        [DataMember(Name = "paywithgoogle.token", EmitDefaultValue = false)]  
+        public string GooglePayToken { get; set; }
 
         public override string ToString()
         {
@@ -79,6 +82,8 @@ namespace Adyen.Model.Checkout
             sb.Append("  SepaOwnerName: ").Append(SepaOwnerName).Append("\n");
             sb.Append("  SepaIbanNumber: ").Append(SepaIbanNumber).Append("\n");
             sb.Append("  BankAccount: ").Append(BankAccount).Append("\n");
+            sb.Append("  ApplePayToken: ").Append(BankAccount).Append("\n");
+            sb.Append("  GooglePayToken: ").Append(BankAccount).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -212,6 +217,16 @@ namespace Adyen.Model.Checkout
                     this.BankAccount == input.BankAccount ||
                     (this.BankAccount != null &&
                     this.BankAccount.Equals(input.BankAccount))
+                ) &&
+                (
+                    this.ApplePayToken == input.ApplePayToken ||
+                    (this.ApplePayToken != null &&
+                    this.ApplePayToken.Equals(input.ApplePayToken))
+                ) &&
+                (
+                    this.GooglePayToken == input.GooglePayToken ||
+                    (this.GooglePayToken != null &&
+                    this.GooglePayToken.Equals(input.GooglePayToken))
                 );
         }
 


### PR DESCRIPTION
We are currently trying to integrate our iOS and Android apps with our own sales API which uses the Adyen Checkout API. However, when sending the token details as specified in the API Explorer on the Adyen site, the token values are lost during deserialisation, as there are no corresponding properties for additionalData.applepay.token or paywithgoogle.token. This change should allow us to complete our integration.