### PR TITLE
[PW-4118]Add the same exception handling for request and request async

### DIFF
--- a/Adyen/Config.cs
+++ b/Adyen/Config.cs
@@ -38,6 +38,7 @@ namespace Adyen
         public string MarketPayEndpoint { get; set; }
         public string ApplicationName { get; set; }
         public IWebProxy Proxy { get; set; }
+        // Please note that http request timeout is milliseconds.
         public int HttpRequestTimeout { get; set; }
         //HPP specific
         public string HppEndpoint { get; set; }

--- a/Adyen/HttpClient/HttpURLConnectionClient.cs
+++ b/Adyen/HttpClient/HttpURLConnectionClient.cs
@@ -68,16 +68,7 @@ namespace Adyen.HttpClient
             }
             catch (WebException e)
             {
-                if (e.Response == null)
-                {
-                    throw new HttpClientException((int) HttpStatusCode.RequestTimeout, "HTTP Exception timeout", null, "No response", e);
-                }
-                var response = (HttpWebResponse) e.Response;
-                using (var sr = new StreamReader(response.GetResponseStream()))
-                {
-                    responseText = sr.ReadToEnd();
-                }
-                throw new HttpClientException((int) response.StatusCode, "HTTP Exception", response.Headers, responseText);
+                ExceptionHandler(e);
             }
             return responseText;
         }
@@ -93,7 +84,7 @@ namespace Adyen.HttpClient
         /// <returns>Task<string></returns>
         public async Task<string> RequestAsync(string endpoint, string json, Config config, bool isApiKeyRequired, RequestOptions requestOptions = null)
         {
-            string responseText;
+            string responseText = null;
             //Set security protocol. Only TLS1.2
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
             var httpWebRequest = GetHttpWebRequest(endpoint, config, isApiKeyRequired, requestOptions);
@@ -103,16 +94,51 @@ namespace Adyen.HttpClient
                 streamWriter.Flush();
                 streamWriter.Close();
             }
-            using (var response = (HttpWebResponse)await httpWebRequest.GetResponseAsync())
+            try
             {
-                using (var reader = new StreamReader(response.GetResponseStream(), _encoding))
+                using (var response = (HttpWebResponse)await httpWebRequest.GetResponseAsync())
                 {
-                    responseText = await reader.ReadToEndAsync();
+                    using (var reader = new StreamReader(response.GetResponseStream(), _encoding))
+                    {
+                        responseText = await reader.ReadToEndAsync();
+                    }
                 }
+            }
+            catch (WebException e)
+            {
+                ExceptionHandler(e);
             }
             return responseText;
         }
 
+        /// <summary>
+        /// Handles the common http exceptions 
+        /// </summary>
+        /// <param name="e">WebException e</param>
+        private static void ExceptionHandler(WebException e)
+        {
+            string responseText = null;
+            //Add check on actual timeout before returning timeout
+            if (e.Response == null && e.Status == WebExceptionStatus.Timeout)
+            {
+                throw new HttpClientException((int)HttpStatusCode.RequestTimeout, "HTTP Exception timeout", null, "No response", e);
+            }
+            //May occur for incorrect certificate: in such case the certificate validation failure is mapped to an UnknownError by Microsoft
+            if (e.Response == null && e.Status == WebExceptionStatus.UnknownError)
+            {
+                throw new HttpClientException((int)HttpStatusCode.Ambiguous, "Potential certificate mismatch", null, e.Message, e);
+            }
+            if (e.Response == null)
+            {
+                throw new HttpClientException((int)e.Status, "Web Exception", null, "No response", e);
+            }
+            var response = (HttpWebResponse)e.Response;
+            using (var sr = new StreamReader(response.GetResponseStream()))
+            {
+                responseText = sr.ReadToEnd();
+            }
+            throw new HttpClientException((int)response.StatusCode, "HTTP Exception", response.Headers, responseText, e);
+        }
 
         [Obsolete("This is deprecated functionality by Adyen. Correct use request method with isApiKeyRequired parameter.")]
         public string Request(string endpoint, string json, Config config)

--- a/Adyen/HttpClient/HttpURLConnectionClient.cs
+++ b/Adyen/HttpClient/HttpURLConnectionClient.cs
@@ -68,7 +68,7 @@ namespace Adyen.HttpClient
             }
             catch (WebException e)
             {
-                ExceptionHandler(e);
+                HandleWebException(e);
             }
             return responseText;
         }
@@ -106,7 +106,7 @@ namespace Adyen.HttpClient
             }
             catch (WebException e)
             {
-                ExceptionHandler(e);
+                HandleWebException(e);
             }
             return responseText;
         }
@@ -115,7 +115,7 @@ namespace Adyen.HttpClient
         /// Handles the common http exceptions 
         /// </summary>
         /// <param name="e">WebException e</param>
-        private static void ExceptionHandler(WebException e)
+        private static void HandleWebException(WebException e)
         {
             string responseText = null;
             //Add check on actual timeout before returning timeout


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
We handle the request sync HTTP exception but not for the async. With this PR we use the same exception handler for both

based on: #371 
co-author-by: @astiskala 


## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
