### PR TITLE
Add test notification item deserialize with escaped chars

### DIFF
--- a/Adyen.Test/Mocks/notification-response-refund-fail.json
+++ b/Adyen.Test/Mocks/notification-response-refund-fail.json
@@ -1,0 +1,23 @@
+{
+	"live": "false",
+	"notificationItems": [{
+		"NotificationRequestItem": {
+			"additionalData": {
+				"hmacSignature": "lQnzbwY09e5mwkC8YZozlHu5v\/2SFzAx6WRrvHx+3b8="
+			},
+			"amount": {
+				"currency": "EUR",
+				"value": 100
+			},
+			"eventCode": "CAPTURE",
+			"eventDate": "2020-01-21T12:30:00+01:00",
+			"merchantAccountCode": "DotNetAlexandros",
+			"merchantReference": "UseqNbr006-orderId006\\\/",
+			"originalReference": "TEST_CUSTOM_881578412007338A",
+			"paymentMethod": "mc",
+			"pspReference": "TEST_CUSTOM_881578412137072J",
+			"reason": "sf",
+			"success": "false"
+		}
+	}]
+}

--- a/Adyen.Test/UtilTest.cs
+++ b/Adyen.Test/UtilTest.cs
@@ -103,7 +103,7 @@ namespace Adyen.Test
         }
         
         [TestMethod]
-        public void TestHmacCalculationModification()
+        public void TestHmacCalculationNotificationRequestWithSpecialChars()
         {
             string key = "66B61474A0AA3736BA8789EDC6D6CD9EBA0C4F414A554E32A407F849C045C69D";
             var mockPath = GetMockFilePath("Mocks/notification-response-refund-fail.json");

--- a/Adyen.Test/UtilTest.cs
+++ b/Adyen.Test/UtilTest.cs
@@ -111,8 +111,6 @@ namespace Adyen.Test
             var hmacValidator = new HmacValidator();
             var notificationRequest = JsonOperation.Deserialize<NotificationRequest>(response);
             var notificationItem = notificationRequest.NotificationItemContainers[0].NotificationItem;
-            var data = hmacValidator.GetDataToSign(notificationItem);
-            var encrypted = hmacValidator.CalculateHmac(notificationItem, key);
             var isValidHmac = hmacValidator.IsValidHmac(notificationItem, key);
             Assert.IsTrue(isValidHmac);
         }

--- a/Adyen.Test/UtilTest.cs
+++ b/Adyen.Test/UtilTest.cs
@@ -25,6 +25,7 @@ using Adyen.Model.Notification;
 using Adyen.Util;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace Adyen.Test
 {
@@ -51,7 +52,7 @@ namespace Adyen.Test
             buildSigningString = hmacValidator.BuildSigningString(postParameters);
             Assert.IsTrue(string.Equals("currencyCode:merchantAccount:EUR:ACC\\:\\\\", buildSigningString));
         }
-
+        
         [TestMethod]
         public void TestHmac()
         {
@@ -69,7 +70,7 @@ namespace Adyen.Test
             var serializedPaymentRequest = JsonOperation.SerializeRequest(paymentRequest);
             Assert.IsFalse(serializedPaymentRequest.Contains("shopperInteraction"));
         }
-
+        
         [TestMethod]
         public void TestNotificationRequestItemHmac()
         {
@@ -100,7 +101,21 @@ namespace Adyen.Test
             notificationRequestItem.AdditionalData[Constants.AdditionalData.HmacSignature] = "notValidSign";
             Assert.IsFalse(hmacValidator.IsValidHmac(notificationRequestItem, key));
         }
-
+        
+        [TestMethod]
+        public void TestHmacCalculationModification()
+        {
+            string key = "66B61474A0AA3736BA8789EDC6D6CD9EBA0C4F414A554E32A407F849C045C69D";
+            var mockPath = GetMockFilePath("Mocks/notification-response-refund-fail.json");
+            var response = MockFileToString(mockPath);
+            var hmacValidator = new HmacValidator();
+            var notificationRequest = JsonOperation.Deserialize<NotificationRequest>(response);
+            var notificationItem = notificationRequest.NotificationItemContainers[0].NotificationItem;
+            var data = hmacValidator.GetDataToSign(notificationItem);
+            var encrypted = hmacValidator.CalculateHmac(notificationItem, key);
+            var isValidHmac = hmacValidator.IsValidHmac(notificationItem, key);
+            Assert.IsTrue(isValidHmac);
+        }
 
         [TestMethod]
         public void TestSerializationShopperInteractionMoto()

--- a/Adyen/Util/HMACValidator.cs
+++ b/Adyen/Util/HMACValidator.cs
@@ -127,7 +127,6 @@ namespace Adyen.Util
         {
             string expectedSign = CalculateHmac(notificationRequestItem, key);
             string merchantSign = notificationRequestItem.AdditionalData[Constants.AdditionalData.HmacSignature];
-
             return string.Equals(expectedSign, merchantSign);
         }
 


### PR DESCRIPTION
Add test to deserialize notification item json with special chars. The test checks if the hmac key is valid. 