### PR TITLE
Add serializers to model

### DIFF
--- a/Adyen.Test/CheckoutTest.cs
+++ b/Adyen.Test/CheckoutTest.cs
@@ -30,6 +30,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Threading.Tasks;
 using static Adyen.Model.Checkout.PaymentResponse;
+using Newtonsoft.Json;
 
 namespace Adyen.Test
 {
@@ -609,7 +610,8 @@ namespace Adyen.Test
         public void BlikDetailsDeserializationTest()
         {
             var json = "{\"amount\":{\"value\":1000,\"currency\":\"USD\"},\"merchantAccount\":\"MerchantAccountTest\",\"paymentMethod\":{\"blikCode\":\"blikCode\",\"type\":\"blik\"},\"reference\":\"Your order number\",\"returnUrl\":\"https://your-company.com/...\",\"applicationInfo\":{\"adyenLibrary\":{\"name\":\"adyen-java-api-library\",\"version\":\"10.1.0\"}}}";
-            var paymentRequest = Util.JsonOperation.Deserialize<PaymentRequest>(json);
+            var paymentRequest = JsonConvert.DeserializeObject<PaymentRequest>(json);
+
             Assert.IsTrue(paymentRequest.PaymentMethod is BlikDetails);
             Assert.AreEqual(paymentRequest.PaymentMethod.Type, BlikDetails.Blik);
         }
@@ -629,7 +631,7 @@ namespace Adyen.Test
             var json = "{\"amount\":{\"value\":1000,\"currency\":\"USD\"},\"merchantAccount\":\"MerchantAccountTest\",\"paymentMethod\":{\"telephoneNumber\":\"telephone\",\"type\":\"lianlianpay_ebanking_credit\"},\"reference\":\"Your order number\",\"returnUrl\":\"https://your-company.com/...\",\"applicationInfo\":{\"adyenLibrary\":{\"name\":\"adyen-java-api-library\",\"version\":\"10.1.0\"}}}";
 
             LianLianPayDetails lianLianPayDetails = new LianLianPayDetails();
-            var paymentRequest = Util.JsonOperation.Deserialize<PaymentRequest>(json);
+            var paymentRequest = JsonConvert.DeserializeObject<PaymentRequest>(json);
             Assert.IsTrue(paymentRequest.PaymentMethod is LianLianPayDetails);
             Assert.AreEqual(paymentRequest.PaymentMethod.Type, LianLianPayDetails.EbankingCredit);
         }

--- a/Adyen/Model/Checkout/PaymentRequest.cs
+++ b/Adyen/Model/Checkout/PaymentRequest.cs
@@ -576,6 +576,7 @@ namespace Adyen.Model.Checkout
         /// </summary>
         /// <value>The collection that contains the type of the payment method and its specific information (e.g. &#x60;idealIssuer&#x60;).</value>
         [DataMember(Name = "paymentMethod", EmitDefaultValue = false)]
+        [JsonConverter(typeof(PaymentMethodDetailsConverter))]
         public IPaymentMethodDetails PaymentMethod { get; set; }
 
         /// <summary>

--- a/Adyen/Util/PaymentMethodDetailsConverter.cs
+++ b/Adyen/Util/PaymentMethodDetailsConverter.cs
@@ -37,7 +37,7 @@ namespace Adyen.Util
         public override void WriteJson(JsonWriter writer,
             object value, JsonSerializer serializer)
         {
-            throw new InvalidOperationException("Use default serialization.");
+            serializer.Serialize(writer, value);
         }
 
         public override object ReadJson(JsonReader reader,


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The new custom deserializer are nice but would be nicer if they are declared in the Model object as well so that they can be deserialized directly in the request body in ASP.NET

## Tested scenarios
Tests added


**Fixed issue**:  <!-- #-prefixed issue number -->
