### PR TITLE
[PW-6193] Convert SaleToAcquirerData to string

### DIFF
--- a/Adyen.Test/SaleToAcquirerDataTest.cs
+++ b/Adyen.Test/SaleToAcquirerDataTest.cs
@@ -26,20 +26,66 @@ using Adyen.Model.Terminal;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using Adyen.Model.Nexo;
+using Adyen.Model.Nexo.Message;
 
 namespace Adyen.Test
 {
     [TestClass]
     public class SaleToAcquirerDataTest
     {
-        private readonly string _json = "{\"metadata\":{\"key\":\"value\"},\"shopperEmail\":\"myemail@mail.com\",\"shopperReference\":\"13164308\",\"recurringContract\":\"RECURRING,ONECLICK\",\"shopperStatement\":\"YOUR SHOPPER STATEMENT\",\"recurringDetailName\":\"VALUE\",\"recurringTokenService\":\"VALUE\",\"store\":\"store value\",\"merchantAccount\":\"merchantAccount\",\"currency\":\"EUR\",\"applicationInfo\":{\"adyenLibrary\":{\"name\":\"adyen-dotnet-api-library\",\"version\":\""+ClientConfig.LibVersion+ "\"},\"externalPlatform\":{\"integrator\":\"externalPlatformIntegrator\",\"name\":\"externalPlatformName\",\"version\":\"2.0.0\"},\"merchantDevice\":{\"os\":\"merchantDeviceOS\",\"osVersion\":\"10.12.6\",\"reference\":\"4c32759faaa7\"}},\"tenderOption\":\"ReceiptHandler,AllowPartialAuthorisation,AskGratuity\",\"authorisationType\":\"PreAuth\",\"additionalData\":{\"key.key\":\"value\",\"key.keyTwo\":\"value2\"}}";
+        private readonly string exptectedSaleToAcquiredataJson = "{\"metadata\":{\"key\":\"value\"},\"shopperEmail\":\"myemail@mail.com\",\"shopperReference\":\"13164308\",\"recurringContract\":\"RECURRING,ONECLICK\",\"shopperStatement\":\"YOUR SHOPPER STATEMENT\",\"recurringDetailName\":\"VALUE\",\"recurringTokenService\":\"VALUE\",\"store\":\"store value\",\"merchantAccount\":\"merchantAccount\",\"currency\":\"EUR\",\"applicationInfo\":{\"adyenLibrary\":{\"name\":\"adyen-dotnet-api-library\",\"version\":\""+ClientConfig.LibVersion+ "\"},\"externalPlatform\":{\"integrator\":\"externalPlatformIntegrator\",\"name\":\"externalPlatformName\",\"version\":\"2.0.0\"},\"merchantDevice\":{\"os\":\"merchantDeviceOS\",\"osVersion\":\"10.12.6\",\"reference\":\"4c32759faaa7\"}},\"tenderOption\":\"ReceiptHandler,AllowPartialAuthorisation,AskGratuity\",\"authorisationType\":\"PreAuth\",\"additionalData\":{\"key.key\":\"value\",\"key.keyTwo\":\"value2\"}}";
 
         [TestMethod]
         public void SerializationTest()
         {
+               Assert.AreEqual(CreateSaleToAcquireData().ToBase64(), JsonToBase64());
+        }
+
+        [TestMethod]
+        public void SaleToPoiRequestSaleDataTest()
+        {
+            var saleToPoiRequest = new SaleToPOIRequest()
+            {
+                MessageHeader = new MessageHeader
+                {
+                    MessageType = MessageType.Request,
+                    MessageClass = MessageClassType.Service,
+                    MessageCategory = MessageCategoryType.Payment,
+                    SaleID = "POSSystemID12345",
+                    POIID = "MX915-284251016",
+                    ServiceID = DateTime.Now.ToString("ddHHmmss") //this should be unique
+                },
+                MessagePayload = new PaymentRequest()
+                {
+                    SaleData = new SaleData()
+                    {
+                        SaleToAcquirerData = CreateSaleToAcquireData().ToBase64(),
+                        SaleTransactionID = new TransactionIdentification()
+                        {
+                            TransactionID = "PosAuth",
+                            TimeStamp = DateTime.Now
+                        },
+                    },
+                    PaymentTransaction = new PaymentTransaction()
+                    {
+                        AmountsReq = new AmountsReq()
+                        {
+                            Currency = "EUR",
+                            RequestedAmount = 10100
+                        }
+                    },
+                }
+            };
+            var paymentRequest = (PaymentRequest)saleToPoiRequest.MessagePayload;
+            Assert.AreEqual(JsonToBase64(), paymentRequest.SaleData.SaleToAcquirerData);
+        }
+
+        private SaleToAcquirerData CreateSaleToAcquireData()
+        {
             SaleToAcquirerData saleToAcquirerData = new SaleToAcquirerData
             {
-                Metadata = new SortedDictionary<string, string> { { "key", "value" } },
+                Metadata = new SortedDictionary<string, string> {{"key", "value"}},
                 ShopperEmail = "myemail@mail.com",
                 ShopperReference = "13164308",
                 RecurringContract = "RECURRING,ONECLICK",
@@ -68,14 +114,13 @@ namespace Adyen.Test
             applicationInfo.MerchantDevice = merchantDevice;
             saleToAcquirerData.ApplicationInfo = applicationInfo;
             saleToAcquirerData.TenderOption = "ReceiptHandler,AllowPartialAuthorisation,AskGratuity";
-            var additionalData = new Dictionary<string, string> { { "key.key", "value" }, { "key.keyTwo", "value2" } };
+            var additionalData = new Dictionary<string, string> {{"key.key", "value"}, {"key.keyTwo", "value2"}};
             saleToAcquirerData.AdditionalData = additionalData;
-            Assert.AreEqual(saleToAcquirerData.ToBase64(), JsonToBase64());
+            return saleToAcquirerData;
         }
-
         private string JsonToBase64()
         {
-            return Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(_json));
+            return Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(exptectedSaleToAcquiredataJson));
         }
     }
 }

--- a/Adyen/Model/Nexo/SaleData.cs
+++ b/Adyen/Model/Nexo/SaleData.cs
@@ -53,9 +53,7 @@ namespace Adyen.Model.Nexo
 
         /// <remarks/>
         [System.Xml.Serialization.XmlElementAttribute(Form = System.Xml.Schema.XmlSchemaForm.Unqualified)]
-        [JsonConverter(typeof(JsonBase64Converter))]
-
-        public SaleToAcquirerData SaleToAcquirerData;
+        public string SaleToAcquirerData;
 
         /// <remarks/>
         [System.Xml.Serialization.XmlElementAttribute(Form = System.Xml.Schema.XmlSchemaForm.Unqualified)]
@@ -92,13 +90,5 @@ namespace Adyen.Model.Nexo
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public CustomerOrderReqType[] CustomerOrderReq;
-
-        public SaleData()
-        {
-            if (SaleToAcquirerData == null)
-            {
-                SaleToAcquirerData = new SaleToAcquirerData();
-            }
-        }
     }
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
The SaleData contains the `SaleToAcquirerData` property which is a flexible and it could be used to host many different structured parameters. The property was `SaleToAcquirerData` type which is limiting the usage of it.
Converting to `string` gives us the flexibility to use it as required and the [`SaleToAcquirerData`](https://github.com/Adyen/adyen-dotnet-api-library/blob/develop/Adyen/Model/Terminal/SaleToAcquirerData.cs) could be used now as a helper class to construct the string. 
Usage example: 
```
MessagePayload = new PaymentRequest()
                {
                    SaleData = new SaleData()
                    {
                        SaleToAcquirerData = SaleToAcquireData().ToBase64(), // or simple a string
                        SaleTransactionID = new TransactionIdentification()
                        {
                            TransactionID = "PosAuth",
                            TimeStamp = DateTime.Now
                        },
                    },
               }

```
For more information please check [Adyen's docs](https://docs.adyen.com/point-of-sale/add-data/sale-to-acquirer-data?tab=json_object_1#page-introduction) 
## Tested scenarios
<!-- Description of tested scenarios -->
Updated the unit tests

**Fixed issue**:  <!-- #-prefixed issue number -->
