### PR TITLE
Update framework version to .net core 2.1 for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: csharp
-dist: trusty
+sudo: required
+dist: xenial
 mono: none
 dotnet: 2.1.0
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: csharp
-dist: xenial
+dist: trusty
 mono: none
 dotnet: 2.1.0
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: csharp
 dist: xenial
 mono: none
-dotnet: 2.0.0
+dotnet: 2.1.0
 install:
 - dotnet restore
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: csharp
 sudo: required
 dist: xenial
 mono: none
-dotnet: 2.1.0
+dotnet: 2.1.200
 install:
 - dotnet restore
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 sudo: required
-dist: xenial
+dist: trusty
 mono: none
 dotnet: 2.1.200
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 sudo: required
-dist: trusty
+dist: xenial
 mono: none
 dotnet: 2.1.200
 install:

--- a/Adyen.Test/Adyen.Test.csproj
+++ b/Adyen.Test/Adyen.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
 


### PR DESCRIPTION
Some dependencies updates failing because the TargetFramework for the tests is in 2.0. 