### PR TITLE
Corrects the property name for Apple Pay tokens

### DIFF
--- a/Adyen.Test/ApplePayDeserializationTest.cs
+++ b/Adyen.Test/ApplePayDeserializationTest.cs
@@ -1,0 +1,23 @@
+﻿using Adyen.Model.Checkout;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+
+namespace Adyen.Test
+{
+    [TestClass]
+    public class ApplePayDeserializationTest : BaseTest
+    {
+        [TestMethod]
+        public void Can_deserialize_applepay_paymentmethod_request()
+        {
+            var mockPath = GetMockFilePath("Mocks/checkout/paymentmethod-applepay-request.json");
+            var response = MockFileToString(mockPath);
+
+            var paymentMethod = JsonConvert.DeserializeObject<DefaultPaymentMethodDetails>(response);
+
+            Assert.IsNotNull(paymentMethod);
+            Assert.AreEqual("applepay", paymentMethod.Type);
+            Assert.AreEqual("VNRWtuNlNEWkRCSm1xWndjMDFFbktkQU...", paymentMethod.ApplePayToken);
+        }
+    }
+}

--- a/Adyen.Test/Mocks/checkout/paymentmethod-applepay-request.json
+++ b/Adyen.Test/Mocks/checkout/paymentmethod-applepay-request.json
@@ -1,0 +1,4 @@
+{
+	"type": "applepay",
+	"applepay.token": "VNRWtuNlNEWkRCSm1xWndjMDFFbktkQU..."
+}

--- a/Adyen/Model/Checkout/DefaultPaymentMethodDetails.cs
+++ b/Adyen/Model/Checkout/DefaultPaymentMethodDetails.cs
@@ -79,7 +79,7 @@ namespace Adyen.Model.Checkout
         public string SepaIbanNumber { get; set; }
         [DataMember(Name = "bankAccount", EmitDefaultValue = false)]
         public BankAccount BankAccount { get; set; }
-        [DataMember(Name = "additionalData.applepay.token", EmitDefaultValue = false)]
+        [DataMember(Name = "applepay.token", EmitDefaultValue = false)]
         public string ApplePayToken { get; set; }
         [DataMember(Name = "paywithgoogle.token", EmitDefaultValue = false)]
         public string GooglePayToken { get; set; }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
We currently parse submitted payments from the front-end in our system using `Adyen.Model.Checkout.DefaultPaymentMethodDetails`, but ran into an issue where Apple Pay tokens weren't present, resulting in the following error when POST-ing the payment to Adyen:

    {
       "status": 422,
       "errorCode": "14_004",
       "message": "Missing payment method details",
       "errorType: "validation"
    }

After investigating and confirming that the frontend was indeed sending `applepay.token` as expected, I noticed issue #330 which is the exact problem we have. Comparing with the Adyen Java library, the same issue isn't present.

## Tested scenarios
Apple Pay payment was successful using Adyen.dll built from this change.

**Fixed issue**:  #330 
