### PR TITLE
Remove null pspReference check in CreateAccountHolderResponse.cs

### DIFF
--- a/Adyen/Model/MarketPay/CreateAccountHolderResponse.cs
+++ b/Adyen/Model/MarketPay/CreateAccountHolderResponse.cs
@@ -88,15 +88,7 @@ namespace Adyen.Model.MarketPay
         /// <param name="verification">verification (required).</param>
         public CreateAccountHolderResponse(string accountCode = default(string), string accountHolderCode = default(string), AccountHolderDetails accountHolderDetails = default(AccountHolderDetails), AccountHolderStatus accountHolderStatus = default(AccountHolderStatus), string description = default(string), List<ErrorFieldType> invalidFields = default(List<ErrorFieldType>), LegalEntityEnum legalEntity = default(LegalEntityEnum), string primaryCurrency = default(string), string pspReference = default(string), string resultCode = default(string), KYCVerificationResult verification = default(KYCVerificationResult))
         { 
-            // to ensure "pspReference" is required (not null)
-            if (pspReference == null)
-            {
-                throw new InvalidDataException("pspReference is a required property for CreateAccountHolderResponse and cannot be null");
-            }
-            else
-            {
-                this.PspReference = pspReference;
-            }
+            this.PspReference = pspReference;
             this.AccountHolderStatus = accountHolderStatus;
             this.LegalEntity = legalEntity;
             this.Verification = verification;


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
The [documentation](https://docs.adyen.com/api-explorer/#/NotificationService/v6/post/ACCOUNT_HOLDER_CREATED__reqParam_content-pspReference) shows that pspReference inside of the "contents" property is not required.


## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
Fixes #486 