### PR TITLE
[PW-3796] In case of missing type in action returns dictionary 

### DIFF
--- a/Adyen.Test/CheckoutTest.cs
+++ b/Adyen.Test/CheckoutTest.cs
@@ -595,6 +595,20 @@ namespace Adyen.Test
             Assert.AreEqual("paypal", result.PaymentMethodType);
         }
 
+        /// <summary>
+        /// Test success without type in action
+        /// Post /payments 
+        /// </summary>
+        //[TestMethod]
+        //public void PaymentResponseWithoutTypeInActionTest()
+        //{
+        //    var client = CreateMockTestClientRequest("Mocks/checkout/payment-success-without-type-action.json");
+        //    var checkout = new Checkout(client);
+        //    var paymentRequest = CreatePaymentRequestCheckout();
+        //    var paymentResponse = checkout.Payments(paymentRequest);
+        //    Assert.IsTrue(paymentResponse.Action is CheckoutSDKAction);
+        //}
+
 
         [TestMethod]
         public void ApplePayDetailsDeserializationTest()

--- a/Adyen.Test/CheckoutTest.cs
+++ b/Adyen.Test/CheckoutTest.cs
@@ -30,6 +30,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Threading.Tasks;
 using static Adyen.Model.Checkout.PaymentResponse;
+using System.Collections;
 
 namespace Adyen.Test
 {
@@ -595,20 +596,28 @@ namespace Adyen.Test
             Assert.AreEqual("paypal", result.PaymentMethodType);
         }
 
-        /// <summary>
-        /// Test success without type in action
-        /// Post /payments 
-        /// </summary>
-        //[TestMethod]
-        //public void PaymentResponseWithoutTypeInActionTest()
-        //{
-        //    var client = CreateMockTestClientRequest("Mocks/checkout/payment-success-without-type-action.json");
-        //    var checkout = new Checkout(client);
-        //    var paymentRequest = CreatePaymentRequestCheckout();
-        //    var paymentResponse = checkout.Payments(paymentRequest);
-        //    Assert.IsTrue(paymentResponse.Action is CheckoutSDKAction);
-        //}
-
+        // <summary>
+        // Test success without type in action
+        // Post /payments 
+        // </summary>
+        [TestMethod]
+        public void PaymentResponseWithoutTypeInActionTest()
+        {
+            var client = CreateMockTestClientRequest("Mocks/checkout/payment-success-without-type-action.json");
+            var checkout = new Checkout(client);
+            var paymentRequest = CreatePaymentRequestCheckout();
+            var paymentResponse = checkout.Payments(paymentRequest);
+            Assert.IsNotNull(paymentResponse);
+            Assert.AreEqual(paymentResponse.ResultCode, ResultCodeEnum.RedirectShopper);
+            var paymentResponseAction = (PaymentResponseActionGeneric)paymentResponse.Action;
+            Assert.AreEqual(paymentResponseAction.PaymentResponseAction["method"], "GET");
+            Assert.AreEqual(paymentResponseAction.PaymentResponseAction["paymentMethodType"], "ideal");
+            Assert.AreEqual(paymentResponseAction.PaymentResponseAction["paymentData"], "Ab02b4c0!BQABAgA9+4KmHLS75...TKqeDpwlSfzHSPUC0/EwYDiN3UMBRl6Y8AkKAle");
+            Assert.AreEqual(paymentResponseAction.PaymentResponseAction["url"], "https://checkoutshopper-test.adyen.com/checkoutshopper/checkoutPaymentRedirect?redirectData=X...");
+            Assert.AreEqual(paymentResponse.Redirect.Method, Redirect.MethodEnum.GET);
+            Assert.AreEqual(paymentResponse.Redirect.Url, "https://checkoutshopper-test.adyen.com/checkoutshopper/checkoutPaymentRedirect?redirectData=...");
+            Assert.AreEqual(paymentResponse.Details[0], new InputDetail() { Key= "redirectResult", Type = "text" });
+        }
 
         [TestMethod]
         public void ApplePayDetailsDeserializationTest()

--- a/Adyen.Test/Mocks/checkout/payment-success-without-type-action.json
+++ b/Adyen.Test/Mocks/checkout/payment-success-without-type-action.json
@@ -1,0 +1,20 @@
+{
+  "resultCode": "RedirectShopper",
+  "action": {
+    "method": "GET",
+    "paymentData": "...",
+    "paymentMethodType": "ideal",
+    "url": "https://checkoutshopper-test.adyen.com/checkoutshopper/checkoutPaymentRedirect?redirectData=X..."
+  },
+  "details": [
+    {
+      "key": "redirectResult",
+      "type": "text"
+    }
+  ],
+  "paymentData": "...,
+  "redirect": {
+    "method": "GET",
+    "url": "https://checkoutshopper-test.adyen.com/checkoutshopper/checkoutPaymentRedirect?redirectData=..."
+  }
+}

--- a/Adyen.Test/Mocks/checkout/payment-success-without-type-action.json
+++ b/Adyen.Test/Mocks/checkout/payment-success-without-type-action.json
@@ -2,7 +2,7 @@
   "resultCode": "RedirectShopper",
   "action": {
     "method": "GET",
-    "paymentData": "...",
+    "paymentData": "Ab02b4c0!BQABAgA9+4KmHLS75...TKqeDpwlSfzHSPUC0/EwYDiN3UMBRl6Y8AkKAle",
     "paymentMethodType": "ideal",
     "url": "https://checkoutshopper-test.adyen.com/checkoutshopper/checkoutPaymentRedirect?redirectData=X..."
   },
@@ -12,7 +12,7 @@
       "type": "text"
     }
   ],
-  "paymentData": "...,
+  "paymentData": "Ab02b4c0!BQABAgA9+4KmHLS75...TKqeDpwlSfzHSPUC0/EwYDiN3UMBRl6Y8AkKAle",
   "redirect": {
     "method": "GET",
     "url": "https://checkoutshopper-test.adyen.com/checkoutshopper/checkoutPaymentRedirect?redirectData=..."

--- a/Adyen/Model/Checkout/Action/PaymentResponseActionGeneric.cs
+++ b/Adyen/Model/Checkout/Action/PaymentResponseActionGeneric.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Adyen.Model.Checkout.Action
+{
+    public class PaymentResponseActionGeneric : IPaymentResponseAction
+    {
+        public string Type { get; set; }
+
+        public Dictionary<string, object> PaymentResponseAction { get; set; }
+    }
+}

--- a/Adyen/Util/PaymentResponseActionConverter.cs
+++ b/Adyen/Util/PaymentResponseActionConverter.cs
@@ -24,6 +24,7 @@ using Newtonsoft.Json;
 using System;
 using Adyen.Model.Checkout.Action;
 using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
 
 namespace Adyen.Util
 {
@@ -45,38 +46,53 @@ namespace Adyen.Util
         {
             var jsonObject = JObject.Load(reader);
             var paymentResponseAction = default(IPaymentResponseAction);
-            switch (jsonObject["type"].ToString())
+            //In case that type is empty
+            if (jsonObject["type"] == null)
             {
-                case "donation":
-                    paymentResponseAction = new CheckoutDonationAction();
-                    break;
-                case "qrCode":
-                    paymentResponseAction = new CheckoutQrCodeAction();
-                    break;
-                case "redirect":
-                    paymentResponseAction = new CheckoutRedirectAction();
-                    break;
-                case "sdk":
-                    paymentResponseAction = new CheckoutSDKAction();
-                    break;
-                case "threeDS2Challenge":
-                    paymentResponseAction = new CheckoutThreeDS2ChallengeAction();
-                    break;
-                case "threeDS2Fingerprint":
-                    paymentResponseAction = new CheckoutThreeDS2FingerPrintAction();
-                    break;
-                case "threeDS2Action":
-                    paymentResponseAction = new CheckoutThreeDS2Action();
-                    break;
-                case "await":
-                    paymentResponseAction = new CheckoutAwaitAction();
-                    break;
-                case "voucher":
-                    paymentResponseAction = new CheckoutVoucherAction();
-                    break;
-                case "oneTimePasscode":
-                    paymentResponseAction = new CheckoutOneTimePasscodeAction();
-                    break;
+                var paymentResponeActionPairs = new Dictionary<string, object>();
+                serializer.Populate(jsonObject.CreateReader(), paymentResponeActionPairs);
+
+                paymentResponseAction = new PaymentResponseActionGeneric
+                {
+                    PaymentResponseAction = paymentResponeActionPairs
+                };
+                return paymentResponseAction;
+            }
+            else
+            {
+                switch (jsonObject["type"].ToString())
+                {
+                    case "donation":
+                        paymentResponseAction = new CheckoutDonationAction();
+                        break;
+                    case "qrCode":
+                        paymentResponseAction = new CheckoutQrCodeAction();
+                        break;
+                    case "redirect":
+                        paymentResponseAction = new CheckoutRedirectAction();
+                        break;
+                    case "sdk":
+                        paymentResponseAction = new CheckoutSDKAction();
+                        break;
+                    case "threeDS2Challenge":
+                        paymentResponseAction = new CheckoutThreeDS2ChallengeAction();
+                        break;
+                    case "threeDS2Fingerprint":
+                        paymentResponseAction = new CheckoutThreeDS2FingerPrintAction();
+                        break;
+                    case "threeDS2Action":
+                        paymentResponseAction = new CheckoutThreeDS2Action();
+                        break;
+                    case "await":
+                        paymentResponseAction = new CheckoutAwaitAction();
+                        break;
+                    case "voucher":
+                        paymentResponseAction = new CheckoutVoucherAction();
+                        break;
+                    case "oneTimePasscode":
+                        paymentResponseAction = new CheckoutOneTimePasscodeAction();
+                        break;
+                }
             }
 
             serializer.Populate(jsonObject.CreateReader(), paymentResponseAction);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
In case of missing type in action returns dictionary<string, object> in a generic class container. This way when the unique identifier is missing for any reason from the response it will return a generic response  

## Tested scenarios
<!-- Description of tested scenarios -->
Create a unit test with missing type from action

**Fixed issue**:  <!-- #-prefixed issue number -->
