### PR TITLE
[PW-3898] Fix the checkout.PaymentsDetails deserialization

### DIFF
--- a/Adyen.Test/CheckoutTest.cs
+++ b/Adyen.Test/CheckoutTest.cs
@@ -251,6 +251,21 @@ namespace Adyen.Test
 
         /// <summary>
         /// Test success flow for
+        /// POST /payments/details
+        /// </summary>
+        [TestMethod]
+        public void PaymentDetailsResponseDeserializeTest()
+        {
+            var detailsRequest = CreateDetailsRequest();
+            detailsRequest.Details = new PaymentCompletionDetails(payload: "Ab02b4c0!BQABAgBQn96RxfJHpp2RXhqQBuhQFWgE...gfGHb4IZSP4IpoCC2==RXhqQBuhQ");
+            var client = CreateMockTestClientApiKeyBasedRequest("Mocks/checkout/paymentsdetails-response-success.json");
+            var checkout = new Checkout(client);
+            var paymentResponse = checkout.PaymentDetails(detailsRequest);
+            Assert.AreEqual("8515232733321252", paymentResponse.PspReference);
+        }
+
+        /// <summary>
+        /// Test success flow for
         /// POST /paymentMethods
         /// </summary>
         [TestMethod]

--- a/Adyen.Test/CheckoutTest.cs
+++ b/Adyen.Test/CheckoutTest.cs
@@ -250,7 +250,7 @@ namespace Adyen.Test
         }
 
         /// <summary>
-        /// Test success flow for
+        /// Test success deserialization for
         /// POST /payments/details
         /// </summary>
         [TestMethod]
@@ -258,10 +258,14 @@ namespace Adyen.Test
         {
             var detailsRequest = CreateDetailsRequest();
             detailsRequest.Details = new PaymentCompletionDetails(payload: "Ab02b4c0!BQABAgBQn96RxfJHpp2RXhqQBuhQFWgE...gfGHb4IZSP4IpoCC2==RXhqQBuhQ");
-            var client = CreateMockTestClientApiKeyBasedRequest("Mocks/checkout/paymentsdetails-response-success.json");
+            var client = CreateMockTestClientApiKeyBasedRequest("Mocks/checkout/paymentsdetails-action-success.json");
             var checkout = new Checkout(client);
             var paymentResponse = checkout.PaymentDetails(detailsRequest);
-            Assert.AreEqual("8515232733321252", paymentResponse.PspReference);
+            Assert.IsTrue(paymentResponse.Action is CheckoutThreeDS2FingerPrintAction);
+            var paymentActionResponse = (CheckoutThreeDS2FingerPrintAction)paymentResponse.Action;
+            Assert.AreEqual("Ab02b4c0!BQABAgBNSfsOs...", paymentActionResponse.PaymentData);
+            Assert.AreEqual("eyJ0aHJlZURTTWVzc2FnZ...", paymentActionResponse.Token);
+            Assert.AreEqual("threeDS2Fingerprint", paymentActionResponse.Type);
         }
 
         /// <summary>

--- a/Adyen.Test/Mocks/checkout/paymentsdetails-action-success.json
+++ b/Adyen.Test/Mocks/checkout/paymentsdetails-action-success.json
@@ -1,0 +1,8 @@
+{
+  "action": {
+    "type": "threeDS2Fingerprint",
+    "paymentData": "Ab02b4c0!BQABAgBNSfsOs...",
+    "paymentMethodType": "scheme",
+    "token": "eyJ0aHJlZURTTWVzc2FnZ..."
+  }
+}

--- a/Adyen.Test/Mocks/checkout/paymentsdetails-response-success.json
+++ b/Adyen.Test/Mocks/checkout/paymentsdetails-response-success.json
@@ -1,7 +1,0 @@
-{
-  "paymentData": "Hee57361f99....",
-  "details": {
-    "MD": "Ab02b4c0!BQABAgCW5sxB4e/==...",
-    "PaRes": "eNrNV0mTo7gS..."
-  }
-}

--- a/Adyen.Test/Mocks/checkout/paymentsdetails-response-success.json
+++ b/Adyen.Test/Mocks/checkout/paymentsdetails-response-success.json
@@ -1,0 +1,7 @@
+{
+  "paymentData": "Hee57361f99....",
+  "details": {
+    "MD": "Ab02b4c0!BQABAgCW5sxB4e/==...",
+    "PaRes": "eNrNV0mTo7gS..."
+  }
+}

--- a/Adyen/Service/Checkout.cs
+++ b/Adyen/Service/Checkout.cs
@@ -158,7 +158,7 @@ namespace Adyen.Service
         {
             var jsonRequest = Util.JsonOperation.SerializeRequest(paymentResultRequest);
             var jsonResponse = _paymentsResult.Request(jsonRequest);
-            return Util.JsonOperation.Deserialize<PaymentResultResponse>(jsonResponse);
+            return JsonConvert.DeserializeObject<PaymentResultResponse>(jsonResponse);
         }
 
         /// <summary>

--- a/Adyen/Service/Checkout.cs
+++ b/Adyen/Service/Checkout.cs
@@ -110,7 +110,7 @@ namespace Adyen.Service
         {
             var jsonRequest = Util.JsonOperation.SerializeRequest(paymentsDetailsRequest);
             var jsonResponse = _paymentDetails.Request(jsonRequest, requestOptions);
-            return JsonConvert.DeserializeObject<PaymentResponse>(jsonResponse);
+            return Util.JsonOperation.Deserialize<PaymentResponse>(jsonResponse);
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
The issue is that when using Adyen Drop-in for web, calling checkout.PaymentsDetails(paymentsDetailsRequest) in other to perform the additional checks in case of 3DS payments, which is this step, an exception is thrown.  PaymentsDetails request 
is using now the correct json convertors  
## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:   fixes #373