### PR TITLE
[PW-2640] Deserialize the response of dropin into the correct paymentMethod model

### DIFF
--- a/Adyen.Test/CheckoutTest.cs
+++ b/Adyen.Test/CheckoutTest.cs
@@ -605,5 +605,44 @@ namespace Adyen.Test
             var paymentResponse = checkout.Payments(paymentRequest);
             Assert.AreEqual("EC-42N19135GM6949000", paymentResponse.Action.SdkData["orderID"]);
         }
+
+      
+        [TestMethod]
+        public void ApplePayDetailsDeserializationTest()
+        {
+            var json = "{\"type\": \"applepay\",\"applePayToken\": \"VNRWtuNlNEWkRCSm1xWndjMDFFbktkQU...\"}";
+            var result = Util.JsonOperation.Deserialize<IPaymentMethodDetails>(json);
+            Assert.IsTrue(result is ApplePayDetails);
+            Assert.AreEqual(result.Type, "applepay");
+        }
+
+        [TestMethod]
+        public void BlikDetailsDeserializationTest()
+        {
+            var json = "{\"amount\":{\"value\":1000,\"currency\":\"USD\"},\"merchantAccount\":\"MerchantAccountTest\",\"paymentMethod\":{\"blikCode\":\"blikCode\",\"type\":\"blik\"},\"reference\":\"Your order number\",\"returnUrl\":\"https://your-company.com/...\",\"applicationInfo\":{\"adyenLibrary\":{\"name\":\"adyen-java-api-library\",\"version\":\"10.1.0\"}}}";
+            var paymentRequest = Util.JsonOperation.Deserialize<PaymentRequest>(json);
+            Assert.IsTrue(paymentRequest.PaymentMethod is BlikDetails);
+            Assert.AreEqual(paymentRequest.PaymentMethod.Type, BlikDetails.Blik);
+        }
+
+        [TestMethod]
+        public void DragonpayDetailsDeserializationTest()
+        {
+            var json = "{\"amount\":{\"value\":1000,\"currency\":\"USD\"},\"merchantAccount\":\"MerchantAccountTest\",\"paymentMethod\":{\"issuer\":\"issuer\",\"shopperEmail\":\"test@test.com\",\"type\":\"dragonpay_ebanking\"},\"reference\":\"Your order number\",\"returnUrl\":\"https://your-company.com/...\",\"applicationInfo\":{\"adyenLibrary\":{\"name\":\"adyen-java-api-library\",\"version\":\"10.1.0\"}}}";
+            var paymentRequest = Util.JsonOperation.Deserialize<PaymentRequest>(json);
+            Assert.IsTrue(paymentRequest.PaymentMethod is DragonpayDetails);
+            Assert.AreEqual(paymentRequest.PaymentMethod.Type, DragonpayDetails.EBanking);
+        }
+
+        [TestMethod]
+        public void LianLianPayDetailsDeserializationTest()
+        {
+            var json = "{\"amount\":{\"value\":1000,\"currency\":\"USD\"},\"merchantAccount\":\"MerchantAccountTest\",\"paymentMethod\":{\"telephoneNumber\":\"telephone\",\"type\":\"lianlianpay_ebanking_credit\"},\"reference\":\"Your order number\",\"returnUrl\":\"https://your-company.com/...\",\"applicationInfo\":{\"adyenLibrary\":{\"name\":\"adyen-java-api-library\",\"version\":\"10.1.0\"}}}";
+
+            LianLianPayDetails lianLianPayDetails = new LianLianPayDetails();
+            var paymentRequest = Util.JsonOperation.Deserialize<PaymentRequest>(json);
+            Assert.IsTrue(paymentRequest.PaymentMethod is LianLianPayDetails);
+            Assert.AreEqual(paymentRequest.PaymentMethod.Type, LianLianPayDetails.EbankingCredit);
+        }
     }
 }

--- a/Adyen/Util/JsonOperation.cs
+++ b/Adyen/Util/JsonOperation.cs
@@ -37,6 +37,7 @@ namespace Adyen.Util
         {
             var jsonSettings = new JsonSerializerSettings();
             jsonSettings.Converters.Add(new ByteArrayConverter());
+            jsonSettings.Converters.Add(new PaymentMethodsDetailsConverter());
             return JsonConvert.DeserializeObject<T>(response, jsonSettings);
         }
         

--- a/Adyen/Util/JsonOperation.cs
+++ b/Adyen/Util/JsonOperation.cs
@@ -37,7 +37,7 @@ namespace Adyen.Util
         {
             var jsonSettings = new JsonSerializerSettings();
             jsonSettings.Converters.Add(new ByteArrayConverter());
-            jsonSettings.Converters.Add(new PaymentMethodsDetailsConverter());
+            jsonSettings.Converters.Add(new PaymentMethodDetailsConverter());
             return JsonConvert.DeserializeObject<T>(response, jsonSettings);
         }
         

--- a/Adyen/Util/PaymentMethodDetailsConverter.cs
+++ b/Adyen/Util/PaymentMethodDetailsConverter.cs
@@ -126,7 +126,7 @@ namespace Adyen.Util
                     paymentMethodDetails = new PayPalDetails();
                     break;
                 case QiwiWalletDetails.QiwiWallet:
-                    paymentMethodDetails = new ApplePayDetails();
+                    paymentMethodDetails = new QiwiWalletDetails();
                     break;
                 case SamsungPayDetails.SamsungPay:
                     paymentMethodDetails = new SamsungPayDetails();

--- a/Adyen/Util/PaymentMethodDetailsConverter.cs
+++ b/Adyen/Util/PaymentMethodDetailsConverter.cs
@@ -27,7 +27,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Adyen.Util
 {
-    internal class PaymentMethodsDetailsConverter : JsonConverter
+    internal class PaymentMethodDetailsConverter : JsonConverter
     {
         public override bool CanConvert(Type objectType)
         {

--- a/Adyen/Util/PaymentMethodsDetailsConverter.cs
+++ b/Adyen/Util/PaymentMethodsDetailsConverter.cs
@@ -1,0 +1,151 @@
+﻿#region License
+// /*
+//  *                       ######
+//  *                       ######
+//  * ############    ####( ######  #####. ######  ############   ############
+//  * #############  #####( ######  #####. ######  #############  #############
+//  *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+//  * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+//  * ###### ######  #####( ######  #####. ######  #####          #####  ######
+//  * #############  #############  #############  #############  #####  ######
+//  *  ############   ############  #############   ############  #####  ######
+//  *                                      ######
+//  *                               #############
+//  *                               ############
+//  *
+//  * Adyen Dotnet API Library
+//  *
+//  * Copyright (c) 2020 Adyen B.V.
+//  * This file is open source and available under the MIT license.
+//  * See the LICENSE file for more info.
+//  */
+#endregion
+using Newtonsoft.Json;
+using System;
+using Adyen.Model.Checkout;
+using Newtonsoft.Json.Linq;
+
+namespace Adyen.Util
+{
+    internal class PaymentMethodsDetailsConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(IPaymentMethodDetails);
+        }
+        public override void WriteJson(JsonWriter writer,
+            object value, JsonSerializer serializer)
+        {
+            throw new InvalidOperationException("Use default serialization.");
+        }
+
+        public override object ReadJson(JsonReader reader,
+            Type objectType, object existingValue,
+            JsonSerializer serializer)
+        {
+            var jsonObject = JObject.Load(reader);
+            var paymentMethodDetails = default(IPaymentMethodDetails);
+            switch (jsonObject["type"].ToString())
+            {
+                case AchDetails.Ach:
+                    paymentMethodDetails = new AchDetails();
+                    break;
+                case AmazonPayDetails.AmazonPay:
+                    paymentMethodDetails = new AmazonPayDetails();
+                    break;
+                case ApplePayDetails.ApplePay:
+                    paymentMethodDetails = new ApplePayDetails();
+                    break;
+                case BacsDirectDebitDetails.Directdebit_GB:
+                    paymentMethodDetails = new BacsDirectDebitDetails();
+                    break;
+                case BilldeskOnlineDetails.BilldeskOnline:
+                    paymentMethodDetails = new BilldeskOnlineDetails();
+                    break;
+                case BilldeskWalletDetails.BilldeskWallet:
+                    paymentMethodDetails = new BilldeskWalletDetails();
+                    break;
+                case BlikDetails.Blik:
+                    paymentMethodDetails = new BlikDetails();
+                    break;
+                case DokuDetails.Alfamart:
+                case DokuDetails.Bcava:
+                case DokuDetails.Bniva:
+                case DokuDetails.Briva:
+                case DokuDetails.Cimbva:
+                case DokuDetails.Danamonva:
+                case DokuDetails.Permataliteatm:
+                case DokuDetails.Permatatm:
+                case DokuDetails.Sinarmasva:
+                case DokuDetails.Indomaret:
+                case DokuDetails.Mandiriva:
+                    paymentMethodDetails = new DokuDetails();
+                    break;
+                case DotpayDetails.Dotpay:
+                    paymentMethodDetails = new DotpayDetails();
+                    break;
+                case DragonpayDetails.EBanking:
+                case DragonpayDetails.OTCBanking:
+                case DragonpayDetails.OTCNonBanking:
+                case DragonpayDetails.OTCPhilippines:
+                    paymentMethodDetails = new DragonpayDetails();
+                    break;
+                case EcontextVoucherDetails.Stores:
+                case EcontextVoucherDetails.Seveneleven:
+                    paymentMethodDetails = new EcontextVoucherDetails();
+                    break;
+                case EntercashDetails.Entercash:
+                    paymentMethodDetails = new EntercashDetails();
+                    break;
+                case GiropayDetails.Giropay:
+                    paymentMethodDetails = new GiropayDetails();
+                    break;
+                case GooglePayDetails.GooglePay:
+                    paymentMethodDetails = new GooglePayDetails();
+                    break;
+                case IdealDetails.Ideal:
+                    paymentMethodDetails = new IdealDetails();
+                    break;
+                case LianLianPayDetails.EbankingCredit:
+                case LianLianPayDetails.EbankingDebit:
+                case LianLianPayDetails.EbankingEnterprise:
+                    paymentMethodDetails = new LianLianPayDetails();
+                    break;
+                case MbwayDetails.Mbway:
+                    paymentMethodDetails = new MbwayDetails();
+                    break;
+                case MolPayDetails.EBankingDirectMY:
+                case MolPayDetails.EBankingFPXMy:
+                case MolPayDetails.EBankingMY:
+                case MolPayDetails.EBankingTH:
+                case MolPayDetails.EBankingVN:
+                case MolPayDetails.FPX:
+                    paymentMethodDetails = new MolPayDetails();
+                    break;
+                case PayPalDetails.PayPal:
+                    paymentMethodDetails = new PayPalDetails();
+                    break;
+                case QiwiWalletDetails.QiwiWallet:
+                    paymentMethodDetails = new ApplePayDetails();
+                    break;
+                case SamsungPayDetails.SamsungPay:
+                    paymentMethodDetails = new SamsungPayDetails();
+                    break;
+                case SepaDirectDebitDetails.Sepadirectdebit:
+                    paymentMethodDetails = new SepaDirectDebitDetails();
+                    break;
+                case VippsDetails.Vipps:
+                    paymentMethodDetails = new VippsDetails();
+                    break;
+                case VisaCheckoutDetails.VisaCheckout:
+                    paymentMethodDetails = new VisaCheckoutDetails();
+                    break;
+                default:
+                    paymentMethodDetails = new DefaultPaymentMethodDetails();
+                    break;
+            }
+            serializer.Populate(jsonObject.CreateReader(), paymentMethodDetails);
+            return paymentMethodDetails;
+        }
+    }
+}


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
In this pr we are extending the Newtonsoft JsonConverter with a custom converter to deserialize the payment request with the payment method details class based on the IPaymentMethodDetails interface. This deserializes the paymentmethod based on the type and return the corresponding payment method detail class instance.
## Tested scenarios 
<!-- Description of tested scenarios -->
Test the deserialization with payment request and payment method detail class

**Fixed issue**:  <!-- #-prefixed issue number -->
