### PR TITLE
[PW-4367] - Update github action sdk version

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet: ['2.1.811','2.2.103']
+        dotnet: ['2.1.811','2.2.110']
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET Core

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The Library supports all APIs under the following services:
 
 ## Requirements
 * Adyen API Library supports .net standard 2.0
-* In order for Adyen API Library to support local terminal api certificate validation the application should be set to .net core 2.1 and above or .net framework 4.6.1 and above
+* In order for Adyen API Library to support local terminal api certificate validation the application should be set to .net core 2.1 and above or .net framework 4.6.1 and above.
 
 ## Installation
 * Simply download and restore nuget packages  

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The Library supports all APIs under the following services:
 
 ## Requirements
 * Adyen API Library supports .net standard 2.0
-* In order for Adyen API Library to support local terminal api certificate validation the application should be set to .net core 2.1 and above or .net framework 4.6.1 and above.
+* In order for Adyen API Library to support local terminal api certificate validation the application should be set to .net core 2.1 and above or .net framework 4.6.1 and above
 
 ## Installation
 * Simply download and restore nuget packages  


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
**Description:**
The dotnet library doesnot run anymore on github actions and specific for dot net version dotnet SDK 2.2.103. We tested with master and still not luck running it with 2.2.103. Updating the SDK to 2.2.110 and it compiles with no issues. The difference is the Visual Studio Compatibility where the 2.2.110 supports both 2019 and 2017 but for 2.2.103 they did not  add that in the release notes. 

<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
