### PR TITLE
Correct the client SetEnviroment overload

### DIFF
--- a/Adyen.Test/CheckoutTest.cs
+++ b/Adyen.Test/CheckoutTest.cs
@@ -101,7 +101,7 @@ namespace Adyen.Test
         public void CheckoutEndpointLiveWithBasicAuthTest()
         {
             var client = new Client("ws_*******", "******", Adyen.Model.Enum.Environment.Live, "live-url");
-            Assert.AreEqual(client.Config.Endpoint, "https://live-url-pal-live.adyenpayments.com");
+            Assert.AreEqual(client.Config.CheckoutEndpoint, "https://live-url-checkout-live.adyenpayments.com/checkout");
         }
 
         /// <summary>

--- a/Adyen.Test/CheckoutTest.cs
+++ b/Adyen.Test/CheckoutTest.cs
@@ -81,7 +81,27 @@ namespace Adyen.Test
         {
             var config = new Config();
             var client = new Client(config);
-            client.SetEnvironment(Model.Enum.Environment.Live);
+            client.SetEnvironment(Model.Enum.Environment.Live,null);
+        }
+        
+        /// <summary>
+        /// Tests unsuccessful checkout client Live URL generation.
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException), "Missing liveEndpointUrlPrefix for endpoint generation")]
+        public void CheckoutEndpointLiveWithBasicAuthErrorTest()
+        {
+            var client = new Client("ws_*******", "******", Adyen.Model.Enum.Environment.Live);
+        }
+        
+        /// <summary>
+        /// Tests successful checkout client Live URL generation.
+        /// </summary>
+        [TestMethod]
+        public void CheckoutEndpointLiveWithBasicAuthTest()
+        {
+            var client = new Client("ws_*******", "******", Adyen.Model.Enum.Environment.Live, "live-url");
+            Assert.AreEqual(client.Config.Endpoint, "https://live-url-pal-live.adyenpayments.com");
         }
 
         /// <summary>

--- a/Adyen/Client.cs
+++ b/Adyen/Client.cs
@@ -41,7 +41,8 @@ namespace Adyen
 
         public event CallbackLogHandler LogCallback;
 
-        public Client(string username, string password, Environment environment)
+        //If the liveEndpointUrlPrefix is null then it is used only for test environment
+        public Client(string username, string password, Environment environment, string liveEndpointUrlPrefix = null)
         {
             Config = new Config
             {
@@ -49,37 +50,23 @@ namespace Adyen
                 Password = password,
                 Environment = environment
             };
-            this.SetEnvironment(environment);
+            SetEnvironment(environment, liveEndpointUrlPrefix);
         }
-
-        public Client(string xapikey, Environment environment)
+        
+        //If the liveEndpointUrlPrefix is null then it is used only for test environment
+        public Client(string xapikey, Environment environment, string liveEndpointUrlPrefix = null)
         {
             Config = new Config
             {
                 Environment = environment,
                 XApiKey = xapikey
             };
-            this.SetEnvironment(environment);
-        }
-
-        public Client(string xapikey, Environment environment, string liveEndpointUrlPrefix)
-        {
-            Config = new Config
-            {
-                Environment = environment,
-                XApiKey = xapikey
-            };
-            this.SetEnvironment(environment, liveEndpointUrlPrefix);
+            SetEnvironment(environment, liveEndpointUrlPrefix);
         }
 
         public Client(Config config)
         {
             Config = config;
-        }
-
-        public void SetEnvironment(Environment environment)
-        {
-            SetEnvironment(environment, null);
         }
 
         public void SetEnvironment(Environment environment, string liveEndpointUrlPrefix)


### PR DESCRIPTION
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
When creating an Adyen.Client for the live environment using basic authentication (username and password) a System.InvalidOperationException is thrown with the following message: Missing liveEndpointUrlPrefix for endpoint generation. For that case we added the liveEndpointUrlPrefix as optional parameter so it can be used in test enviroment
**Tested scenarios**
<!-- Description of tested scenarios -->
- Create a client with `null` liveEndpointUrlPrefix 
- Create a client with liveEndpointUrlPrefix
**Fixed issue**:  <!-- #-prefixed issue number -->
fixes #594