### PR TITLE
PrintResponse extends IMessagePayload

### DIFF
--- a/Adyen/Model/Nexo/PrintResponse.cs
+++ b/Adyen/Model/Nexo/PrintResponse.cs
@@ -21,6 +21,8 @@
 //  */
 #endregion
 
+using Adyen.CloudApiSerialization;
+
 namespace Adyen.Model.Nexo
 {
     /// <remarks/>
@@ -28,7 +30,7 @@ namespace Adyen.Model.Nexo
     [System.SerializableAttribute()]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
     [System.ComponentModel.DesignerCategoryAttribute("code")]
-    public partial class PrintResponse
+    public partial class PrintResponse :IMessagePayload
     {
 
         /// <remarks/>


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
There is bug with the nexo PrintResponse model. It needs to extend the IMessagePayload to use the serializer.
-->

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  #284 
