### PR TITLE
Added RecurringProcessingModel to CreatePaymentLinkRequest

### DIFF
--- a/Adyen.Test/CheckoutTest.cs
+++ b/Adyen.Test/CheckoutTest.cs
@@ -511,7 +511,7 @@ namespace Adyen.Test
             var createPaymentLinkRequest = new CreatePaymentLinkRequest { Store = "TheDemoStore" };
             Assert.AreEqual(createPaymentLinkRequest.Store, "TheDemoStore");
         }
-        
+
         /// <summary>
         /// Test success flow for
         /// POST  /payments/result
@@ -528,7 +528,37 @@ namespace Adyen.Test
             Assert.AreEqual(paymentLinksResponse.Reference, "YOUR_ORDER_NUMBER");
             Assert.IsNotNull(paymentLinksResponse.Amount);
         }
-        
+
+        /// <summary>
+        /// Test success flow for creation of a payment link with recurring payment
+        /// POST /paymentLinks
+        /// </summary>
+        [TestMethod]
+        public void CreateRecurringPaymentLinkSuccessTest()
+        {
+            var client = CreateMockTestClientApiKeyBasedRequest("Mocks/checkout/paymentlinks-recurring-payment-success.json");
+            var checkout = new Checkout(client);
+
+            var createPaymentLinkRequest = new CreatePaymentLinkRequest
+            {
+                Reference = "REFERENCE_NUMBER",
+                MerchantAccount = "MerchantAccount",
+                Amount = new Amount("EUR", 100),
+                CountryCode = "GR",
+                ShopperLocale = "GR",
+                ShopperReference = "ShopperReference",
+                StorePaymentMethod = true,
+                RecurringProcessingModel = Model.Enum.RecurringProcessingModelEnum.Subscription
+            };
+
+            var paymentLinksResponse = checkout.PaymentLinks(createPaymentLinkRequest);
+
+            Assert.AreEqual(createPaymentLinkRequest.Reference, paymentLinksResponse.Reference);
+            Assert.AreEqual("https://checkoutshopper-test.adyen.com/checkoutshopper/payByLink.shtml?d=YW1vdW50TWlub3JW...JRA", paymentLinksResponse.Url);
+            Assert.AreEqual(createPaymentLinkRequest.Amount.Currency, paymentLinksResponse.Amount.Currency);
+            Assert.AreEqual(createPaymentLinkRequest.Amount.Value, paymentLinksResponse.Amount.Value);
+        }
+
         /// <summary>
         /// Test success flow for multibanco
         /// Post /payments 

--- a/Adyen.Test/Mocks/checkout/paymentlinks-recurring-payment-success.json
+++ b/Adyen.Test/Mocks/checkout/paymentlinks-recurring-payment-success.json
@@ -1,0 +1,9 @@
+{
+  "amount": {
+    "currency": "EUR",
+    "value": 100
+  },
+  "expiresAt": "2020-10-28T12:00:00Z",
+  "reference": "REFERENCE_NUMBER",
+  "url": "https://checkoutshopper-test.adyen.com/checkoutshopper/payByLink.shtml?d=YW1vdW50TWlub3JW...JRA"
+}

--- a/Adyen/Model/Checkout/CreatePaymentLinkRequest.cs
+++ b/Adyen/Model/Checkout/CreatePaymentLinkRequest.cs
@@ -24,6 +24,7 @@ using System.Text;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
+using Adyen.Model.Enum;
 
 namespace Adyen.Model.Checkout
 {
@@ -104,6 +105,14 @@ namespace Adyen.Model.Checkout
         public string MerchantAccount { get; set; }
 
         /// <summary>
+        /// Defines the type of a recurring payment.
+        /// </summary>
+        /// <value> Defines the type of a recurring payment.</value>
+        [DataMember(Name = "recurringProcessingModel", EmitDefaultValue = false)]
+        [JsonProperty(PropertyName = "recurringProcessingModel")]
+        public RecurringProcessingModelEnum? RecurringProcessingModel { get; set; }
+
+        /// <summary>
         /// The reference to uniquely identify a payment. This reference is used in all communication with you about the payment status. We recommend using a unique value per payment; however, it is not a requirement. If you need to provide multiple references for a transaction, separate them with hyphens (\"-\"). Maximum length: 80 characters.
         /// </summary>
         /// <value>The reference to uniquely identify a payment. This reference is used in all communication with you about the payment status. We recommend using a unique value per payment; however, it is not a requirement. If you need to provide multiple references for a transaction, separate them with hyphens (\"-\"). Maximum length: 80 characters.</value>
@@ -175,6 +184,7 @@ namespace Adyen.Model.Checkout
             sb.Append("  Description: ").Append(Description).Append("\n");
             sb.Append("  ExpiresAt: ").Append(ExpiresAt).Append("\n");
             sb.Append("  MerchantAccount: ").Append(MerchantAccount).Append("\n");
+            sb.Append("  RecurringProcessingModel: ").Append(RecurringProcessingModel).Append("\n");
             sb.Append("  Reference: ").Append(Reference).Append("\n");
             sb.Append("  ReturnUrl: ").Append(ReturnUrl).Append("\n");
             sb.Append("  ShopperEmail: ").Append(ShopperEmail).Append("\n");


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

The `RecurringProcessingModel` property was added to the `Adyen.Model.Checkout.CreatePaymentLinkRequest` class.

Now it is possible to specify the type of a recurring payment during the creation of a Payment Link request.

## Tested scenarios
<!-- Description of tested scenarios -->

- Tested a successful Payment Link response when the `RecurringProcessingModel` parameter is passed to the request.

**Fixed issue**:  <!-- #-prefixed issue number -->

#336 RecurringProcessingModel property missing from CreatePaymentLinkRequest