### PR TITLE
Ok check should also be implemented for sync api calls

### DIFF
--- a/Adyen/Service/PosPaymentCloudApi.cs
+++ b/Adyen/Service/PosPaymentCloudApi.cs
@@ -71,7 +71,7 @@ namespace Adyen.Service
             this.Client.LogLine("Request: \n"+ serializedMessage);
             var response = _terminalApiSync.Request(serializedMessage);
             this.Client.LogLine("Response: \n"+ response);
-            if (string.IsNullOrEmpty(response))
+            if (string.IsNullOrEmpty(response) || string.Equals("ok", response))
             {
                 return null;
             }


### PR DESCRIPTION
There was already a fix for requests that returned ok for async calls, but this fix also solves it for sync calls.