### PR TITLE
Renaming master to main in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ If you have a feature request, or spotted a bug or a technical problem, [create 
 For other questions, [contact our Support Team](https://www.adyen.help/hc/en-us/requests/new?ticket_form_id=360000705420).
 
 ## Licence
-This repository is available under the [MIT license](https://github.com/Adyen/adyen-dotnet-api-library/blob/master/LICENSE).
+This repository is available under the [MIT license](https://github.com/Adyen/adyen-dotnet-api-library/blob/main/LICENSE).
 
 ## See also
 * [Example integration](https://github.com/adyen-examples/adyen-dotnet-online-payments)


### PR DESCRIPTION
## Summary
The `master` branch in this repo has been renamed to `main`.