### PR TITLE
Added missing SubType property and unit test for it.

### DIFF
--- a/Adyen.Test/BaseTest.cs
+++ b/Adyen.Test/BaseTest.cs
@@ -152,6 +152,23 @@ namespace Adyen.Test
             return paymentsRequest;
         }
 
+        public Model.Checkout.PaymentRequest CreatePayPalSmartPaymentRequestCheckout()
+        {
+            var amount = new Model.Checkout.Amount("USD", 1000);
+            var makePaymentRequest = new Model.Checkout.DefaultPaymentMethodDetails()
+            {
+                SubType = "Sdk"
+            };
+            var paymentsRequest = new Model.Checkout.PaymentRequest
+            {
+                Reference = "Your order number ",
+                ReturnUrl = @"https://your-company.com/...",
+                MerchantAccount = "MerchantAccount",  
+                PaymentMethod = makePaymentRequest
+            };
+            return paymentsRequest;
+        }
+
         /// <summary>
         /// Check out Apple Pay payment request
         /// </summary>

--- a/Adyen.Test/CheckoutTest.cs
+++ b/Adyen.Test/CheckoutTest.cs
@@ -606,7 +606,28 @@ namespace Adyen.Test
             Assert.AreEqual("EC-42N19135GM6949000", paymentResponse.Action.SdkData["orderID"]);
         }
 
-      
+        /// <summary>
+        /// Test success flow for paypal smart payment
+        /// Post /payments 
+        /// </summary>
+        [TestMethod]
+        public void PayPalSmartPaymentSuccessTest()
+        {
+            var client = CreateMockTestClientRequest("Mocks/checkout/payments-success-paypal.json");
+            var checkout = new Checkout(client);
+            var paymentRequest = CreatePayPalSmartPaymentRequestCheckout();
+            var paymentResponse = checkout.Payments(paymentRequest);           
+            var defaultPaymentMethod = paymentRequest.PaymentMethod as DefaultPaymentMethodDetails;
+
+            Assert.IsTrue(paymentRequest.PaymentMethod is DefaultPaymentMethodDetails);
+            Assert.IsNotNull(defaultPaymentMethod.SubType);
+            Assert.AreEqual("Sdk", defaultPaymentMethod.SubType);
+            Assert.AreEqual("Sdk", paymentResponse.Action.Type.ToString());
+            Assert.AreEqual("EC-42N19135GM6949000", paymentResponse.Action.SdkData["orderID"]);
+            
+        }
+
+
         [TestMethod]
         public void ApplePayDetailsDeserializationTest()
         {

--- a/Adyen.Test/CheckoutTest.cs
+++ b/Adyen.Test/CheckoutTest.cs
@@ -621,8 +621,8 @@ namespace Adyen.Test
 
             Assert.IsTrue(paymentRequest.PaymentMethod is DefaultPaymentMethodDetails);
             Assert.IsNotNull(defaultPaymentMethod.SubType);
-            Assert.AreEqual("Sdk", defaultPaymentMethod.SubType);
-            Assert.AreEqual("Sdk", paymentResponse.Action.Type.ToString());
+            Assert.AreEqual(Model.Checkout.CheckoutPaymentsAction.CheckoutActionType.Sdk.ToString(), defaultPaymentMethod.SubType);
+            Assert.AreEqual(Model.Checkout.CheckoutPaymentsAction.CheckoutActionType.Sdk.ToString(), paymentResponse.Action.Type.ToString());
             Assert.AreEqual("EC-42N19135GM6949000", paymentResponse.Action.SdkData["orderID"]);
             
         }

--- a/Adyen/Model/Checkout/DefaultPaymentMethodDetails.cs
+++ b/Adyen/Model/Checkout/DefaultPaymentMethodDetails.cs
@@ -83,6 +83,8 @@ namespace Adyen.Model.Checkout
         public string ApplePayToken { get; set; }
         [DataMember(Name = "paywithgoogle.token", EmitDefaultValue = false)]
         public string GooglePayToken { get; set; }
+        [DataMember(Name = "subtype", EmitDefaultValue = false)]
+        public string SubType { get; set; }
 
         public override string ToString()
         {
@@ -113,6 +115,7 @@ namespace Adyen.Model.Checkout
             sb.Append("  BankAccount: ").Append(BankAccount).Append("\n");
             sb.Append("  ApplePayToken: ").Append(BankAccount).Append("\n");
             sb.Append("  GooglePayToken: ").Append(BankAccount).Append("\n");
+            sb.Append("  SubType: ").Append(SubType).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -263,6 +266,11 @@ namespace Adyen.Model.Checkout
                     this.GooglePayToken == input.GooglePayToken ||
                     (this.GooglePayToken != null &&
                     this.GooglePayToken.Equals(input.GooglePayToken))
+                ) &&
+                (
+                    this.SubType == input.SubType ||
+                    (this.SubType != null &&
+                    this.SubType.Equals(input.SubType))
                 );
         }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
-->

Describe the changes proposed in this pull request:
- We noticed that SubType property is missing from the DefaultPaymentMethodDetails.cs and because of that PayPay smart payment was not able to trigger. 

When this property is added PayPay smart option becomes available for customers.

## Tested scenarios
<!-- Description of tested scenarios -->
Added Unittest that covers if SubType propery is present and if its value is the one expected for PayPal smart option.

**Fixed issue**:  <!-- #-prefixed issue number -->
