### PR TITLE
[PW-5828]Add application info in payment request service

### DIFF
--- a/Adyen.Test/CheckoutTest.cs
+++ b/Adyen.Test/CheckoutTest.cs
@@ -439,16 +439,7 @@ namespace Adyen.Test
             Assert.AreEqual(applicationInfo.AdyenLibrary.Version, Constants.ClientConfig.LibVersion);
 
         }
-        [TestMethod]
-        public void PaymentRequestApplicationInfoTest()
-        {
-            var paymentRequest = CreatePaymentRequestCheckout();
-            var name = paymentRequest.ApplicationInfo.AdyenLibrary.Name;
-            var version = paymentRequest.ApplicationInfo.AdyenLibrary.Version;
-            Assert.AreEqual(version, Constants.ClientConfig.LibVersion);
-            Assert.AreEqual(name, Constants.ClientConfig.LibName);
-        }
-
+     
         [TestMethod]
         public void PaymentRequestAppInfoExternalTest()
         {
@@ -459,14 +450,14 @@ namespace Adyen.Test
             externalPlatform.Version = "TestExternalPlatformVersion";
             merchantApplication.Name = "MerchantApplicationName";
             merchantApplication.Version = "MerchantApplicationVersion";
-            var paymentRequest = CreatePaymentRequestCheckout();
-            paymentRequest.ApplicationInfo.ExternalPlatform = externalPlatform;
-            paymentRequest.ApplicationInfo.MerchantApplication = merchantApplication;
-            Assert.AreEqual(paymentRequest.ApplicationInfo.ExternalPlatform.Integrator, "TestExternalPlatformIntegration");
-            Assert.AreEqual(paymentRequest.ApplicationInfo.ExternalPlatform.Name, "TestExternalPlatformName");
-            Assert.AreEqual(paymentRequest.ApplicationInfo.ExternalPlatform.Version, "TestExternalPlatformVersion");
-            Assert.AreEqual(paymentRequest.ApplicationInfo.MerchantApplication.Name, "MerchantApplicationName");
-            Assert.AreEqual(paymentRequest.ApplicationInfo.MerchantApplication.Version, "MerchantApplicationVersion");
+            var applicationInfo = new ApplicationInfo();
+            applicationInfo.ExternalPlatform = externalPlatform;
+            applicationInfo.MerchantApplication = merchantApplication;
+            Assert.AreEqual(applicationInfo.ExternalPlatform.Integrator, "TestExternalPlatformIntegration");
+            Assert.AreEqual(applicationInfo.ExternalPlatform.Name, "TestExternalPlatformName");
+            Assert.AreEqual(applicationInfo.ExternalPlatform.Version, "TestExternalPlatformVersion");
+            Assert.AreEqual(applicationInfo.MerchantApplication.Name, "MerchantApplicationName");
+            Assert.AreEqual(applicationInfo.MerchantApplication.Version, "MerchantApplicationVersion");
         }
 
 

--- a/Adyen/Model/Checkout/PaymentRequest.cs
+++ b/Adyen/Model/Checkout/PaymentRequest.cs
@@ -168,7 +168,7 @@ namespace Adyen.Model.Checkout
         [JsonConstructor]
         public PaymentRequest()
         {
-            CreateApplicationInfo();
+          
         }
         /// <summary>
         /// Initializes a new instance of the <see cref="PaymentRequest" /> class.
@@ -264,7 +264,6 @@ namespace Adyen.Model.Checkout
             ThreeDS2RequestData threeDS2RequestData = default(ThreeDS2RequestData),
             bool? threeDSAuthenticationOnly = false, bool? trustedShopper = default(bool?))
         {
-            CreateApplicationInfo();
             // to ensure "amount" is required (not null)
             if (amount == null)
             {
@@ -766,12 +765,6 @@ namespace Adyen.Model.Checkout
             }
 
             this.PaymentMethod = defaultPaymentMethodDetails;
-        }
-
-        private void CreateApplicationInfo()
-        {
-            if (ApplicationInfo == null)
-                ApplicationInfo = new ApplicationInfo();
         }
 
         /// <summary>

--- a/Adyen/Service/Checkout.cs
+++ b/Adyen/Service/Checkout.cs
@@ -23,6 +23,7 @@
 
 using System.Threading.Tasks;
 using Adyen.Model;
+using Adyen.Model.ApplicationInformation;
 using Adyen.Model.Checkout;
 using Adyen.Service.Resource.Checkout;
 using Newtonsoft.Json;
@@ -43,7 +44,7 @@ namespace Adyen.Service
         private Orders _orders;
         private OrdersCancel _ordersCancel;
         private PaymentMethodsBalance _paymentMethodsBalance;
-
+       
         public Checkout(Client client) : base(client)
         {
             IsApiKeyRequired = true;
@@ -67,6 +68,12 @@ namespace Adyen.Service
         /// <returns>PaymentsResponse</returns>
         public PaymentResponse Payments(PaymentRequest paymentRequest, RequestOptions requestOptions = null)
         {
+            //if it is set by the merchant do not override
+            if (paymentRequest.ApplicationInfo == null)
+            {
+                paymentRequest.ApplicationInfo = new ApplicationInfo();
+
+            }
             var jsonRequest = Util.JsonOperation.SerializeRequest(paymentRequest);
             var jsonResponse = _payments.Request(jsonRequest, requestOptions);
             return Util.JsonOperation.Deserialize<PaymentResponse>(jsonResponse);
@@ -80,6 +87,12 @@ namespace Adyen.Service
         /// <returns>PaymentsResponse</returns>
         public async Task<PaymentResponse> PaymentsAsync(PaymentRequest paymentRequest, RequestOptions requestOptions = null)
         {
+            //if it is set by the merchant do not override
+            if (paymentRequest.ApplicationInfo == null)
+            {
+                paymentRequest.ApplicationInfo = new ApplicationInfo();
+
+            }
             var jsonRequest = Util.JsonOperation.SerializeRequest(paymentRequest);
             var jsonResponse = await _payments.RequestAsync(jsonRequest, requestOptions);
             return Util.JsonOperation.Deserialize<PaymentResponse>(jsonResponse);
@@ -140,6 +153,12 @@ namespace Adyen.Service
         /// <returns>PaymentSessionResponse</returns>
         public PaymentSessionResponse PaymentSession(PaymentSessionRequest paymentSessionRequest)
         {
+            //if it is set by the merchant do not override
+            if (paymentSessionRequest.ApplicationInfo == null)
+            {
+                paymentSessionRequest.ApplicationInfo = new ApplicationInfo();
+
+            }
             var jsonRequest = Util.JsonOperation.SerializeRequest(paymentSessionRequest);
             var jsonResponse = _paymentSession.Request(jsonRequest);
             return JsonConvert.DeserializeObject<PaymentSessionResponse>(jsonResponse);
@@ -152,6 +171,12 @@ namespace Adyen.Service
         /// <returns>PaymentSessionResponse</returns>
         public async Task<PaymentSessionResponse> PaymentSessionAsync(PaymentSessionRequest paymentSessionRequest)
         {
+            //if it is set by the merchant do not override
+            if (paymentSessionRequest.ApplicationInfo == null)
+            {
+                paymentSessionRequest.ApplicationInfo = new ApplicationInfo();
+
+            }
             var jsonRequest = Util.JsonOperation.SerializeRequest(paymentSessionRequest);
             var jsonResponse = await _paymentSession.RequestAsync(jsonRequest);
             return JsonConvert.DeserializeObject<PaymentSessionResponse>(jsonResponse);


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
The application info was part of payment request added manually. That means every time that we create the models the application info should be added again. Now we included in the service so it is not part of the payment request model.
## Tested scenarios
<!-- Description of tested scenarios -->
Update the unit tests

**Fixed issue**:  <!-- #-prefixed issue number -->
