### PR TITLE
Add Async support for the Account Service

### DIFF
--- a/Adyen.Test/MarketPayTests/MarketpayAccountTest.cs
+++ b/Adyen.Test/MarketPayTests/MarketpayAccountTest.cs
@@ -20,6 +20,7 @@
 //  * See the LICENSE file for more info.
 //  */
 #endregion
+using System.Threading.Tasks;
 using Adyen.Model.MarketPay;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
@@ -45,6 +46,21 @@ namespace Adyen.Test.MarketPayTest
             Assert.AreEqual(closeAccountResponse.Status,CloseAccountResponse.StatusEnum.Closed);
         }
 
+        // <summary>
+        // Test /closeAccount
+        // </summary>
+        [TestMethod]
+        public async Task TestCloseAccountSuccessAsync()
+        {
+          var client = CreateMockTestClientNullRequiredFieldsRequest("Mocks/marketpay/account/close-account-success.json");
+          var account = new Account(client);
+          var closeAccountRequest = new CloseAccountRequest(accountCode: "123456");
+          var closeAccountResponse = await account.CloseAccountAsync(closeAccountRequest);
+          Assert.IsNotNull(closeAccountResponse);
+          Assert.AreEqual(closeAccountResponse.PspReference, "8515810799236011");
+          Assert.AreEqual(closeAccountResponse.Status, CloseAccountResponse.StatusEnum.Closed);
+        }
+
         /// <summary>
         /// Test /closeAccountHolder API call/
         /// </summary>
@@ -68,6 +84,28 @@ namespace Adyen.Test.MarketPayTest
         }
 
         /// <summary>
+        /// Test /closeAccountHolder API call/
+        /// </summary>
+        [TestMethod]
+        public async Task TestCloseAccountHolderSuccessAsync()
+        {
+            var client = CreateMockTestClientNullRequiredFieldsRequest("Mocks/marketpay/account/close-account-holder-success.json");
+            var account = new Account(client);
+            var closeAccountHolderRequest = new CloseAccountHolderRequest(accountHolderCode: "123456");
+            var closeAccountHolderResponse = await account.CloseAccountHolderAsync(closeAccountHolderRequest);
+            Assert.IsNotNull(closeAccountHolderResponse);
+            Assert.AreEqual(closeAccountHolderResponse.PspReference, "8515810799236011");
+            Assert.IsNotNull(closeAccountHolderResponse);
+            Assert.AreEqual(closeAccountHolderResponse.AccountHolderStatus.Status, AccountHolderStatus.StatusEnum.Closed);
+            Assert.AreEqual(closeAccountHolderResponse.AccountHolderStatus.ProcessingState.ProcessedFrom, new Amount("USD", 0));
+            Assert.AreEqual(closeAccountHolderResponse.AccountHolderStatus.ProcessingState.ProcessedTo, new Amount("USD", 0));
+            Assert.AreEqual(closeAccountHolderResponse.AccountHolderStatus.PayoutState.AllowPayout, true);
+            Assert.AreEqual(closeAccountHolderResponse.AccountHolderStatus.PayoutState.Disabled, false);
+            Assert.AreEqual(closeAccountHolderResponse.AccountHolderStatus.ProcessingState.TierNumber, 0);
+            Assert.AreEqual(closeAccountHolderResponse.AccountHolderStatus.PayoutState.TierNumber, 0);
+        }
+
+        /// <summary>
         /// Test /createAccount API call/
         /// </summary>
         [TestMethod]
@@ -77,6 +115,22 @@ namespace Adyen.Test.MarketPayTest
             var account = new Account(client);
             var createAccountRequest = new CreateAccountRequest(accountHolderCode: "123456");
             var createAccountResponse = account.CreateAccount(createAccountRequest);
+            Assert.AreEqual(createAccountResponse.PspReference, "9914913130220156");
+            Assert.AreEqual(createAccountResponse.Status, CreateAccountResponse.StatusEnum.Active);
+            Assert.AreEqual(createAccountResponse.AccountHolderCode, "TestAccountHolder5691");
+            Assert.AreEqual(createAccountResponse.AccountCode, "195920946");
+        }
+
+        /// <summary>
+        /// Test /createAccount API call/
+        /// </summary>
+        [TestMethod]
+        public async Task TestCreateAccountSuccessAsync()
+        {
+            var client = CreateMockTestClientNullRequiredFieldsRequest("Mocks/marketpay/account/create-account-success.json");
+            var account = new Account(client);
+            var createAccountRequest = new CreateAccountRequest(accountHolderCode: "123456");
+            var createAccountResponse = await account.CreateAccountAsync(createAccountRequest);
             Assert.AreEqual(createAccountResponse.PspReference, "9914913130220156");
             Assert.AreEqual(createAccountResponse.Status, CreateAccountResponse.StatusEnum.Active);
             Assert.AreEqual(createAccountResponse.AccountHolderCode, "TestAccountHolder5691");
@@ -115,12 +169,57 @@ namespace Adyen.Test.MarketPayTest
         /// Test /createAccountHolder API call/
         /// </summary>
         [TestMethod]
+        public async Task TestCreateAccountHolderSuccessAsync()
+        {
+            var client = CreateMockTestClientNullRequiredFieldsRequest("Mocks/marketpay/account/create-account-holder-success.json");
+            var account = new Account(client);
+            var createAccountHolderRequest = new CreateAccountHolderRequest(accountHolderCode: "123456", accountHolderDetails: new AccountHolderDetails(email: "test@test.com", fullPhoneNumber: "123456789", webAddress: "webaddress"));
+            var createAccountHolderResponse = await account.CreateAccountHolderAsync(createAccountHolderRequest);
+            Assert.AreEqual(createAccountHolderResponse.PspReference, "8815810875863517");
+            Assert.AreEqual(createAccountHolderResponse.AccountCode, "8815810875863525");
+            Assert.AreEqual(createAccountHolderResponse.AccountHolderCode, "97112729718522222");
+            Assert.AreEqual(createAccountHolderResponse.AccountHolderDetails.Address.Country, "US");
+            Assert.AreEqual(createAccountHolderResponse.AccountHolderDetails.IndividualDetails.Name.FirstName, "John");
+            Assert.AreEqual(createAccountHolderResponse.AccountHolderDetails.IndividualDetails.Name.Gender, ViasName.GenderEnum.MALE);
+            Assert.AreEqual(createAccountHolderResponse.AccountHolderDetails.IndividualDetails.Name.LastName, "Smith");
+            Assert.AreEqual(createAccountHolderResponse.AccountHolderStatus.Status,
+                AccountHolderStatus.StatusEnum.Active);
+            Assert.AreEqual(createAccountHolderResponse.LegalEntity, CreateAccountHolderResponse.LegalEntityEnum.Individual);
+            Assert.AreEqual(createAccountHolderResponse.AccountHolderStatus.Status,
+                AccountHolderStatus.StatusEnum.Active);
+            Assert.AreEqual(createAccountHolderResponse.AccountHolderStatus.PayoutState.AllowPayout, false);
+            Assert.AreEqual(createAccountHolderResponse.AccountHolderStatus.PayoutState.Disabled, false);
+            Assert.AreEqual(createAccountHolderResponse.AccountHolderStatus.PayoutState.Disabled, false);
+            Assert.IsNotNull(createAccountHolderResponse.Verification.AccountHolder.Checks);
+        }
+
+        /// <summary>
+        /// Test /createAccountHolder API call/
+        /// </summary>
+        [TestMethod]
         public void TestCreateAccountHolderError()
         {
             var client = CreateMockTestClientNullRequiredFieldsRequest("Mocks/marketpay/account/create-account-holder-error-invalid-fields.json");
             var account = new Account(client);
             var createAccountHolderRequest = new CreateAccountHolderRequest(accountHolderCode: "123456", accountHolderDetails: new AccountHolderDetails(email: "test@test.com", fullPhoneNumber: "123456789", webAddress: "webaddress"));
             var createAccountHolderResponse = account.CreateAccountHolder(createAccountHolderRequest);
+            Assert.AreEqual(createAccountHolderResponse.PspReference, "8815813233102537");
+            Assert.IsNotNull(createAccountHolderResponse.InvalidFields);
+            Assert.AreEqual(createAccountHolderResponse.InvalidFields[0].ErrorCode, 28);
+            Assert.AreEqual(createAccountHolderResponse.InvalidFields[0].FieldType.Field, "accountHolderCode");
+            Assert.AreEqual(createAccountHolderResponse.InvalidFields[0].FieldType.FieldName, FieldType.FieldNameEnum.AccountHolderCode);
+        }
+
+        /// <summary>
+        /// Test /createAccountHolder API call/
+        /// </summary>
+        [TestMethod]
+        public async Task TestCreateAccountHolderErrorAsync()
+        {
+            var client = CreateMockTestClientNullRequiredFieldsRequest("Mocks/marketpay/account/create-account-holder-error-invalid-fields.json");
+            var account = new Account(client);
+            var createAccountHolderRequest = new CreateAccountHolderRequest(accountHolderCode: "123456", accountHolderDetails: new AccountHolderDetails(email: "test@test.com", fullPhoneNumber: "123456789", webAddress: "webaddress"));
+            var createAccountHolderResponse = await account.CreateAccountHolderAsync(createAccountHolderRequest);
             Assert.AreEqual(createAccountHolderResponse.PspReference, "8815813233102537");
             Assert.IsNotNull(createAccountHolderResponse.InvalidFields);
             Assert.AreEqual(createAccountHolderResponse.InvalidFields[0].ErrorCode, 28);
@@ -142,6 +241,19 @@ namespace Adyen.Test.MarketPayTest
         }
 
         /// <summary>
+        /// Test /deleteBankAccounts API call/
+        /// </summary>
+        [TestMethod]
+        public async Task TestDeleteBankAccountSuccessAsync()
+        {
+            var client = CreateMockTestClientNullRequiredFieldsRequest("Mocks/marketpay/account/delete-bank-account-success.json");
+            var account = new Account(client);
+            var deleteAccountSuccessRequest = new DeleteBankAccountRequest(accountHolderCode: "123456", bankAccountUUIDs: new List<string>());
+            var deleteAccountSuccessResponse = await account.DeleteBankAccountAsync(deleteAccountSuccessRequest);
+            Assert.AreEqual(deleteAccountSuccessResponse.PspReference, "9914694372670551");
+        }
+
+        /// <summary>
         /// Test /deleteShareholders API call/
         /// </summary>
         [TestMethod]
@@ -155,6 +267,19 @@ namespace Adyen.Test.MarketPayTest
         }
 
         /// <summary>
+        /// Test /deleteShareholders API call/
+        /// </summary>
+        [TestMethod]
+        public async Task TestDeleteShareholderSuccessAsync()
+        {
+            var client = CreateMockTestClientNullRequiredFieldsRequest("Mocks/marketpay/account/delete-shareholder-success.json");
+            var account = new Account(client);
+            var deleteShareholderRequest = new DeleteShareholderRequest(accountHolderCode: "123456", shareholderCodes: new List<string>());
+            var deleteShareholderResponse = await account.DeleteShareHolderAsync(deleteShareholderRequest);
+            Assert.AreEqual(deleteShareholderResponse.PspReference, "9914694372990637");
+        }
+
+        /// <summary>
         /// Test /getAccountHolder API call/
         /// </summary>
         [TestMethod]
@@ -164,6 +289,44 @@ namespace Adyen.Test.MarketPayTest
             var account = new Account(client);
             var getAccountHolderRequest = new GetAccountHolderRequest(accountHolderCode: "123456");
             var getAccountHolderResponse = account.GetAccountHolder(getAccountHolderRequest);
+            Assert.AreEqual(getAccountHolderResponse.PspReference, "8515813355311349");
+            Assert.AreEqual(getAccountHolderResponse.AccountHolderCode, "8515843355311359");
+            Assert.AreEqual(getAccountHolderResponse.AccountHolderDetails.Email, "test@test.com");
+            Assert.AreEqual(getAccountHolderResponse.LegalEntity, GetAccountHolderResponse.LegalEntityEnum.Individual);
+            Assert.AreEqual(getAccountHolderResponse.AccountHolderDetails.BankAccountDetails[0].BankAccountName, "MarketPlace Account");
+            Assert.AreEqual(getAccountHolderResponse.AccountHolderDetails.BankAccountDetails[0].BankAccountUUID, "6026a526-7863-aaaa-dddd-f8fadc47473e");
+            Assert.AreEqual(getAccountHolderResponse.AccountHolderDetails.BankAccountDetails[0].BankBicSwift, "TESTNL01");
+            Assert.AreEqual(getAccountHolderResponse.AccountHolderDetails.BankAccountDetails[0].BankCity, "bankCity");
+            Assert.AreEqual(getAccountHolderResponse.AccountHolderDetails.BankAccountDetails[0].BankName, "bankName");
+            Assert.AreEqual(getAccountHolderResponse.AccountHolderDetails.BankAccountDetails[0].CountryCode, "NL");
+            Assert.AreEqual(getAccountHolderResponse.AccountHolderDetails.BankAccountDetails[1].BankAccountName, "MarketPlace Account");
+            Assert.AreEqual(getAccountHolderResponse.AccountHolderDetails.BankAccountDetails[1].BankAccountUUID, "ab3aeec6-a679-aaaa-dddd-88bd936a6a33");
+            Assert.AreEqual(getAccountHolderResponse.AccountHolderDetails.BankAccountDetails[1].BankBicSwift, "TESTNL01");
+            Assert.AreEqual(getAccountHolderResponse.AccountHolderDetails.BankAccountDetails[1].BankCity, "bankCity");
+            Assert.AreEqual(getAccountHolderResponse.AccountHolderDetails.BankAccountDetails[1].BankName, "bankName");
+            Assert.AreEqual(getAccountHolderResponse.AccountHolderDetails.BankAccountDetails[1].CountryCode, "NL");
+            Assert.AreEqual(getAccountHolderResponse.AccountHolderDetails.BankAccountDetails[2].BankAccountName, "MarketPlace Account");
+            Assert.AreEqual(getAccountHolderResponse.AccountHolderDetails.BankAccountDetails[2].BankAccountUUID, "b301ca68-e227-aaaa-dddd-9bc1f94fc0f0");
+            Assert.AreEqual(getAccountHolderResponse.AccountHolderDetails.BankAccountDetails[2].BankBicSwift, "TESTNL01");
+            Assert.AreEqual(getAccountHolderResponse.AccountHolderDetails.BankAccountDetails[2].BankCity, "bankCity");
+            Assert.AreEqual(getAccountHolderResponse.AccountHolderDetails.BankAccountDetails[2].BankName, "bankName");
+            Assert.AreEqual(getAccountHolderResponse.AccountHolderDetails.BankAccountDetails[2].CountryCode, "NL");
+            Assert.AreEqual(getAccountHolderResponse.Accounts[0].AccountCode, "115548513");
+            Assert.AreEqual(getAccountHolderResponse.Accounts[1].AccountCode, "158653516");
+            Assert.AreEqual(getAccountHolderResponse.Accounts[2].AccountCode, "162994490");
+        }
+
+    
+        /// <summary>
+        /// Test /getAccountHolder API call/
+        /// </summary>
+        [TestMethod]
+        public async Task TestGetAccountHoldersAsync()
+        {
+            var client = CreateMockTestClientNullRequiredFieldsRequest("Mocks/marketpay/account/get-account-holder-success.json");
+            var account = new Account(client);
+            var getAccountHolderRequest = new GetAccountHolderRequest(accountHolderCode: "123456");
+            var getAccountHolderResponse = await account.GetAccountHolderAsync(getAccountHolderRequest);
             Assert.AreEqual(getAccountHolderResponse.PspReference, "8515813355311349");
             Assert.AreEqual(getAccountHolderResponse.AccountHolderCode, "8515843355311359");
             Assert.AreEqual(getAccountHolderResponse.AccountHolderDetails.Email, "test@test.com");
@@ -208,12 +371,47 @@ namespace Adyen.Test.MarketPayTest
             Assert.AreEqual(getUploadedDocumentsResponse.DocumentDetails[0].DocumentType, DocumentDetail.DocumentTypeEnum.BANKSTATEMENT);
             Assert.AreEqual(getUploadedDocumentsResponse.DocumentDetails[0].AccountHolderCode, "TestAccountHolder8031");
         }
+    
+        /// <summary>
+        /// Test /getUploadedDocuments API call/
+        /// </summary>
+        [TestMethod]
+        public async Task TestGetUploadedDocumentsSuccessAsync()
+        {
+            var client = CreateMockTestClientNullRequiredFieldsRequest("Mocks/marketpay/account/get-uploaded-documents-success.json");
+            var account = new Account(client);
+            var getUploadedDocumentsRequest = new GetUploadedDocumentsRequest(accountHolderCode: "123456");
+            var getUploadedDocumentsResponse = account.GetUploadedDocuments(getUploadedDocumentsRequest);
+            Assert.AreEqual(getUploadedDocumentsResponse.PspReference, "9914694369860322");
+            Assert.AreEqual(getUploadedDocumentsResponse.DocumentDetails[0].AccountHolderCode, "TestAccountHolder8031");
+            Assert.AreEqual(getUploadedDocumentsResponse.DocumentDetails[0].BankAccountUUID, "EXAMPLE_UUID");
+            Assert.AreEqual(getUploadedDocumentsResponse.DocumentDetails[0].Description, "description1");
+            Assert.AreEqual(getUploadedDocumentsResponse.DocumentDetails[0].DocumentType, DocumentDetail.DocumentTypeEnum.BANKSTATEMENT);
+            Assert.AreEqual(getUploadedDocumentsResponse.DocumentDetails[0].AccountHolderCode, "TestAccountHolder8031");
+        }
 
         /// <summary>
         /// Test /suspendAccountHolder API call/
         /// </summary>
         [TestMethod]
         public void TestSuspendAccountHolderSuccess()
+        {
+            var client = CreateMockTestClientNullRequiredFieldsRequest("Mocks/marketpay/account/suspend-account-holder-success.json");
+            var account = new Account(client);
+            var suspendAccountHolderRequest = new SuspendAccountHolderRequest(accountHolderCode: "123456");
+            var suspendAccountHolderResponse = account.SuspendAccountHolder(suspendAccountHolderRequest);
+            Assert.AreEqual(suspendAccountHolderResponse.PspReference, "8515813523937793");
+            Assert.AreEqual(suspendAccountHolderResponse.AccountHolderStatus.Status, AccountHolderStatus.StatusEnum.Suspended);
+            Assert.AreEqual(suspendAccountHolderResponse.AccountHolderStatus.PayoutState.AllowPayout, false);
+            Assert.AreEqual(suspendAccountHolderResponse.AccountHolderStatus.PayoutState.Disabled, false);
+        }
+
+    
+        /// <summary>
+        /// Test /suspendAccountHolder API call/
+        /// </summary>
+        [TestMethod]
+        public async Task TestSuspendAccountHolderSuccessAsync()
         {
             var client = CreateMockTestClientNullRequiredFieldsRequest("Mocks/marketpay/account/suspend-account-holder-success.json");
             var account = new Account(client);
@@ -240,7 +438,23 @@ namespace Adyen.Test.MarketPayTest
             Assert.AreEqual(unSuspendAccountHolderResponse.AccountHolderStatus.PayoutState.AllowPayout, false);
             Assert.AreEqual(unSuspendAccountHolderResponse.AccountHolderStatus.PayoutState.Disabled, false);
         }
-
+    
+        /// <summary>
+        /// Test /unSuspendAccountHolder API call/
+        /// </summary>
+        [TestMethod]
+        public async Task TestUnSuspendAccountHolderSuccessAsync()
+        {
+            var client = CreateMockTestClientNullRequiredFieldsRequest("Mocks/marketpay/account/un-suspend-account-holder-success.json");
+            var account = new Account(client);
+            var unSuspendAccountHolderRequest = new UnSuspendAccountHolderRequest(accountHolderCode: "123456");
+            var unSuspendAccountHolderResponse = account.UnSuspendAccountHolder(unSuspendAccountHolderRequest);
+            Assert.AreEqual(unSuspendAccountHolderResponse.PspReference, "8815813528286482");
+            Assert.AreEqual(unSuspendAccountHolderResponse.AccountHolderStatus.Status, AccountHolderStatus.StatusEnum.Active);
+            Assert.AreEqual(unSuspendAccountHolderResponse.AccountHolderStatus.PayoutState.AllowPayout, false);
+            Assert.AreEqual(unSuspendAccountHolderResponse.AccountHolderStatus.PayoutState.Disabled, false);
+        }
+        
         /// <summary>
         /// Test /updateAccount API call
         /// </summary>
@@ -256,6 +470,22 @@ namespace Adyen.Test.MarketPayTest
             Assert.AreEqual(updateAccountResponse.PayoutSchedule.Schedule, PayoutScheduleResponse.ScheduleEnum.WEEKLY);
         }
 
+    
+        /// <summary>
+        /// Test /updateAccount API call
+        /// </summary>
+        [TestMethod]
+        public async Task TestUpdateAccountSuccessAsync()
+        {
+            var client = CreateMockTestClientNullRequiredFieldsRequest("Mocks/marketpay/account/update-account-success.json");
+            var account = new Account(client);
+            var updateAccountRequest = new UpdateAccountRequest(accountCode: "123456");
+            var updateAccountResponse = await account.UpdateAccountAsync(updateAccountRequest);
+            Assert.AreEqual(updateAccountResponse.PspReference, "9914860311411119");
+            Assert.AreEqual(updateAccountResponse.AccountCode, "198360329231");
+            Assert.AreEqual(updateAccountResponse.PayoutSchedule.Schedule, PayoutScheduleResponse.ScheduleEnum.WEEKLY);
+        }
+
         /// <summary>
         /// Test /updateAccountHolder API call
         /// </summary>
@@ -266,6 +496,35 @@ namespace Adyen.Test.MarketPayTest
             var account = new Account(client);
             var updateAccountHolderRequest = new UpdateAccountHolderRequest(accountHolderCode: "123456");
             var updateAccountHolderResponse = account.UpdateAccountHolder(updateAccountHolderRequest);
+            Assert.AreEqual(updateAccountHolderResponse.PspReference, "8515813355311349");
+            Assert.AreEqual(updateAccountHolderResponse.AccountHolderCode, "8515843355311359");
+            Assert.AreEqual(updateAccountHolderResponse.AccountHolderDetails.Email, "test@test.com");
+            Assert.AreEqual(updateAccountHolderResponse.AccountHolderDetails.Address, new ViasAddress(country: "US"));
+            Assert.AreEqual(updateAccountHolderResponse.AccountHolderDetails.IndividualDetails.Name.FirstName, "John");
+            Assert.AreEqual(updateAccountHolderResponse.AccountHolderDetails.IndividualDetails.Name.Gender, ViasName.GenderEnum.MALE);
+            Assert.AreEqual(updateAccountHolderResponse.AccountHolderDetails.IndividualDetails.Name.LastName, "Smith");
+            Assert.AreEqual(updateAccountHolderResponse.AccountHolderStatus.Status,
+                AccountHolderStatus.StatusEnum.Active);
+            Assert.AreEqual(updateAccountHolderResponse.AccountHolderStatus.Events.Count, 0);
+            Assert.AreEqual(updateAccountHolderResponse.AccountHolderStatus.ProcessingState.Disabled, false);
+            Assert.AreEqual(updateAccountHolderResponse.AccountHolderStatus.ProcessingState.ProcessedFrom, new Amount("USD", 0));
+            Assert.AreEqual(updateAccountHolderResponse.AccountHolderStatus.ProcessingState.ProcessedTo, new Amount("USD", 9999));
+            Assert.AreEqual(updateAccountHolderResponse.AccountHolderStatus.PayoutState.AllowPayout, false);
+            Assert.AreEqual(updateAccountHolderResponse.AccountHolderStatus.PayoutState.Disabled, false);
+            Assert.IsNotNull(updateAccountHolderResponse.Verification.AccountHolder.Checks);
+        }
+
+    
+        /// <summary>
+        /// Test /updateAccountHolder API call
+        /// </summary>
+        [TestMethod]
+        public async Task TestUpdateAccountHolderSuccessAsync()
+        {
+            var client = CreateMockTestClientNullRequiredFieldsRequest("Mocks/marketpay/account/update-account-holder-success.json");
+            var account = new Account(client);
+            var updateAccountHolderRequest = new UpdateAccountHolderRequest(accountHolderCode: "123456");
+            var updateAccountHolderResponse = await account.UpdateAccountHolderAsync(updateAccountHolderRequest);
             Assert.AreEqual(updateAccountHolderResponse.PspReference, "8515813355311349");
             Assert.AreEqual(updateAccountHolderResponse.AccountHolderCode, "8515843355311359");
             Assert.AreEqual(updateAccountHolderResponse.AccountHolderDetails.Email, "test@test.com");
@@ -307,6 +566,30 @@ namespace Adyen.Test.MarketPayTest
             Assert.AreEqual(updateAccountHolderStateResponse.AccountHolderStatus.PayoutState.DisableReason, "test reason payout");
         }
 
+    
+        /// <summary>
+        /// Test /updateAccountHolderState API call
+        /// </summary>
+        [TestMethod]
+        public async Task TestUpdateAccountHolderStateSuccessAsync()
+        {
+            var client = CreateMockTestClientNullRequiredFieldsRequest("Mocks/marketpay/account/update-account-holder-state-success.json");
+            var account = new Account(client);
+            var updateAccountHolderStateRequest = new UpdateAccountHolderStateRequest(accountHolderCode: "123456", reason: "test reason payout", stateType: UpdateAccountHolderStateRequest.StateTypeEnum.Payout, disable: false);
+            var updateAccountHolderStateResponse = await account.UpdateAccountHolderStateAsync(updateAccountHolderStateRequest);
+            Assert.AreEqual(updateAccountHolderStateResponse.PspReference, "8515813355311349");
+            Assert.AreEqual(updateAccountHolderStateResponse.AccountHolderCode, "8515843355311359");
+            Assert.AreEqual(updateAccountHolderStateResponse.AccountHolderStatus.Status,
+            AccountHolderStatus.StatusEnum.Active);
+            Assert.AreEqual(updateAccountHolderStateResponse.AccountHolderStatus.Events.Count, 0);
+            Assert.AreEqual(updateAccountHolderStateResponse.AccountHolderStatus.ProcessingState.Disabled, false);
+            Assert.AreEqual(updateAccountHolderStateResponse.AccountHolderStatus.ProcessingState.ProcessedFrom, new Amount("USD", 0));
+            Assert.AreEqual(updateAccountHolderStateResponse.AccountHolderStatus.ProcessingState.ProcessedTo, new Amount("USD", 9999));
+            Assert.AreEqual(updateAccountHolderStateResponse.AccountHolderStatus.PayoutState.AllowPayout, false);
+            Assert.AreEqual(updateAccountHolderStateResponse.AccountHolderStatus.PayoutState.Disabled, true);
+            Assert.AreEqual(updateAccountHolderStateResponse.AccountHolderStatus.PayoutState.DisableReason, "test reason payout");
+        }
+
         /// <summary>
         /// Test /uploadDocument API call
         /// </summary>
@@ -318,6 +601,21 @@ namespace Adyen.Test.MarketPayTest
             var documentDetail = new DocumentDetail(accountHolderCode: "123456", filename: "stament.pdf", bankAccountUUID: "aaaaaaaa-7863-f943-4e3s-ffffffff", documentType: DocumentDetail.DocumentTypeEnum.BANKSTATEMENT);          
             var uploadDocumentRequest = new UploadDocumentRequest(documentDetail:documentDetail,documentContent:new byte[1000]);
             var uploadDocumentResponse = account.UploadDocument(uploadDocumentRequest);
+            Assert.AreEqual(uploadDocumentResponse.PspReference, "8815815165741111");
+            Assert.AreEqual(uploadDocumentResponse.AccountHolderCode, "TestAccountHolder8031");
+        }
+
+        /// <summary>
+        /// Test /uploadDocument API call
+        /// </summary>
+        [TestMethod]
+        public async Task TestUpdateDocumentSuccessAsync()
+        {
+            var client = CreateMockTestClientNullRequiredFieldsRequest("Mocks/marketpay/account/upload-document-success.json");
+            var account = new Account(client);
+            var documentDetail = new DocumentDetail(accountHolderCode: "123456", filename: "stament.pdf", bankAccountUUID: "aaaaaaaa-7863-f943-4e3s-ffffffff", documentType: DocumentDetail.DocumentTypeEnum.BANKSTATEMENT);          
+            var uploadDocumentRequest = new UploadDocumentRequest(documentDetail:documentDetail,documentContent:new byte[1000]);
+            var uploadDocumentResponse = await account.UploadDocumentAsync(uploadDocumentRequest);
             Assert.AreEqual(uploadDocumentResponse.PspReference, "8815815165741111");
             Assert.AreEqual(uploadDocumentResponse.AccountHolderCode, "TestAccountHolder8031");
         }
@@ -337,6 +635,20 @@ namespace Adyen.Test.MarketPayTest
         }
 
         /// <summary>
+        /// Test /deletePayoutMethods API call
+        /// </summary>
+        [TestMethod]
+        public async Task TestDeletePayoutMethodsSuccessAsync()
+        {
+            var client = CreateMockTestClientNullRequiredFieldsRequest("Mocks/marketpay/account/delete-payout-methods.json");
+            var account = new Account(client);
+            var deletePayoutMethodRequest = new DeletePayoutMethodRequest(accountHolderCode: "123456",payoutMethodCodes:new List<string>());
+            var genericResponse = await account.DeletePayoutMethodsAsync(deletePayoutMethodRequest);
+            Assert.AreEqual(genericResponse.PspReference, "85158152328111154");
+            Assert.AreEqual(genericResponse.ResultCode, "Success");
+        }
+
+        /// <summary>
         /// Test /checkoutAccountHolder API call
         /// </summary>
         [TestMethod]
@@ -346,6 +658,20 @@ namespace Adyen.Test.MarketPayTest
             var account = new Account(client);
             var performVerificationRequest = new PerformVerificationRequest(accountHolderCode: "TestAccountHolder8031", accountStateType: PerformVerificationRequest.AccountStateTypeEnum.Processing, tier: 2);
             var genericResponse = account.CheckAccountholder(performVerificationRequest);
+            Assert.AreEqual(genericResponse.PspReference, "85158152328111154");
+            Assert.AreEqual(genericResponse.ResultCode, "Success");
+        }
+
+        /// <summary>
+        /// Test /checkoutAccountHolder API call
+        /// </summary>
+        [TestMethod]
+        public async Task TestCheckAccountHolderSuccessAsync()
+        {
+            var client = CreateMockTestClientNullRequiredFieldsRequest("Mocks/marketpay/account/check-account-holder-success.json");
+            var account = new Account(client);
+            var performVerificationRequest = new PerformVerificationRequest(accountHolderCode: "TestAccountHolder8031", accountStateType: PerformVerificationRequest.AccountStateTypeEnum.Processing, tier: 2);
+            var genericResponse = await account.CheckAccountholderAsync(performVerificationRequest);
             Assert.AreEqual(genericResponse.PspReference, "85158152328111154");
             Assert.AreEqual(genericResponse.ResultCode, "Success");
         }

--- a/Adyen/Service/Account.cs
+++ b/Adyen/Service/Account.cs
@@ -81,7 +81,7 @@ namespace Adyen.Service
         }
 
         /// <summary>
-        /// Post /closeAccount API call
+        /// Post /closeAccount API call async
         /// </summary>
         /// <param name="closeAccountRequest"></param>
         /// <returns>CloseAccountResponse</returns>
@@ -105,7 +105,7 @@ namespace Adyen.Service
         }
 
         /// <summary>
-        /// Post /closeAccountHolder API call
+        /// Post /closeAccountHolder API call async
         /// </summary>
         /// <param name="closeAccountHolderRequest"></param>
         /// <returns>CloseAccountResponse</returns>
@@ -129,7 +129,7 @@ namespace Adyen.Service
         }
 
         /// <summary>
-        /// Post /createAccount API call
+        /// Post /createAccount API call async
         /// </summary>
         /// <param name="createAccountRequest"></param>
         /// <returns>CloseAccountResponse</returns>
@@ -153,7 +153,7 @@ namespace Adyen.Service
         }
 
         /// <summary>
-        /// Post /createAccountHolder API call
+        /// Post /createAccountHolder API call async
         /// </summary>
         /// <param name="createAccountHolderRequest"></param>
         /// <returns>CloseAccountHolderResponse</returns>
@@ -177,7 +177,7 @@ namespace Adyen.Service
         }
 
         /// <summary>
-        /// Post /deleteBankAccount API call
+        /// Post /deleteBankAccount API call async
         /// </summary>
         /// <param name="deleteBankAccountRequest"></param>
         /// <returns>GenericResponse</returns>
@@ -201,7 +201,7 @@ namespace Adyen.Service
         }
 
         /// <summary>
-        /// Post /deleteShareHolder API call
+        /// Post /deleteShareHolder API call async
         /// </summary>
         /// <param name="deleteShareholderRequest"></param>
         /// <returns>GenericResponse</returns>
@@ -225,7 +225,7 @@ namespace Adyen.Service
         }
 
         /// <summary>
-        /// Post /getAccountHolder API call
+        /// Post /getAccountHolder API call async
         /// </summary>
         /// <param name="getAccountHolderRequest"></param>
         /// <returns>GetAccountHolderResponse</returns>
@@ -249,7 +249,7 @@ namespace Adyen.Service
         }
 
         /// <summary>
-        /// Post /getUploadedDocuments API call
+        /// Post /getUploadedDocuments API call async
         /// </summary>
         /// <param name="getUploadedDocumentsRequest"></param>
         /// <returns>GetUploadedDocumentsResponse</returns>
@@ -273,7 +273,7 @@ namespace Adyen.Service
         }
 
         /// <summary>
-        /// Post /suspendAccountHolder API call
+        /// Post /suspendAccountHolder API call async
         /// </summary>
         /// <param name="suspendAccountHolderRequest"></param>
         /// <returns>SuspendAccountHolderResponse</returns>
@@ -297,7 +297,7 @@ namespace Adyen.Service
         }
 
         /// <summary>
-        /// Post /unSuspendAccountHolder API call
+        /// Post /unSuspendAccountHolder API call async
         /// </summary>
         /// <param name="unSuspendAccountHolderRequest"></param>
         /// <returns>UnSuspendAccountHolderResponse</returns>
@@ -321,7 +321,7 @@ namespace Adyen.Service
         }
 
         /// <summary>
-        /// Post /updateAccount API call
+        /// Post /updateAccount API call async
         /// </summary>
         /// <param name="updateAccountRequest"></param>
         /// <returns>UpdateAccountResponse</returns>
@@ -345,7 +345,7 @@ namespace Adyen.Service
         }
 
         /// <summary>
-        /// Post /updateAccountHolder API call
+        /// Post /updateAccountHolder API call async
         /// </summary>
         /// <param name="updateAccountHolderRequest"></param>
         /// <returns>UpdateAccountHolderResponse</returns>
@@ -369,7 +369,7 @@ namespace Adyen.Service
         }
 
         /// <summary>
-        /// Post /updateAccountHolderState API call
+        /// Post /updateAccountHolderState API call async
         /// </summary>
         /// <param name="updateAccountHolderStateRequest"></param>
         /// <returns>GetAccountHolderStatusResponse</returns>
@@ -393,7 +393,7 @@ namespace Adyen.Service
         }
 
         /// <summary>
-        /// Post /uploadDocument API call
+        /// Post /uploadDocument API call async
         /// </summary>
         /// <param name="uploadDocumentRequest"></param>
         /// <returns> UploadDocumentResponse </returns>
@@ -417,7 +417,7 @@ namespace Adyen.Service
         }
 
         /// <summary>
-        /// Post /checkAccountholder API call
+        /// Post /checkAccountholder API call async
         /// </summary>
         /// <param name="performVerificationRequest"></param>
         /// <returns>GenericResponse</returns>
@@ -439,9 +439,9 @@ namespace Adyen.Service
             var jsonResponse = _deletePayoutMethods.Request(jsonRequest);
             return JsonConvert.DeserializeObject<GenericResponse>(jsonResponse);
         }
- 
-    /// <summary>
-        /// Post /deletePayoutMethods API call
+
+        /// <summary>
+        /// Post /deletePayoutMethods API call async
         /// </summary>
         /// <param name="deletePayoutMethodRequest"></param>
         /// <returns>GenericResponse</returns>

--- a/Adyen/Service/Account.cs
+++ b/Adyen/Service/Account.cs
@@ -21,6 +21,7 @@
 //  */
 #endregion
 
+using System.Threading.Tasks;
 using Adyen.Model.MarketPay;
 using Adyen.Service.Resource.Account;
 using Newtonsoft.Json;
@@ -80,6 +81,18 @@ namespace Adyen.Service
         }
 
         /// <summary>
+        /// Post /closeAccount API call
+        /// </summary>
+        /// <param name="closeAccountRequest"></param>
+        /// <returns>CloseAccountResponse</returns>
+        public async Task<CloseAccountResponse> CloseAccountAsync(CloseAccountRequest closeAccountRequest)
+        {
+            var jsonRequest = Util.JsonOperation.SerializeRequest(closeAccountRequest);
+            var jsonResponse = await _closeAccount.RequestAsync(jsonRequest);
+            return JsonConvert.DeserializeObject<CloseAccountResponse>(jsonResponse);
+        }
+
+        /// <summary>
         /// Post /closeAccountHolder API call
         /// </summary>
         /// <param name="closeAccountHolderRequest"></param>
@@ -88,6 +101,18 @@ namespace Adyen.Service
         {
             var jsonRequest = Util.JsonOperation.SerializeRequest(closeAccountHolderRequest);
             var jsonResponse = _closeAccountHolder.Request(jsonRequest);
+            return JsonConvert.DeserializeObject<CloseAccountHolderResponse>(jsonResponse);
+        }
+
+        /// <summary>
+        /// Post /closeAccountHolder API call
+        /// </summary>
+        /// <param name="closeAccountHolderRequest"></param>
+        /// <returns>CloseAccountResponse</returns>
+        public async Task<CloseAccountHolderResponse> CloseAccountHolderAsync(CloseAccountHolderRequest closeAccountHolderRequest)
+        {
+            var jsonRequest = Util.JsonOperation.SerializeRequest(closeAccountHolderRequest);
+            var jsonResponse = await _closeAccountHolder.RequestAsync(jsonRequest);
             return JsonConvert.DeserializeObject<CloseAccountHolderResponse>(jsonResponse);
         }
 
@@ -104,6 +129,18 @@ namespace Adyen.Service
         }
 
         /// <summary>
+        /// Post /createAccount API call
+        /// </summary>
+        /// <param name="createAccountRequest"></param>
+        /// <returns>CloseAccountResponse</returns>
+        public async Task<CreateAccountResponse> CreateAccountAsync(CreateAccountRequest createAccountRequest)
+        {
+            var jsonRequest = Util.JsonOperation.SerializeRequest(createAccountRequest);
+            var jsonResponse = await _createAccount.RequestAsync(jsonRequest);
+            return JsonConvert.DeserializeObject<CreateAccountResponse>(jsonResponse);
+        }
+
+        /// <summary>
         /// Post /createAccountHolder API call
         /// </summary>
         /// <param name="createAccountHolderRequest"></param>
@@ -112,6 +149,18 @@ namespace Adyen.Service
         {
             var jsonRequest = Util.JsonOperation.SerializeRequest(createAccountHolderRequest);
             var jsonResponse = _createAccountHolder.Request(jsonRequest);
+            return JsonConvert.DeserializeObject<CreateAccountHolderResponse>(jsonResponse);
+        }
+
+        /// <summary>
+        /// Post /createAccountHolder API call
+        /// </summary>
+        /// <param name="createAccountHolderRequest"></param>
+        /// <returns>CloseAccountHolderResponse</returns>
+        public async Task<CreateAccountHolderResponse> CreateAccountHolderAsync(CreateAccountHolderRequest createAccountHolderRequest)
+        {
+            var jsonRequest = Util.JsonOperation.SerializeRequest(createAccountHolderRequest);
+            var jsonResponse = await _createAccountHolder.RequestAsync(jsonRequest);
             return JsonConvert.DeserializeObject<CreateAccountHolderResponse>(jsonResponse);
         }
 
@@ -128,6 +177,18 @@ namespace Adyen.Service
         }
 
         /// <summary>
+        /// Post /deleteBankAccount API call
+        /// </summary>
+        /// <param name="deleteBankAccountRequest"></param>
+        /// <returns>GenericResponse</returns>
+        public async Task<GenericResponse> DeleteBankAccountAsync(DeleteBankAccountRequest deleteBankAccountRequest)
+        {
+            var jsonRequest = Util.JsonOperation.SerializeRequest(deleteBankAccountRequest);
+            var jsonResponse = await _deleteBankAccount.RequestAsync(jsonRequest);
+            return JsonConvert.DeserializeObject<GenericResponse>(jsonResponse);
+        }
+
+        /// <summary>
         /// Post /deleteShareHolder API call
         /// </summary>
         /// <param name="deleteShareholderRequest"></param>
@@ -136,6 +197,18 @@ namespace Adyen.Service
         {
             var jsonRequest = Util.JsonOperation.SerializeRequest(deleteShareholderRequest);
             var jsonResponse = _deleteShareholder.Request(jsonRequest);
+            return JsonConvert.DeserializeObject<GenericResponse>(jsonResponse);
+        }
+
+        /// <summary>
+        /// Post /deleteShareHolder API call
+        /// </summary>
+        /// <param name="deleteShareholderRequest"></param>
+        /// <returns>GenericResponse</returns>
+        public async Task<GenericResponse> DeleteShareHolderAsync(DeleteShareholderRequest deleteShareholderRequest)
+        {
+            var jsonRequest = Util.JsonOperation.SerializeRequest(deleteShareholderRequest);
+            var jsonResponse = await _deleteShareholder.RequestAsync(jsonRequest);
             return JsonConvert.DeserializeObject<GenericResponse>(jsonResponse);
         }
 
@@ -152,6 +225,18 @@ namespace Adyen.Service
         }
 
         /// <summary>
+        /// Post /getAccountHolder API call
+        /// </summary>
+        /// <param name="getAccountHolderRequest"></param>
+        /// <returns>GetAccountHolderResponse</returns>
+        public async Task<GetAccountHolderResponse> GetAccountHolderAsync(GetAccountHolderRequest getAccountHolderRequest)
+        {
+            var jsonRequest = Util.JsonOperation.SerializeRequest(getAccountHolderRequest);
+            var jsonResponse = await _getAccountHolder.RequestAsync(jsonRequest);
+            return JsonConvert.DeserializeObject<GetAccountHolderResponse>(jsonResponse);
+        }
+
+        /// <summary>
         /// Post /getUploadedDocuments API call
         /// </summary>
         /// <param name="getUploadedDocumentsRequest"></param>
@@ -160,6 +245,18 @@ namespace Adyen.Service
         {
             var jsonRequest = Util.JsonOperation.SerializeRequest(getUploadedDocumentsRequest);
             var jsonResponse = _getUploadedDocuments.Request(jsonRequest);
+            return JsonConvert.DeserializeObject<GetUploadedDocumentsResponse>(jsonResponse);
+        }
+
+        /// <summary>
+        /// Post /getUploadedDocuments API call
+        /// </summary>
+        /// <param name="getUploadedDocumentsRequest"></param>
+        /// <returns>GetUploadedDocumentsResponse</returns>
+        public async Task<GetUploadedDocumentsResponse> GetUploadedDocumentsAsync(GetUploadedDocumentsRequest getUploadedDocumentsRequest)
+        {
+            var jsonRequest = Util.JsonOperation.SerializeRequest(getUploadedDocumentsRequest);
+            var jsonResponse = await _getUploadedDocuments.RequestAsync(jsonRequest);
             return JsonConvert.DeserializeObject<GetUploadedDocumentsResponse>(jsonResponse);
         }
 
@@ -176,6 +273,18 @@ namespace Adyen.Service
         }
 
         /// <summary>
+        /// Post /suspendAccountHolder API call
+        /// </summary>
+        /// <param name="suspendAccountHolderRequest"></param>
+        /// <returns>SuspendAccountHolderResponse</returns>
+        public async Task<SuspendAccountHolderResponse> SuspendAccountHolderAsync(SuspendAccountHolderRequest suspendAccountHolderRequest)
+        {
+            var jsonRequest = Util.JsonOperation.SerializeRequest(suspendAccountHolderRequest);
+            var jsonResponse = await _suspendAccountHolder.RequestAsync(jsonRequest);
+            return JsonConvert.DeserializeObject<SuspendAccountHolderResponse>(jsonResponse);
+        }
+
+        /// <summary>
         /// Post /unSuspendAccountHolder API call
         /// </summary>
         /// <param name="unSuspendAccountHolderRequest"></param>
@@ -184,6 +293,18 @@ namespace Adyen.Service
         {
             var jsonRequest = Util.JsonOperation.SerializeRequest(unSuspendAccountHolderRequest);
             var jsonResponse = _unSuspendAccountHolder.Request(jsonRequest);
+            return JsonConvert.DeserializeObject<UnSuspendAccountHolderResponse>(jsonResponse);
+        }
+
+        /// <summary>
+        /// Post /unSuspendAccountHolder API call
+        /// </summary>
+        /// <param name="unSuspendAccountHolderRequest"></param>
+        /// <returns>UnSuspendAccountHolderResponse</returns>
+        public async Task<UnSuspendAccountHolderResponse> UnSuspendAccountHolderAsync(UnSuspendAccountHolderRequest unSuspendAccountHolderRequest)
+        {
+            var jsonRequest = Util.JsonOperation.SerializeRequest(unSuspendAccountHolderRequest);
+            var jsonResponse = await _unSuspendAccountHolder.RequestAsync(jsonRequest);
             return JsonConvert.DeserializeObject<UnSuspendAccountHolderResponse>(jsonResponse);
         }
 
@@ -200,6 +321,18 @@ namespace Adyen.Service
         }
 
         /// <summary>
+        /// Post /updateAccount API call
+        /// </summary>
+        /// <param name="updateAccountRequest"></param>
+        /// <returns>UpdateAccountResponse</returns>
+        public async Task<UpdateAccountResponse> UpdateAccountAsync(UpdateAccountRequest updateAccountRequest)
+        {
+            var jsonRequest = Util.JsonOperation.SerializeRequest(updateAccountRequest);
+            var jsonResponse = await _updateAccount.RequestAsync(jsonRequest);
+            return JsonConvert.DeserializeObject<UpdateAccountResponse>(jsonResponse);
+        }
+
+        /// <summary>
         /// Post /updateAccountHolder API call
         /// </summary>
         /// <param name="updateAccountHolderRequest"></param>
@@ -208,6 +341,18 @@ namespace Adyen.Service
         {
             var jsonRequest = Util.JsonOperation.SerializeRequest(updateAccountHolderRequest);
             var jsonResponse = _updateAccountHolder.Request(jsonRequest);
+            return JsonConvert.DeserializeObject<UpdateAccountHolderResponse>(jsonResponse);
+        }
+
+        /// <summary>
+        /// Post /updateAccountHolder API call
+        /// </summary>
+        /// <param name="updateAccountHolderRequest"></param>
+        /// <returns>UpdateAccountHolderResponse</returns>
+        public async Task<UpdateAccountHolderResponse> UpdateAccountHolderAsync(UpdateAccountHolderRequest updateAccountHolderRequest)
+        {
+            var jsonRequest = Util.JsonOperation.SerializeRequest(updateAccountHolderRequest);
+            var jsonResponse = await _updateAccountHolder.RequestAsync(jsonRequest);
             return JsonConvert.DeserializeObject<UpdateAccountHolderResponse>(jsonResponse);
         }
 
@@ -224,6 +369,18 @@ namespace Adyen.Service
         }
 
         /// <summary>
+        /// Post /updateAccountHolderState API call
+        /// </summary>
+        /// <param name="updateAccountHolderStateRequest"></param>
+        /// <returns>GetAccountHolderStatusResponse</returns>
+        public async Task<GetAccountHolderStatusResponse> UpdateAccountHolderStateAsync(UpdateAccountHolderStateRequest updateAccountHolderStateRequest)
+        {
+            var jsonRequest = Util.JsonOperation.SerializeRequest(updateAccountHolderStateRequest);
+            var jsonResponse = await _updateAccountHolderState.RequestAsync(jsonRequest);
+            return JsonConvert.DeserializeObject<GetAccountHolderStatusResponse>(jsonResponse);
+        }
+
+        /// <summary>
         /// Post /uploadDocument API call
         /// </summary>
         /// <param name="uploadDocumentRequest"></param>
@@ -232,6 +389,18 @@ namespace Adyen.Service
         {
             var jsonRequest = Util.JsonOperation.SerializeRequest(uploadDocumentRequest);
             var jsonResponse = _uploadDocument.Request(jsonRequest);
+            return JsonConvert.DeserializeObject<UploadDocumentResponse>(jsonResponse);
+        }
+
+        /// <summary>
+        /// Post /uploadDocument API call
+        /// </summary>
+        /// <param name="uploadDocumentRequest"></param>
+        /// <returns> UploadDocumentResponse </returns>
+        public async Task<UploadDocumentResponse> UploadDocumentAsync(UploadDocumentRequest uploadDocumentRequest)
+        {
+            var jsonRequest = Util.JsonOperation.SerializeRequest(uploadDocumentRequest);
+            var jsonResponse = await _uploadDocument.RequestAsync(jsonRequest);
             return JsonConvert.DeserializeObject<UploadDocumentResponse>(jsonResponse);
         }
 
@@ -248,6 +417,18 @@ namespace Adyen.Service
         }
 
         /// <summary>
+        /// Post /checkAccountholder API call
+        /// </summary>
+        /// <param name="performVerificationRequest"></param>
+        /// <returns>GenericResponse</returns>
+        public async Task<GenericResponse> CheckAccountholderAsync(PerformVerificationRequest performVerificationRequest)
+        {
+            var jsonRequest = Util.JsonOperation.SerializeRequest(performVerificationRequest);
+            var jsonResponse = await _checkAccountHolder.RequestAsync(jsonRequest);
+            return JsonConvert.DeserializeObject<GenericResponse>(jsonResponse);
+        }
+
+        /// <summary>
         /// Post /deletePayoutMethods API call
         /// </summary>
         /// <param name="deletePayoutMethodRequest"></param>
@@ -256,6 +437,18 @@ namespace Adyen.Service
         {
             var jsonRequest = Util.JsonOperation.SerializeRequest(deletePayoutMethodRequest);
             var jsonResponse = _deletePayoutMethods.Request(jsonRequest);
+            return JsonConvert.DeserializeObject<GenericResponse>(jsonResponse);
+        }
+ 
+    /// <summary>
+        /// Post /deletePayoutMethods API call
+        /// </summary>
+        /// <param name="deletePayoutMethodRequest"></param>
+        /// <returns>GenericResponse</returns>
+        public async Task<GenericResponse> DeletePayoutMethodsAsync(DeletePayoutMethodRequest deletePayoutMethodRequest)
+        {
+            var jsonRequest = Util.JsonOperation.SerializeRequest(deletePayoutMethodRequest);
+            var jsonResponse = await _deletePayoutMethods.RequestAsync(jsonRequest);
             return JsonConvert.DeserializeObject<GenericResponse>(jsonResponse);
         }
     }


### PR DESCRIPTION
**Description**
Add Async support for the Account Service, this was done by adding an Async version of each method and calling:
```csharp
Adyen.Service.Resource.RequestAsync(string json)
```
This should hopefully fix issue #387 

**Tested scenarios**
Unit tests were added to `MarketpayAccountTest` for each Async method that was added.
All tests pass
