### PR TITLE
Changed ctor for Name model to not (apparently) accept nulls and made props readonly

### DIFF
--- a/Adyen.Test/ModelTests/NameTests.cs
+++ b/Adyen.Test/ModelTests/NameTests.cs
@@ -1,0 +1,40 @@
+﻿using Adyen.Model.Checkout;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Adyen.Test.ModelTests
+{
+    [TestClass]
+    public class NameTests
+    {
+        /// <summary>
+        /// Since first name is mandatory, it should not be possible to create a name instance without it
+        /// </summary>
+        [TestMethod]
+        public void CreatingNameWithoutFirstNameFails()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => new Name(null, Name.GenderEnum.MALE, null, null));
+        }
+
+        /// <summary>
+        /// Since last name is mandatory, it should not be possible to create a Name instance without it
+        /// </summary>
+        [TestMethod]
+        public void CreatingNameWithoutLastNameFails()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => new Name("firstName", Name.GenderEnum.MALE, null, null));
+        }
+
+        /// <summary>
+        /// Since last name is mandatory, it should not be possible to create a Name instance without it
+        /// </summary>
+        [TestMethod]
+        public void CreatingNameWithoutInfixSucceeds()
+        {
+            var name = new Name("firstName", Name.GenderEnum.MALE, null, "lastName");
+            Assert.IsNull(name.Infix);
+        }
+    }
+}

--- a/Adyen/Model/Checkout/Name.cs
+++ b/Adyen/Model/Checkout/Name.cs
@@ -24,7 +24,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.IO;
 using System.Runtime.Serialization;
 using System.Text;
 using Newtonsoft.Json;
@@ -122,14 +121,14 @@ namespace Adyen.Model.Checkout
         /// </summary>
         /// <value>The name&#39;s infix, if applicable. &gt;A maximum length of twenty (20) characters is imposed.</value>
         [DataMember(Name = "infix", EmitDefaultValue = false)]
-        public string Infix { get; set; }
+        public string Infix { get; }
 
         /// <summary>
         /// The last name.
         /// </summary>
         /// <value>The last name.</value>
         [DataMember(Name = "lastName", EmitDefaultValue = false)]
-        public string LastName { get; set; }
+        public string LastName { get;  }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/Adyen/Model/Checkout/Name.cs
+++ b/Adyen/Model/Checkout/Name.cs
@@ -36,7 +36,7 @@ namespace Adyen.Model.Checkout
     /// Name
     /// </summary>
     [DataContract]
-    public partial class Name :  IEquatable<Name>, IValidatableObject
+    public partial class Name : IEquatable<Name>, IValidatableObject
     {
         /// <summary>
         /// The gender. &gt;The following values are permitted: &#x60;MALE&#x60;, &#x60;FEMALE&#x60;, &#x60;UNKNOWN&#x60;.
@@ -45,19 +45,19 @@ namespace Adyen.Model.Checkout
         [JsonConverter(typeof(StringEnumConverter))]
         public enum GenderEnum
         {
-            
+
             /// <summary>
             /// Enum MALE for value: MALE
             /// </summary>
             [EnumMember(Value = "MALE")]
             MALE = 1,
-            
+
             /// <summary>
             /// Enum FEMALE for value: FEMALE
             /// </summary>
             [EnumMember(Value = "FEMALE")]
             FEMALE = 2,
-            
+
             /// <summary>
             /// Enum UNKNOWN for value: UNKNOWN
             /// </summary>
@@ -69,7 +69,7 @@ namespace Adyen.Model.Checkout
         /// The gender. &gt;The following values are permitted: &#x60;MALE&#x60;, &#x60;FEMALE&#x60;, &#x60;UNKNOWN&#x60;.
         /// </summary>
         /// <value>The gender. &gt;The following values are permitted: &#x60;MALE&#x60;, &#x60;FEMALE&#x60;, &#x60;UNKNOWN&#x60;.</value>
-        [DataMember(Name="gender", EmitDefaultValue=false)]
+        [DataMember(Name = "gender", EmitDefaultValue = false)]
         public GenderEnum Gender { get; set; }
         /// <summary>
         /// Initializes a new instance of the <see cref="Name" /> class.
@@ -79,62 +79,56 @@ namespace Adyen.Model.Checkout
         /// <summary>
         /// Initializes a new instance of the <see cref="Name" /> class.
         /// </summary>
-        /// <param name="FirstName">The first name. (required).</param>
-        /// <param name="Gender">The gender. &gt;The following values are permitted: &#x60;MALE&#x60;, &#x60;FEMALE&#x60;, &#x60;UNKNOWN&#x60;. (required).</param>
-        /// <param name="Infix">The name&#39;s infix, if applicable. &gt;A maximum length of twenty (20) characters is imposed..</param>
-        /// <param name="LastName">The last name. (required).</param>
-        public Name(string FirstName = default(string), GenderEnum Gender = default(GenderEnum), string Infix = default(string), string LastName = default(string))
+        /// <param name="firstName">The first name. (required).</param>
+        /// <param name="gender">The gender. &gt;The following values are permitted: &#x60;MALE&#x60;, &#x60;FEMALE&#x60;, &#x60;UNKNOWN&#x60;. (required).</param>
+        /// <param name="infix">The name&#39;s infix, if applicable. &gt;A maximum length of twenty (20) characters is imposed..</param>
+        /// <param name="lastName">The last name. (required).</param>
+        public Name(string firstName, GenderEnum gender, string infix, string lastName)
         {
             // to ensure "FirstName" is required (not null)
-            if (FirstName == null)
+            if (firstName == null)
             {
-                throw new InvalidDataException("FirstName is a required property for Name and cannot be null");
+                throw new ArgumentNullException("FirstName is a required property for Name and cannot be null");
             }
             else
             {
-                this.FirstName = FirstName;
+                this.FirstName = firstName;
             }
-            // to ensure "Gender" is required (not null)
-            if (Gender == null)
-            {
-                throw new InvalidDataException("Gender is a required property for Name and cannot be null");
-            }
-            else
-            {
-                this.Gender = Gender;
-            }
+
+            this.Gender = gender;
+
             // to ensure "LastName" is required (not null)
-            if (LastName == null)
+            if (lastName == null)
             {
-                throw new InvalidDataException("LastName is a required property for Name and cannot be null");
+                throw new ArgumentNullException("LastName is a required property for Name and cannot be null");
             }
             else
             {
-                this.LastName = LastName;
+                this.LastName = lastName;
             }
-            this.Infix = Infix;
+            this.Infix = infix;
         }
-        
+
         /// <summary>
         /// The first name.
         /// </summary>
         /// <value>The first name.</value>
-        [DataMember(Name="firstName", EmitDefaultValue=false)]
-        public string FirstName { get; set; }
+        [DataMember(Name = "firstName", EmitDefaultValue = false)]
+        public string FirstName { get; }
 
 
         /// <summary>
         /// The name&#39;s infix, if applicable. &gt;A maximum length of twenty (20) characters is imposed.
         /// </summary>
         /// <value>The name&#39;s infix, if applicable. &gt;A maximum length of twenty (20) characters is imposed.</value>
-        [DataMember(Name="infix", EmitDefaultValue=false)]
+        [DataMember(Name = "infix", EmitDefaultValue = false)]
         public string Infix { get; set; }
 
         /// <summary>
         /// The last name.
         /// </summary>
         /// <value>The last name.</value>
-        [DataMember(Name="lastName", EmitDefaultValue=false)]
+        [DataMember(Name = "lastName", EmitDefaultValue = false)]
         public string LastName { get; set; }
 
         /// <summary>
@@ -152,7 +146,7 @@ namespace Adyen.Model.Checkout
             sb.Append("}\n");
             return sb.ToString();
         }
-  
+
         /// <summary>
         /// Returns the JSON string presentation of the object
         /// </summary>
@@ -182,22 +176,22 @@ namespace Adyen.Model.Checkout
             if (input == null)
                 return false;
 
-            return 
+            return
                 (
                     this.FirstName == input.FirstName ||
                     (this.FirstName != null &&
                     this.FirstName.Equals(input.FirstName))
-                ) && 
+                ) &&
                 (
                     this.Gender == input.Gender ||
                     (this.Gender != null &&
                     this.Gender.Equals(input.Gender))
-                ) && 
+                ) &&
                 (
                     this.Infix == input.Infix ||
                     (this.Infix != null &&
                     this.Infix.Equals(input.Infix))
-                ) && 
+                ) &&
                 (
                     this.LastName == input.LastName ||
                     (this.LastName != null &&
@@ -234,15 +228,15 @@ namespace Adyen.Model.Checkout
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         {
             // Gender (string) maxLength
-            if(this.Gender != null && this.Gender.ToString().Length > 1)
+            if (this.Gender != null && this.Gender.ToString().Length > 1)
             {
-                yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Gender, length must be less than 1.", new [] { "Gender" });
+                yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Gender, length must be less than 1.", new[] { "Gender" });
             }
 
             // Gender (string) minLength
-            if(this.Gender != null && this.Gender.ToString().Length < 1)
+            if (this.Gender != null && this.Gender.ToString().Length < 1)
             {
-                yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Gender, length must be greater than 1.", new [] { "Gender" });
+                yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Gender, length must be greater than 1.", new[] { "Gender" });
             }
 
             yield break;


### PR DESCRIPTION
We recently integrated against Adyen, and experienced a couple of unnecessary issues which would have been avoided with a more intuitive code interface.

This PR alters the Name object to not (apparently) allow nulls. The original code exposes a ctor which allows not passing in arguments, but immediately fails if firstName or lastName are null. It seems a bit silly to set default values which immediately throws exceptions.

The PR also removed the check for gender == null, since enums can't actually be null, throws ArgumentNullException instead of InvalidDataExeption and renames parameters to pascal case, since that's conventional .net.

I'm not sure if the checks should actually be string.IsNullOrEmpty, though, but this should keep the original functionality while giving devs a better experience.

Lastly,  all properties are changed to readonly, since they are required to construct the object.