### PR TITLE
Minor update to the Client class and the related test CheckoutTest

### DIFF
--- a/Adyen.Test/CheckoutTest.cs
+++ b/Adyen.Test/CheckoutTest.cs
@@ -41,7 +41,7 @@ namespace Adyen.Test
         {
             var config = new Config();
             var client = new Client(config);
-            client.SetEnviroment(Model.Enum.Environment.Test, "companyUrl");
+            client.SetEnvironment(Model.Enum.Environment.Test, "companyUrl");
             Assert.AreEqual(config.CheckoutEndpoint, @"https://checkout-test.adyen.com");
             Assert.AreEqual(config.Endpoint, @"https://pal-test.adyen.com");
         }
@@ -54,7 +54,7 @@ namespace Adyen.Test
         {
             var config = new Config();
             var client = new Client(config);
-            client.SetEnviroment(Model.Enum.Environment.Live, "companyUrl");
+            client.SetEnvironment(Model.Enum.Environment.Live, "companyUrl");
             Assert.AreEqual(config.CheckoutEndpoint, @"https://companyUrl-checkout-live.adyenpayments.com/checkout");
             Assert.AreEqual(config.Endpoint, @"https://companyUrl-pal-live.adyenpayments.com");
         }
@@ -68,7 +68,7 @@ namespace Adyen.Test
         {
             var config = new Config();
             var client = new Client(config);
-            client.SetEnviroment(Model.Enum.Environment.Live);
+            client.SetEnvironment(Model.Enum.Environment.Live);
         }
 
         /// <summary>

--- a/Adyen/Client.cs
+++ b/Adyen/Client.cs
@@ -49,7 +49,7 @@ namespace Adyen
                 Password = password,
                 Environment = environment
             };
-            this.SetEnviroment(environment);
+            this.SetEnvironment(environment);
         }
         
         public Client(string xapikey, Environment environment)
@@ -59,7 +59,7 @@ namespace Adyen
                 Environment = environment,
                 XApiKey = xapikey
             };
-            this.SetEnviroment(environment);
+            this.SetEnvironment(environment);
         }
 
         public Client(string xapikey, Environment environment, string liveEndpointUrlPrefix)
@@ -69,7 +69,7 @@ namespace Adyen
                 Environment = environment,
                 XApiKey = xapikey
             };
-            this.SetEnviroment(environment,liveEndpointUrlPrefix);
+            this.SetEnvironment(environment,liveEndpointUrlPrefix);
         }
 
         public Client(Config config)
@@ -77,12 +77,12 @@ namespace Adyen
             Config = config;
         }
 
-        public void SetEnviroment(Environment environment)
+        public void SetEnvironment(Environment environment)
         {
-            SetEnviroment(environment, null);
+            SetEnvironment(environment, null);
         }
 
-        public void SetEnviroment(Environment environment, string liveEndpointUrlPrefix)
+        public void SetEnvironment(Environment environment, string liveEndpointUrlPrefix)
         {
             Config.Environment = environment;
             switch (environment)


### PR DESCRIPTION
Correcting the typo in the member name (Client.SetEnviroment -> Client.SetEnvironment) and in the CheckoutTest test that references this method.