### PR TITLE
Add DisableAsync to Recurring

### DIFF
--- a/Adyen.Test/RecurringTest.cs
+++ b/Adyen.Test/RecurringTest.cs
@@ -75,7 +75,16 @@ namespace Adyen.Test
             Assert.AreEqual("[detail-successfully-disabled]", disableResult.Response);
         }
 
-
+        [TestMethod]
+        public async Task TestDisableAsync()
+        {
+            var client = base.CreateMockTestClientNullRequiredFieldsRequest("Mocks/recurring/disable-success.json");
+            var recurring = new Service.Recurring(client);
+            var disableRequest = this.CreateDisableRequest();
+            var disableResult = await recurring.DisableAsync(disableRequest);
+            Assert.AreEqual(1L, (long)disableResult.Details.Count);
+            Assert.AreEqual("[detail-successfully-disabled]", disableResult.Response);
+        }
 
         [TestMethod]
         public void TestDisable803()

--- a/Adyen/Service/Recurring.cs
+++ b/Adyen/Service/Recurring.cs
@@ -58,5 +58,12 @@ namespace Adyen.Service
             var jsonResponse = _disable.Request(jsonRequest);
             return Util.JsonOperation.Deserialize<DisableResult>(jsonResponse);
         }
+
+        public async Task<DisableResult> DisableAsync(DisableRequest disableRequest)
+        {
+            var jsonRequest = Util.JsonOperation.SerializeRequest(disableRequest);
+            var jsonResponse = await _disable.RequestAsync(jsonRequest);
+            return Util.JsonOperation.Deserialize<DisableResult>(jsonResponse);
+        }
     }
 }


### PR DESCRIPTION
## Summary
This PR adds an asynchronous method to disable recurring contracts. DisableAsync in Recurring.

## Tested scenarios
Uses an equivalent test as the synchronous Disable method.