### PR TITLE
Payment completion details: ReturnUrlQueryString

### DIFF
--- a/Adyen/Model/Checkout/PaymentCompletionDetails.cs
+++ b/Adyen/Model/Checkout/PaymentCompletionDetails.cs
@@ -63,7 +63,7 @@ namespace Adyen.Model.Checkout
             string payerID = default(string), string payload = default(string), string paymentID = default(string),
             string paymentStatus = default(string), string redirectResult = default(string),
             string threeDSResult = default(string), string threeds2ChallengeResult = default(string),
-            string threeds2Fingerprint = default(string))
+            string threeds2Fingerprint = default(string), string returnUrlQueryString = default(string))
         {
             this.MD = mD;
             this.PaReq = paReq;
@@ -81,6 +81,7 @@ namespace Adyen.Model.Checkout
             this.ThreeDSResult = threeDSResult;
             this.Threeds2ChallengeResult = threeds2ChallengeResult;
             this.Threeds2Fingerprint = threeds2Fingerprint;
+            this.ReturnUrlQueryString = returnUrlQueryString;
         }
 
         /// <summary>
@@ -196,6 +197,14 @@ namespace Adyen.Model.Checkout
         public string Threeds2Fingerprint { get; set; }
 
         /// <summary>
+        /// Return url query string supplied by the redirect component.
+        /// Used by Swish redirects.
+        /// </summary>
+        /// <value>Return url query string supplied by the redirect component.</value>
+        [DataMember(Name = "returnUrlQueryString", EmitDefaultValue = false)]
+        public string ReturnUrlQueryString { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -219,6 +228,7 @@ namespace Adyen.Model.Checkout
             sb.Append("  ThreeDSResult: ").Append(ThreeDSResult).Append("\n");
             sb.Append("  Threeds2ChallengeResult: ").Append(Threeds2ChallengeResult).Append("\n");
             sb.Append("  Threeds2Fingerprint: ").Append(Threeds2Fingerprint).Append("\n");
+            sb.Append("  ReturnUrlQueryString: ").Append(Threeds2Fingerprint).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -332,6 +342,11 @@ namespace Adyen.Model.Checkout
                     this.Threeds2Fingerprint == input.Threeds2Fingerprint ||
                     this.Threeds2Fingerprint != null &&
                     this.Threeds2Fingerprint.Equals(input.Threeds2Fingerprint)
+                ) &&
+                (
+                    this.ReturnUrlQueryString == input.ReturnUrlQueryString ||
+                    this.ReturnUrlQueryString != null &&
+                    this.ReturnUrlQueryString.Equals(input.ReturnUrlQueryString)
                 );
         }
 
@@ -376,6 +391,8 @@ namespace Adyen.Model.Checkout
                     hashCode = hashCode * 59 + this.Threeds2ChallengeResult.GetHashCode();
                 if (this.Threeds2Fingerprint != null)
                     hashCode = hashCode * 59 + this.Threeds2Fingerprint.GetHashCode();
+                if (this.ReturnUrlQueryString != null)
+                    hashCode = hashCode * 59 + this.ReturnUrlQueryString.GetHashCode();
                 return hashCode;
             }
         }


### PR DESCRIPTION
Added ReturnUrlQueryString to support swish payments

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary

This changes Adyen/Model/Checkout/PaymentCompletionDetails.cs to include the property **ReturnUrlQueryString** 


**- What is the motivation for this change?** 
We needed support for swish payments and the ios version of this sdk https://github.com/Adyen/adyen-ios/releases/tag/4.0.0-beta.2 will send that property but it was not handled in this server sdk.

## Tested scenarios
Tested payments with swish from the ios sdk 

https://user-images.githubusercontent.com/84770613/119466356-d130e380-bd44-11eb-9617-d47989da8851.mp4




**Fixed issue**:  <!-- #-prefixed issue number -->
