### PR TITLE
[PW-4726] Support Android certificate validation

### DIFF
--- a/Adyen.Test/TerminalCommonNameValidatorTest.cs
+++ b/Adyen.Test/TerminalCommonNameValidatorTest.cs
@@ -55,7 +55,10 @@ namespace Adyen.Test
                         new TerminalCNValidationParameters  ( "EMAILADDRESS=mock@adyen.com, CN=P400-123456789.test.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Adyen.Model.Enum.Environment.Live, false ),
                         new TerminalCNValidationParameters  ( "EMAILADDRESS=mock@adyen.com, CN=legacy-terminal-certificate.live.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Adyen.Model.Enum.Environment.Test, false ),
                         new TerminalCNValidationParameters  ( "EMAILADDRESS=mock@adyen.com, CN=P400-123456789.live.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Adyen.Model.Enum.Environment.Test, false),
-                       // Invalid CN
+                        new TerminalCNValidationParameters  ( "EMAILADDRESS=mock@adyen.com, CN=S1E-000150123456789.test.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Adyen.Model.Enum.Environment.Live, false ),
+                        new TerminalCNValidationParameters  ( "EMAILADDRESS=mock@adyen.com, CN=S1E-000150123456789.live.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Adyen.Model.Enum.Environment.Test, false ),
+                       
+                        // Invalid CN
                         new TerminalCNValidationParameters  ( "EMAILADDRESS=mock@adyen.com, CN=wrong-terminal-certificate.test.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Adyen.Model.Enum.Environment.Test, false ),
                         new TerminalCNValidationParameters  ( "EMAILADDRESS=mock@adyen.com, CN=legacyy-terminal-certificate.test.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Adyen.Model.Enum.Environment.Test, false ),
                         new TerminalCNValidationParameters  ( "EMAILADDRESS=mock@adyen.com, CN=legacy-terminaal-certificate.test.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Adyen.Model.Enum.Environment.Test, false ),
@@ -69,6 +72,9 @@ namespace Adyen.Test
                         new TerminalCNValidationParameters  ( "EMAILADDRESS=mock@adyen.com, CN=-123.test.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Adyen.Model.Enum.Environment.Test, false ),
                         new TerminalCNValidationParameters  ( "EMAILADDRESS=mock@adyen.com, CN=www.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Adyen.Model.Enum.Environment.Test, false ),
                         new TerminalCNValidationParameters  ( "EMAILADDRESS=mock@adyen.com, CN=ANY, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Adyen.Model.Enum.Environment.Test, false ),
+                        new TerminalCNValidationParameters  ( "EMAILADDRESS=mock@adyen.com, CN=S1E-0001501234567891.test.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Adyen.Model.Enum.Environment.Test, false ),
+                        new TerminalCNValidationParameters  ( "EMAILADDRESS=mock@adyen.com, CN=S1E-0001501234567891.live.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Adyen.Model.Enum.Environment.Live, false ),
+                     
                         // Missing CN
                         new TerminalCNValidationParameters( "EMAILADDRESS=mock@adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Adyen.Model.Enum.Environment.Test, false )
             };

--- a/Adyen.Test/TerminalCommonNameValidatorTest.cs
+++ b/Adyen.Test/TerminalCommonNameValidatorTest.cs
@@ -34,11 +34,11 @@ namespace Adyen.Test
         {
             foreach (var terminalCNValidationParameter in GetTerminalCNValidationParameters())
             {
-               bool result = Security.TerminalCommonNameValidator.ValidateCertificate(terminalCNValidationParameter.CommonName, terminalCNValidationParameter.Environment);
-               Assert.AreEqual(result, terminalCNValidationParameter.TestSuccess);
+                bool result = Security.TerminalCommonNameValidator.ValidateCertificate(terminalCNValidationParameter.CommonName, terminalCNValidationParameter.Environment);
+                Assert.AreEqual(result, terminalCNValidationParameter.TestSuccess);
             }
         }
-        
+
         private List<TerminalCNValidationParameters> GetTerminalCNValidationParameters()
         {
             return new List<TerminalCNValidationParameters>
@@ -48,6 +48,8 @@ namespace Adyen.Test
                         new TerminalCNValidationParameters  ( "EMAILADDRESS=mock@adyen.com, CN=legacy-terminal-certificate.live.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Adyen.Model.Enum.Environment.Live, true ),
                         new TerminalCNValidationParameters  ( "EMAILADDRESS=mock@adyen.com, CN=P400-123456789.test.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Adyen.Model.Enum.Environment.Test, true ),
                         new TerminalCNValidationParameters  ( "EMAILADDRESS=mock@adyen.com, CN=P400-123456789.live.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Adyen.Model.Enum.Environment.Live, true ),
+                        new TerminalCNValidationParameters  ( "EMAILADDRESS=mock@adyen.com, CN=S1E-000150123456789.test.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Adyen.Model.Enum.Environment.Test, true ),
+                        new TerminalCNValidationParameters  ( "EMAILADDRESS=mock@adyen.com, CN=S1E-000150123456789.live.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Adyen.Model.Enum.Environment.Live, true ),
                        // Wrong environment
                         new TerminalCNValidationParameters  ( "EMAILADDRESS=mock@adyen.com, CN=legacy-terminal-certificate.test.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Adyen.Model.Enum.Environment.Live, false ),
                         new TerminalCNValidationParameters  ( "EMAILADDRESS=mock@adyen.com, CN=P400-123456789.test.terminal.adyen.com, OU=Mock, O=Mock, L=Mock, ST=MO, C=MO", Adyen.Model.Enum.Environment.Live, false ),

--- a/Adyen/Security/TerminalCommonNameValidator.cs
+++ b/Adyen/Security/TerminalCommonNameValidator.cs
@@ -1,24 +1,24 @@
 ﻿#region License
-// /*
-//  *                       ######
-//  *                       ######
-//  * ############    ####( ######  #####. ######  ############   ############
-//  * #############  #####( ######  #####. ######  #############  #############
-//  *        ######  #####( ######  #####. ######  #####  ######  #####  ######
-//  * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
-//  * ###### ######  #####( ######  #####. ######  #####          #####  ######
-//  * #############  #############  #############  #############  #####  ######
-//  *  ############   ############  #############   ############  #####  ######
-//  *                                      ######
-//  *                               #############
-//  *                               ############
-//  *
-//  * Adyen Dotnet API Library
-//  *
-//  * Copyright (c) 2020 Adyen B.V.
-//  * This file is open source and available under the MIT license.
-//  * See the LICENSE file for more info.
-//  */
+/*
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Dotnet API Library
+ *
+ * Copyright (c) 2021 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ */
 #endregion
 
 using System.Linq;
@@ -29,7 +29,7 @@ namespace Adyen.Security
     public static class TerminalCommonNameValidator
     {
         private static readonly string _environmentWildcard = "{environment}";
-        private static string _terminalApiCnRegex = "[a-zA-Z0-9]{4,}-[0-9]{9}\\." + _environmentWildcard + "\\.terminal\\.adyen\\.com";
+        private static string _terminalApiCnRegex = "[a-zA-Z0-9]{3,}-[0-9]{9,15}\\." + _environmentWildcard + "\\.terminal\\.adyen\\.com";
         private static string _terminalApiLegacy = "legacy-terminal-certificate." + _environmentWildcard + ".terminal.adyen.com";
 
         public static bool ValidateCertificate(string certificateSubject, Model.Enum.Environment environment)


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
TerminalCommonNameValidator does not support certificates from Castles terminals but only for Verifone. Update the certificate CN validation in the following way:
- Minimum length of terminal model name has been changed from 4 to 3 characters (to account for S1E)
- Changed regular expression for serial number to allow a range from 9 to 15 digits (to account for all Castles serial numbers)
## Tested scenarios
<!-- Description of tested scenarios -->

Update certificate validation unit test for Android terminal serial number
Tested with local api:
V400m
S1F


**Fixed issue**:  <!-- #-prefixed issue number -->
