### PR TITLE
[PW-2616]Test the escape string with encryption

### DIFF
--- a/Adyen.Test/MockPosApiRequest.cs
+++ b/Adyen.Test/MockPosApiRequest.cs
@@ -75,9 +75,53 @@ namespace Adyen.Test
             };
             return saleToPoiRequest;
         }
-       
+
         /// <summary>
-        /// Dummy Nexo json Cloud api/terminal api request
+        /// Returns SaleToPOIRequest with MessagePayload PrintRequest with unescaped characters
+        /// </summary>
+        /// <returns>SaleToPOIRequest</returns>
+        public static SaleToPOIRequest CreateSaleToPOIPrintRequestEscape()
+        {
+            return new SaleToPOIRequest
+            {
+                MessageHeader = new MessageHeader()
+                {
+                    MessageClass = MessageClassType.Device,
+                    MessageCategory = MessageCategoryType.Print,
+                    MessageType = MessageType.Request,
+                    SaleID = "1234567",
+                    POIID = "VX680-12343454",
+                    ServiceID = "1",
+                },
+                MessagePayload = new PrintRequest
+                {
+                    PrintOutput = new PrintOutput
+                    {
+                        DocumentQualifier = DocumentQualifierType.Document,
+                        ResponseMode = ResponseModeType.PrintEnd,
+                        OutputContent = new OutputContent
+                        {
+                            OutputFormat = OutputFormatType.Text,
+                            OutputText = new OutputText[] { new OutputText { Text = @"m\u006DÄ\u00C4" } },
+                        },
+                    },
+                },
+            };
+        }
+
+        /// <summary>
+        /// Dummy Nexo json print request 
+        /// </summary>
+        /// <returns></returns>
+        public static string MockNexoJsonPrintRequest()
+        {
+            return "{\"SaleToPOIRequest\":{\"MessageHeader\":{\"MessageClass\":\"Device\",\"MessageCategory\":\"Print\",\"MessageType\":\"Request\",\"ServiceID\":\"1\",\"SaleID\":\"1234567\",\"POIID\":\"VX680-12343454\",\"ProtocolVersion\":\"3.0\"}," +
+                "\"PrintRequest\":{\"PrintOutput\":{\"OutputContent\":{\"OutputText\":[{\"Color\":\"White\",\"CharacterWidth\":\"SingleWidth\",\"CharacterHeight\":\"SingleHeight\",\"CharacterStyle\":\"Normal\",\"Alignment\":\"Left\"," +
+                "\"EndOfLineFlag\":true,\"Text\":\"m\\\\u006D?\\\\u00C4\"}],\"OutputFormat\":\"Text\"},\"DocumentQualifier\":\"Document\",\"ResponseMode\":\"PrintEnd\"}}}}";
+        }
+
+        /// <summary>
+        /// Dummy Nexo json api/terminal api request
         /// </summary>
         /// <returns></returns>
         public static string MockNexoJsonRequest()
@@ -90,6 +134,5 @@ namespace Adyen.Test
                    "     \"Currency\" : \"EUR\",\r\n               \"RequestedAmount\" : 15.25 \r\n            },\r\n            \"TransactionConditions\" : {}\r\n         },\r\n      " +
                    "   \"PaymentData\" : {\"PaymentType\" : \"Normal\"}\r\n      }\r\n   }\r\n}\r\n";
         }
-
     }
 }

--- a/Adyen.Test/MockPosApiRequest.cs
+++ b/Adyen.Test/MockPosApiRequest.cs
@@ -77,7 +77,7 @@ namespace Adyen.Test
         }
 
         /// <summary>
-        /// Returns SaleToPOIRequest with MessagePayload PrintRequest with unescaped characters
+        /// Returns SaleToPOIRequest with MessagePayload PrintRequest with escaped characters
         /// </summary>
         /// <returns>SaleToPOIRequest</returns>
         public static SaleToPOIRequest CreateSaleToPOIPrintRequestEscape()

--- a/Adyen.Test/TerminalApiPosSecurityTest.cs
+++ b/Adyen.Test/TerminalApiPosSecurityTest.cs
@@ -78,8 +78,8 @@ namespace Adyen.Test
         { 
             var saleToPoiRequest = MockPosApiRequest.CreateSaleToPOIPrintRequestEscape();
             var messageHeader = MockPosApiRequest.CreateSaleToPOIPrintRequestEscape().MessageHeader;
-            var _saleToPoiMessageSerializer = new SaleToPoiMessageSerializer();
-            var saleToPoiRequestMessageSerialized = _saleToPoiMessageSerializer.Serialize(saleToPoiRequest);
+            var saleToPoiMessageSerializer = new SaleToPoiMessageSerializer();
+            var saleToPoiRequestMessageSerialized = saleToPoiMessageSerializer.Serialize(saleToPoiRequest);
             var saleToPoiMessageSecured = _messageSecuredEncryptor.Encrypt(saleToPoiRequestMessageSerialized, messageHeader, _encryptionCredentialDetails);
             var saleToPoiRequestDecrypt = _messageSecuredEncryptor.Decrypt(saleToPoiMessageSecured, _encryptionCredentialDetails);
             Assert.IsNotNull(saleToPoiRequestDecrypt);

--- a/Adyen.Test/TerminalApiPosSecurityTest.cs
+++ b/Adyen.Test/TerminalApiPosSecurityTest.cs
@@ -21,6 +21,9 @@
 //  */
 #endregion
 
+using Adyen.ApiSerialization;
+using Adyen.Model.Nexo;
+using Adyen.Model.Nexo.Message;
 using Adyen.Security;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -69,5 +72,18 @@ namespace Adyen.Test
             Assert.IsNotNull(saleToPoiRequestDecrypt);
             Assert.AreEqual(saleToPoiRequest, saleToPoiRequestDecrypt);
         }
+
+        [TestMethod]
+        public void TestSaleToPoiMessageEscapeStringDecryption()
+        { 
+            var saleToPoiRequest = MockPosApiRequest.CreateSaleToPOIPrintRequestEscape();
+            var messageHeader = MockPosApiRequest.CreateSaleToPOIPrintRequestEscape().MessageHeader;
+            var _saleToPoiMessageSerializer = new SaleToPoiMessageSerializer();
+            var saleToPoiRequestMessageSerialized = _saleToPoiMessageSerializer.Serialize(saleToPoiRequest);
+            var saleToPoiMessageSecured = _messageSecuredEncryptor.Encrypt(saleToPoiRequestMessageSerialized, messageHeader, _encryptionCredentialDetails);
+            var saleToPoiRequestDecrypt = _messageSecuredEncryptor.Decrypt(saleToPoiMessageSecured, _encryptionCredentialDetails);
+            Assert.IsNotNull(saleToPoiRequestDecrypt);
+            Assert.AreEqual(MockPosApiRequest.MockNexoJsonPrintRequest(), saleToPoiRequestDecrypt);
+        } 
     }
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The encryption parses the strings properly but the string with unescaped chars should be escaped before encryption

## Tested scenarios
Parse a string with escapes characters

**Fixed issue**:  <!-- #-prefixed issue number -->
