### PR TITLE
a proposed change to the GetDataToSign function in hmacvalidator

### DIFF
--- a/Adyen.Test/UtilTest.cs
+++ b/Adyen.Test/UtilTest.cs
@@ -51,7 +51,7 @@ namespace Adyen.Test
         public void TestNotificationRequestItemHmac()
         {
             string key = "DFB1EB5485895CFA84146406857104ABB4CBCABDC8AAF103A624C8F6A3EAAB00";
-            var expectedSign = "Awgfqd8xaKOgp6qZA3m+eCToAIWIPWvv4pBtXMzJL0Q=";
+            var expectedSign = "ipnxGCaUZ4l8TUW75a71/ghd2Fe5ffvX0pV4TLTntIc=";
             var additionalData = new Dictionary<string, string>
             {
                 { Constants.AdditionalData.HmacSignature, expectedSign }
@@ -69,7 +69,7 @@ namespace Adyen.Test
             };
             var hmacValidator = new HmacValidator();
             var data = hmacValidator.GetDataToSign(notificationRequestItem);
-            Assert.AreEqual("pspReference:originalReference:merchantAccount:reference:1000:EUR:EVENT:True", data);
+            Assert.AreEqual("pspReference:originalReference:merchantAccount:reference:1000:EUR:EVENT:true", data);
             var encrypted = hmacValidator.CalculateHmac(notificationRequestItem, key);
             Assert.AreEqual(expectedSign, encrypted);
             notificationRequestItem.AdditionalData[Constants.AdditionalData.HmacSignature] = expectedSign;

--- a/Adyen/Util/HMACValidator.cs
+++ b/Adyen/Util/HMACValidator.cs
@@ -95,7 +95,7 @@ namespace Adyen.Util
                 Convert.ToString(amount.Value),
                 amount.Currency,
                 notificationRequestItem.EventCode,
-                notificationRequestItem.Success.ToString()
+                notificationRequestItem.Success.ToString().toLower()
             };
             return String.Join(":", signedDataList);
         }


### PR DESCRIPTION
In the example on the website the boolean is shown with a lowercase t. 
I presume (maybe mistakenly) that the encyption done on the adyenside is done with a lower case t(rue) or f(alse)
doing this in dotnet will result in a string with an uppercase T or F.  (that why is propose a ToLower()
rendering a different hash and will give a false negative.
Shouldn't this be the same as in the java test?
because you are using the same data and same key. so the hash should be the same

in the java test:
`assertEquals("pspReference:originalReference:merchantAccount:reference:1000:EUR:EVENT:true", data);`
[java](https://github.com/Adyen/adyen-java-api-library/blob/develop/src/test/java/com/adyen/UtilTest.java)
or in the nodejs test:
 `expect(data).toEqual("pspReference:originalReference:merchantAccount:reference:1000:EUR:EVENT:true");`
[nodejs](https://github.com/Adyen/adyen-node-api-library/blob/develop/src/__tests__/hmacValidator.spec.ts)
