### PR TITLE
Add missing fields to account model

### DIFF
--- a/Adyen/Model/MarketPay/Account.cs
+++ b/Adyen/Model/MarketPay/Account.cs
@@ -34,75 +34,102 @@ namespace Adyen.Model.MarketPay
     /// Account
     /// </summary>
     [DataContract]
-        public partial class Account :  IEquatable<Account>, IValidatableObject
+    public partial class Account : IEquatable<Account>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Account" /> class.
         /// </summary>
         /// <param name="accountCode">The code of the account..</param>
+        /// <param name="bankAccountUUID">The bankAccountUUID of the bank account held by the account holder to couple the account with.</param>
         /// <param name="beneficiaryAccount">The beneficiary of the account..</param>
         /// <param name="beneficiaryMerchantReference">The reason that a beneficiary has been set up for this account. This may have been supplied during the setup of a beneficiary at the discretion of the executing user..</param>
         /// <param name="description">A description of the account..</param>
         /// <param name="metadata">A set of key and value pairs for general use by the merchant. The keys do not have specific names and may be used for storing miscellaneous data as desired. &gt; Note that during an update of metadata, the omission of existing key-value pairs will result in the deletion of those key-value pairs..</param>
+        /// <param name="payoutMethodCode">The payout method code held by the account holder to couple the account with. Scheduled card payouts will be sent using this payout method code.</param>
         /// <param name="payoutSchedule">payoutSchedule.</param>
+        /// <param name="payoutSpeed">Speed with which payouts for this account are processed. Permitted values: STANDARD, SAME_DAY.</param>
         /// <param name="status">The status of the account. Possible values: &#x60;Active&#x60;, &#x60;Inactive&#x60;, &#x60;Suspended&#x60;, &#x60;Closed&#x60;..</param>
-        public Account(string accountCode = default(string), string beneficiaryAccount = default(string), string beneficiaryMerchantReference = default(string), string description = default(string), Object metadata = default(Object), PayoutScheduleResponse payoutSchedule = default(PayoutScheduleResponse), string status = default(string))
+        public Account(string accountCode = default(string), string bankAccountUUID = default(string), string beneficiaryAccount = default(string), string beneficiaryMerchantReference = default(string), string description = default(string), Object metadata = default(Object), string payoutMethodCode = default(string), PayoutScheduleResponse payoutSchedule = default(PayoutScheduleResponse), string payoutSpeed = default(string), string status = default(string))
         {
             this.AccountCode = accountCode;
+            this.BankAccountUUID = bankAccountUUID;
             this.BeneficiaryAccount = beneficiaryAccount;
             this.BeneficiaryMerchantReference = beneficiaryMerchantReference;
             this.Description = description;
             this.Metadata = metadata;
+            this.PayoutMethodCode = payoutMethodCode;
             this.PayoutSchedule = payoutSchedule;
+            this.PayoutSpeed = payoutSpeed;
             this.Status = status;
         }
-        
+
         /// <summary>
         /// The code of the account.
         /// </summary>
         /// <value>The code of the account.</value>
-        [DataMember(Name="accountCode", EmitDefaultValue=false)]
+        [DataMember(Name = "accountCode", EmitDefaultValue = false)]
         public string AccountCode { get; set; }
+
+        /// <summary>
+        /// The bankAccountUUID of the bank account held by the account holder to couple the account with. Scheduled payouts in currencies matching the currency of this bank account will be sent to this bank account. Payouts in different currencies will be sent to a matching bank account of the account holder.
+        /// </summary>
+        /// <value>The bankAccountUUID of the bank account held by the account holder to couple the account with. Scheduled payouts in currencies matching the currency of this bank account will be sent to this bank account. Payouts in different currencies will be sent to a matching bank account of the account holder.</value>
+        [DataMember(Name = "bankAccountUUID", EmitDefaultValue = false)]
+        public string BankAccountUUID { get; set; }
 
         /// <summary>
         /// The beneficiary of the account.
         /// </summary>
         /// <value>The beneficiary of the account.</value>
-        [DataMember(Name="beneficiaryAccount", EmitDefaultValue=false)]
+        [DataMember(Name = "beneficiaryAccount", EmitDefaultValue = false)]
         public string BeneficiaryAccount { get; set; }
 
         /// <summary>
         /// The reason that a beneficiary has been set up for this account. This may have been supplied during the setup of a beneficiary at the discretion of the executing user.
         /// </summary>
         /// <value>The reason that a beneficiary has been set up for this account. This may have been supplied during the setup of a beneficiary at the discretion of the executing user.</value>
-        [DataMember(Name="beneficiaryMerchantReference", EmitDefaultValue=false)]
+        [DataMember(Name = "beneficiaryMerchantReference", EmitDefaultValue = false)]
         public string BeneficiaryMerchantReference { get; set; }
 
         /// <summary>
         /// A description of the account.
         /// </summary>
         /// <value>A description of the account.</value>
-        [DataMember(Name="description", EmitDefaultValue=false)]
+        [DataMember(Name = "description", EmitDefaultValue = false)]
         public string Description { get; set; }
 
         /// <summary>
         /// A set of key and value pairs for general use by the merchant. The keys do not have specific names and may be used for storing miscellaneous data as desired. &gt; Note that during an update of metadata, the omission of existing key-value pairs will result in the deletion of those key-value pairs.
         /// </summary>
         /// <value>A set of key and value pairs for general use by the merchant. The keys do not have specific names and may be used for storing miscellaneous data as desired. &gt; Note that during an update of metadata, the omission of existing key-value pairs will result in the deletion of those key-value pairs.</value>
-        [DataMember(Name="metadata", EmitDefaultValue=false)]
+        [DataMember(Name = "metadata", EmitDefaultValue = false)]
         public Object Metadata { get; set; }
+
+        /// <summary>
+        /// The payout method code held by the account holder to couple the account with. Scheduled card payouts will be sent using this payout method code.
+        /// </summary>
+        /// <value>The payout method code held by the account holder to couple the account with. Scheduled card payouts will be sent using this payout method code.</value>
+        [DataMember(Name = "payoutMethodCode", EmitDefaultValue = false)]
+        public string PayoutMethodCode { get; set; }
 
         /// <summary>
         /// Gets or Sets PayoutSchedule
         /// </summary>
-        [DataMember(Name="payoutSchedule", EmitDefaultValue=false)]
+        [DataMember(Name = "payoutSchedule", EmitDefaultValue = false)]
         public PayoutScheduleResponse PayoutSchedule { get; set; }
+
+        /// <summary>
+        /// Speed with which payouts for this account are processed. Permitted values: STANDARD, SAME_DAY.
+        /// </summary>
+        /// <value>Speed with which payouts for this account are processed. Permitted values: STANDARD, SAME_DAY.</value>
+        [DataMember(Name = "payoutSpeed", EmitDefaultValue = false)]
+        public string PayoutSpeed { get; set; }
 
         /// <summary>
         /// The status of the account. Possible values: &#x60;Active&#x60;, &#x60;Inactive&#x60;, &#x60;Suspended&#x60;, &#x60;Closed&#x60;.
         /// </summary>
         /// <value>The status of the account. Possible values: &#x60;Active&#x60;, &#x60;Inactive&#x60;, &#x60;Suspended&#x60;, &#x60;Closed&#x60;.</value>
-        [DataMember(Name="status", EmitDefaultValue=false)]
+        [DataMember(Name = "status", EmitDefaultValue = false)]
         public string Status { get; set; }
 
         /// <summary>
@@ -114,16 +141,19 @@ namespace Adyen.Model.MarketPay
             var sb = new StringBuilder();
             sb.Append("class Account {\n");
             sb.Append("  AccountCode: ").Append(AccountCode).Append("\n");
+            sb.Append("  BankAccountUUID: ").Append(BankAccountUUID).Append("\n");
             sb.Append("  BeneficiaryAccount: ").Append(BeneficiaryAccount).Append("\n");
             sb.Append("  BeneficiaryMerchantReference: ").Append(BeneficiaryMerchantReference).Append("\n");
             sb.Append("  Description: ").Append(Description).Append("\n");
             sb.Append("  Metadata: ").Append(Metadata).Append("\n");
+            sb.Append("  PayoutMethodCode: ").Append(PayoutMethodCode).Append("\n");
             sb.Append("  PayoutSchedule: ").Append(PayoutSchedule).Append("\n");
+            sb.Append("  PayoutSpeed: ").Append(PayoutSpeed).Append("\n");
             sb.Append("  Status: ").Append(Status).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
-  
+
         /// <summary>
         /// Returns the JSON string presentation of the object
         /// </summary>
@@ -153,36 +183,51 @@ namespace Adyen.Model.MarketPay
             if (input == null)
                 return false;
 
-            return 
+            return
                 (
                     this.AccountCode == input.AccountCode ||
                     (this.AccountCode != null &&
                     this.AccountCode.Equals(input.AccountCode))
-                ) && 
+                ) &&
+                (
+                    this.BankAccountUUID == input.BankAccountUUID ||
+                    (this.BankAccountUUID != null &&
+                     this.BankAccountUUID.Equals(input.BankAccountUUID))
+                ) &&
                 (
                     this.BeneficiaryAccount == input.BeneficiaryAccount ||
                     (this.BeneficiaryAccount != null &&
                     this.BeneficiaryAccount.Equals(input.BeneficiaryAccount))
-                ) && 
+                ) &&
                 (
                     this.BeneficiaryMerchantReference == input.BeneficiaryMerchantReference ||
                     (this.BeneficiaryMerchantReference != null &&
                     this.BeneficiaryMerchantReference.Equals(input.BeneficiaryMerchantReference))
-                ) && 
+                ) &&
                 (
                     this.Description == input.Description ||
                     (this.Description != null &&
                     this.Description.Equals(input.Description))
-                ) && 
+                ) &&
                 (
                     this.Metadata == input.Metadata ||
                     (this.Metadata != null &&
                     this.Metadata.Equals(input.Metadata))
-                ) && 
+                ) &&
+                (
+                    this.PayoutMethodCode == input.PayoutMethodCode ||
+                    (this.PayoutMethodCode != null &&
+                     this.PayoutMethodCode.Equals(input.PayoutMethodCode))
+                ) &&
                 (
                     this.PayoutSchedule == input.PayoutSchedule ||
-                    (this.PayoutSchedule != null )
-                ) && 
+                    (this.PayoutSchedule != null)
+                ) &&
+                (
+                    this.PayoutSpeed == input.PayoutSpeed ||
+                    (this.PayoutSpeed != null &&
+                     this.PayoutSpeed.Equals(input.PayoutSpeed))
+                ) &&
                 (
                     this.Status == input.Status ||
                     (this.Status != null &&
@@ -201,6 +246,8 @@ namespace Adyen.Model.MarketPay
                 int hashCode = 41;
                 if (this.AccountCode != null)
                     hashCode = hashCode * 59 + this.AccountCode.GetHashCode();
+                if (this.BankAccountUUID != null)
+                    hashCode = hashCode * 59 + this.BankAccountUUID.GetHashCode();
                 if (this.BeneficiaryAccount != null)
                     hashCode = hashCode * 59 + this.BeneficiaryAccount.GetHashCode();
                 if (this.BeneficiaryMerchantReference != null)
@@ -209,8 +256,12 @@ namespace Adyen.Model.MarketPay
                     hashCode = hashCode * 59 + this.Description.GetHashCode();
                 if (this.Metadata != null)
                     hashCode = hashCode * 59 + this.Metadata.GetHashCode();
+                if (this.PayoutMethodCode != null)
+                    hashCode = hashCode * 59 + this.PayoutMethodCode.GetHashCode();
                 if (this.PayoutSchedule != null)
                     hashCode = hashCode * 59 + this.PayoutSchedule.GetHashCode();
+                if (this.PayoutSpeed != null)
+                    hashCode = hashCode * 59 + this.PayoutSpeed.GetHashCode();
                 if (this.Status != null)
                     hashCode = hashCode * 59 + this.Status.GetHashCode();
                 return hashCode;


### PR DESCRIPTION
## Summary

Describe the changes proposed in this pull request:
- What is the motivation for this change? 
We are in the process of integrating with Adyen for Platforms and while building a view to show which bank account is linked to a certain account (within an account holder) we missed a few fields in the [GetAccountHolderResponse](https://github.com/Adyen/adyen-dotnet-api-library/blob/develop/Adyen/Model/MarketPay/GetAccountHolderResponse.cs). 

According to the [documentation](https://docs.adyen.com/api-explorer/#/Account/v6/post/getAccountHolder__resParam_accounts)  these 3 fields should be there.