### PR TITLE
Adds paymentMethod as a property for PaymentsResponse

### DIFF
--- a/Adyen.Test/CheckoutTest.cs
+++ b/Adyen.Test/CheckoutTest.cs
@@ -575,5 +575,23 @@ namespace Adyen.Test
             var paymentResponse = checkout.Payments(paymentRequest);
             Assert.AreEqual("EC-42N19135GM6949000", paymentResponse.Action.SdkData["orderID"]);
         }
+
+
+        /// <summary>
+        /// Test paymentMethod field for /payments/details requests
+        /// Post /payments/details 
+        /// </summary>
+        [TestMethod]
+        public void TrustlyPaymentSuccessMockedTest()
+        {
+            var client = CreateMockTestClientRequest("Mocks/checkout/paymentsdetails-success-trustly.json");
+            var checkout = new Checkout(client);
+            var paymentDetails = CreateDetailsRequest();
+            var paymentResponse = checkout.PaymentDetails(paymentDetails);
+            Assert.AreEqual(paymentResponse.PaymentMethod, "trustly");
+            Assert.AreEqual(paymentResponse.PspReference, "881595517976891A");
+            Assert.AreEqual(paymentResponse.ResultCode, ResultCodeEnum.Received);
+            Assert.AreEqual(paymentResponse.MerchantReference, "81d5a69d-6880-4011-9a5d-8e120491010b");
+        }
     }
 }

--- a/Adyen.Test/Mocks/checkout/paymentsdetails-success-trustly.json
+++ b/Adyen.Test/Mocks/checkout/paymentsdetails-success-trustly.json
@@ -1,0 +1,7 @@
+{
+  "pspReference": "881595517976891A",
+  "resultCode": "Received",
+  "merchantReference": "81d5a69d-6880-4011-9a5d-8e120491010b",
+  "paymentMethod": "trustly",
+  "shopperLocale": "en_GB"
+}

--- a/Adyen/Model/Checkout/PaymentsResponse.cs
+++ b/Adyen/Model/Checkout/PaymentsResponse.cs
@@ -235,7 +235,14 @@ namespace Adyen.Model.Checkout
 
         [DataMember(Name = "serviceError", EmitDefaultValue = false)]
         public ServiceError ServiceError { get; set; }
-       
+
+        /// <summary>
+        /// The payment method that was submited on /payments or /payments/details, not currently documented on the official API documentation
+        /// </summary>
+        /// <value>The payment method that was submited on /payments or /payments/details, not currently documented on the official API documentation</value>
+        [DataMember(Name = "paymentMethod", EmitDefaultValue = false)]
+        public string PaymentMethod { get; set; }
+
         /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
@@ -259,6 +266,7 @@ namespace Adyen.Model.Checkout
             sb.Append("  Action: ").Append(Action).Append("\n");
             sb.Append("  ThreeDS2Result: ").Append(ThreeDS2Result).Append("\n");
             sb.Append("  ServiceError: ").Append(ServiceError).Append("\n");
+            sb.Append("  PaymentMethod: ").Append(PaymentMethod).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -368,6 +376,11 @@ namespace Adyen.Model.Checkout
                     this.ServiceError == input.ServiceError ||
                     (this.ServiceError != null &&
                     this.ServiceError.Equals(input.ServiceError))
+                ) &&
+                (
+                    this.PaymentMethod == input.PaymentMethod ||
+                    (this.PaymentMethod != null &&
+                    this.PaymentMethod.Equals(input.PaymentMethod))
                 );
         }
 


### PR DESCRIPTION

## Summary
Adds paymentMethod as a property for PaymentsResponse
This field is particularly useful to determine which payment method the customer verified without having to resort to storing and manipulating temporary data from the submit request.
There is still no documentation available on the Adyen Docs.


## Tested scenarios
Basic deserialization of a successful request (performed locally and exported to .json)


Let me know if there's other tests you find necessary for this approval


**Fixed issue**:  #290 
