### PR TITLE
Add TokenDetails to RecurringDetail

### DIFF
--- a/Adyen/Model/Recurring/RecurringDetail.cs
+++ b/Adyen/Model/Recurring/RecurringDetail.cs
@@ -40,6 +40,7 @@ namespace Adyen.Model.Recurring
         /// <summary>
         /// Initializes a new instance of the <see cref="RecurringDetail" /> class.
         /// </summary>
+        /// <param name="TokenDetails">TokenDetails.</param>
         /// <param name="SocialSecurityNumber">SocialSecurityNumber.</param>
         /// <param name="FirstPspReference">FirstPspReference.</param>
         /// <param name="CreationDate">CreationDate.</param>
@@ -57,8 +58,9 @@ namespace Adyen.Model.Recurring
         /// <param name="BillingAddress">BillingAddress.</param>
         /// <param name="AdditionalData">AdditionalData.</param>
         /// <param name="Card">Card.</param>
-        public RecurringDetail(string SocialSecurityNumber = default(string), string FirstPspReference = default(string), DateTime? CreationDate = default(DateTime?), string Acquirer = default(string), BankAccount Bank = default(BankAccount), Name ShopperName = default(Name), string AcquirerAccount = default(string), string AliasType = default(string), string Name = default(string), string Variant = default(string), string RecurringDetailReference = default(string), string Alias = default(string), List<string> ContractTypes = default(List<string>), string PaymentMethodVariant = default(string), Address BillingAddress = default(Address), Dictionary<string, string> AdditionalData = default(Dictionary<string, string>), Card Card = default(Card))
+        public RecurringDetail(TokenDetails TokenDetails = default(TokenDetails), string SocialSecurityNumber = default(string), string FirstPspReference = default(string), DateTime? CreationDate = default(DateTime?), string Acquirer = default(string), BankAccount Bank = default(BankAccount), Name ShopperName = default(Name), string AcquirerAccount = default(string), string AliasType = default(string), string Name = default(string), string Variant = default(string), string RecurringDetailReference = default(string), string Alias = default(string), List<string> ContractTypes = default(List<string>), string PaymentMethodVariant = default(string), Address BillingAddress = default(Address), Dictionary<string, string> AdditionalData = default(Dictionary<string, string>), Card Card = default(Card))
         {
+            this.TokenDetails = TokenDetails;
             this.SocialSecurityNumber = SocialSecurityNumber;
             this.FirstPspReference = FirstPspReference;
             this.CreationDate = CreationDate;
@@ -78,7 +80,13 @@ namespace Adyen.Model.Recurring
             this.AdditionalData = AdditionalData;
             this.Card = Card;
         }
-        
+
+        /// <summary>
+        /// Gets or Sets TokenDetails
+        /// </summary>
+        [DataMember(Name = "tokenDetails", EmitDefaultValue = false)]
+        public TokenDetails TokenDetails { get; set; }
+
         /// <summary>
         /// Gets or Sets SocialSecurityNumber
         /// </summary>
@@ -193,6 +201,7 @@ namespace Adyen.Model.Recurring
         {
             var sb = new StringBuilder();
             sb.Append("class RecurringDetail {\n");
+            sb.Append("  TokenDetails: ").Append(TokenDetails).Append("\n");
             sb.Append("  SocialSecurityNumber: ").Append(SocialSecurityNumber).Append("\n");
             sb.Append("  FirstPspReference: ").Append(FirstPspReference).Append("\n");
             sb.Append("  CreationDate: ").Append(CreationDate).Append("\n");
@@ -247,6 +256,10 @@ namespace Adyen.Model.Recurring
                 return false;
 
             return 
+                (
+                    this.TokenDetails == other.TokenDetails ||
+                    this.TokenDetails != null &&
+                    this.TokenDetails.Equals(other.TokenDetails)) &&
                 (
                     this.SocialSecurityNumber == other.SocialSecurityNumber ||
                     this.SocialSecurityNumber != null &&

--- a/Adyen/Model/Recurring/TokenDetails.cs
+++ b/Adyen/Model/Recurring/TokenDetails.cs
@@ -68,7 +68,7 @@ namespace Adyen.Model.Recurring
         {
             var sb = new StringBuilder();
             sb.Append("class TokenDetails {\n");
-            sb.Append("  TokenData: ").Append(TokenData).Append("\n");
+            sb.Append("  TokenData: ").Append(TokenData.ObjectListToString()).Append("\n");
             sb.Append("  TokenDataType: ").Append(TokenDataType).Append("\n");
             sb.Append("}\n");
             return sb.ToString();

--- a/Adyen/Model/Recurring/TokenDetails.cs
+++ b/Adyen/Model/Recurring/TokenDetails.cs
@@ -1,0 +1,150 @@
+﻿#region License
+// /*
+//  *                       ######
+//  *                       ######
+//  * ############    ####( ######  #####. ######  ############   ############
+//  * #############  #####( ######  #####. ######  #############  #############
+//  *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+//  * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+//  * ###### ######  #####( ######  #####. ######  #####          #####  ######
+//  * #############  #############  #############  #############  #####  ######
+//  *  ############   ############  #############   ############  #####  ######
+//  *                                      ######
+//  *                               #############
+//  *                               ############
+//  *
+//  * Adyen Dotnet API Library
+//  *
+//  * Copyright (c) 2021 Adyen B.V.
+//  * This file is open source and available under the MIT license.
+//  * See the LICENSE file for more info.
+//  */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Adyen.Model.Recurring
+{
+    /// <summary>
+    /// TokenDetails
+    /// </summary>
+    [DataContract]
+    public partial class TokenDetails : IEquatable<TokenDetails>, IValidatableObject
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TokenDetails" /> class.
+        /// </summary>
+        /// <param name="TokenData">TokenData.</param>
+        /// <param name="TokenDataType">TokenDataType.</param>
+        public TokenDetails(Dictionary<string, string> TokenData = default(Dictionary<string, string>), string TokenDataType = default(string))
+        {
+            this.TokenData = TokenData;
+            this.TokenDataType = TokenDataType;
+        }
+
+        /// <summary>
+        /// Gets or Sets TokenData
+        /// </summary>
+        [DataMember(Name = "tokenData", EmitDefaultValue = false)]
+        public Dictionary<string, string> TokenData { get; set; }
+
+        /// <summary>
+        /// Gets or Sets TokenDataType
+        /// </summary>
+        [DataMember(Name = "tokenDataType", EmitDefaultValue = false)]
+        public string TokenDataType { get; set; }
+
+        /// <summary>
+        /// Returns the string presentation of the object
+        /// </summary>
+        /// <returns>String presentation of the object</returns>
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.Append("class TokenDetails {\n");
+            sb.Append("  TokenData: ").Append(TokenData).Append("\n");
+            sb.Append("  TokenDataType: ").Append(TokenDataType).Append("\n");
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns the JSON string presentation of the object
+        /// </summary>
+        /// <returns>JSON string presentation of the object</returns>
+        public string ToJson()
+        {
+            return JsonConvert.SerializeObject(this, Formatting.Indented);
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="obj">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object obj)
+        {
+            // credit: http://stackoverflow.com/a/10454552/677735
+            return this.Equals(obj as TokenDetails);
+        }
+
+        /// <summary>
+        /// Returns true if TokenDetails instances are equal
+        /// </summary>
+        /// <param name="other">Instance of TokenDetails to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TokenDetails other)
+        {
+            // credit: http://stackoverflow.com/a/10454552/677735
+            if (other == null)
+                return false;
+
+            return
+                (
+                    this.TokenData == other.TokenData ||
+                    this.TokenData != null &&
+                    this.TokenData.SequenceEqual(other.TokenData)
+                ) &&
+                (
+                    this.TokenDataType == other.TokenDataType ||
+                    this.TokenDataType != null &&
+                    this.TokenDataType.Equals(other.TokenDataType)
+                );
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            // credit: http://stackoverflow.com/a/263416/677735
+            unchecked // Overflow is fine, just wrap
+            {
+                int hash = 41;
+                // Suitable nullity checks etc, of course :)
+                if (this.TokenData != null)
+                    hash = hash * 59 + this.TokenData.GetHashCode();
+                if (this.TokenDataType != null)
+                    hash = hash * 59 + this.TokenDataType.GetHashCode();
+                return hash;
+            }
+        }
+
+        /// <summary>
+        /// To validate all properties of the instance
+        /// </summary>
+        /// <param name="validationContext">Validation context</param>
+        /// <returns>Validation Result</returns>
+        IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
+        {
+            yield break;
+        }
+    }
+}

--- a/Adyen/Model/Recurring/TokenDetails.cs
+++ b/Adyen/Model/Recurring/TokenDetails.cs
@@ -15,7 +15,7 @@
 //  *
 //  * Adyen Dotnet API Library
 //  *
-//  * Copyright (c) 2021 Adyen B.V.
+//  * Copyright (c) 2022 Adyen N.V.
 //  * This file is open source and available under the MIT license.
 //  * See the LICENSE file for more info.
 //  */

--- a/Adyen/Model/Recurring/TokenDetails.cs
+++ b/Adyen/Model/Recurring/TokenDetails.cs
@@ -68,7 +68,7 @@ namespace Adyen.Model.Recurring
         {
             var sb = new StringBuilder();
             sb.Append("class TokenDetails {\n");
-            sb.Append("  TokenData: ").Append(TokenData.ObjectListToString()).Append("\n");
+            sb.Append("  TokenData: ").Append(TokenData.ToCollectionsString()).Append("\n");
             sb.Append("  TokenDataType: ").Append(TokenDataType).Append("\n");
             sb.Append("}\n");
             return sb.ToString();

--- a/Adyen/Model/Recurring/TokenDetails.cs
+++ b/Adyen/Model/Recurring/TokenDetails.cs
@@ -28,7 +28,7 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
 using Newtonsoft.Json;
-
+using Adyen.Util;
 namespace Adyen.Model.Recurring
 {
     /// <summary>


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR solves the [issue introduced in 7.2](https://github.com/Adyen/adyen-dotnet-api-library/issues/517) where TokenDetails was deleted for no apparent reason. 

TokenDetails are still sent from the API when calling /ListRecurringDetails. RecurringDetail object will set TokenDetails if these details are sent from the API. 

## Tested scenarios
Tested locally using my company's test Adyen account. RecurringDetail now correctly deserializes TokenDetails from the API. 


**Fixed issue**:  https://github.com/Adyen/adyen-dotnet-api-library/issues/517
