### PR TITLE
Cleanup Result Code enum class

### DIFF
--- a/Adyen/Model/Checkout/PaymentDetailsResponse.cs
+++ b/Adyen/Model/Checkout/PaymentDetailsResponse.cs
@@ -1,6 +1,6 @@
 ﻿#region Licence
 
-// 
+//
 //                        ######
 //                        ######
 //  ############    ####( ######  #####. ######  ############   ############
@@ -13,9 +13,9 @@
 //                                       ######
 //                                #############
 //                                ############
-// 
+//
 //  Adyen Dotnet API Library
-// 
+//
 //  Copyright (c) 2021 Adyen B.V.
 //  This file is open source and available under the MIT license.
 //  See the LICENSE file for more info.
@@ -104,14 +104,14 @@ namespace Adyen.Model.Checkout
             [EnumMember(Value = "Refused")]
             Refused = 11,
             /// <summary>
+            /// Enum Refused for value: AuthenticationNotRequired
+            /// </summary>
+            [EnumMember(Value = "AuthenticationNotRequired")] AuthenticationNotRequired = 12,
+            /// <summary>
             /// Enum Success for value: Success
             /// </summary>
             [EnumMember(Value = "Success")]
-            Success = 12,
-            /// <summary>
-            /// Enum Refused for value: AuthenticationNotRequired
-            /// </summary>
-            [EnumMember(Value = "AuthenticationNotRequired")] AuthenticationNotRequired = 13
+            Success = 13
         }
         /// <summary>
         /// The result of the payment. For more information, see [Result codes](https://docs.adyen.com/online-payments/payment-result-codes).  Possible values:  * **AuthenticationFinished** – The payment has been successfully authenticated with 3D Secure 2. Returned for 3D Secure 2 authentication-only transactions. * **AuthenticationNotRequired** – The transaction does not require 3D Secure authentication. Returned for [standalone authentication-only integrations](https://docs.adyen.com/online-payments/3d-secure/other-3ds-flows/authentication-only). * **Authorised** – The payment was successfully authorised. This state serves as an indicator to proceed with the delivery of goods and services. This is a final state. * **Cancelled** – Indicates the payment has been cancelled (either by the shopper or the merchant) before processing was completed. This is a final state. * **ChallengeShopper** – The issuer requires further shopper interaction before the payment can be authenticated. Returned for 3D Secure 2 transactions. * **Error** – There was an error when the payment was being processed. The reason is given in the &#x60;refusalReason&#x60; field. This is a final state. * **IdentifyShopper** – The issuer requires the shopper&#x27;s device fingerprint before the payment can be authenticated. Returned for 3D Secure 2 transactions. * **Pending** – Indicates that it is not possible to obtain the final status of the payment. This can happen if the systems providing final status information for the payment are unavailable, or if the shopper needs to take further action to complete the payment. * **PresentToShopper** – Indicates that the response contains additional information that you need to present to a shopper, so that they can use it to complete a payment. * **Received** – Indicates the payment has successfully been received by Adyen, and will be processed. This is the initial state for all payments. * **RedirectShopper** – Indicates the shopper should be redirected to an external web page or app to complete the authorisation. * **Refused** – Indicates the payment was refused. The reason is given in the &#x60;refusalReason&#x60; field. This is a final state.
@@ -308,7 +308,7 @@ namespace Adyen.Model.Checkout
                     this.FraudResult == input.FraudResult ||
                     (this.FraudResult != null &&
                     this.FraudResult.Equals(input.FraudResult))
-                ) &&                
+                ) &&
                 (
                     this.MerchantReference == input.MerchantReference ||
                     (this.MerchantReference != null &&


### PR DESCRIPTION
**Description**
Make the PaymentDetailsResponse result code enum class the same as PaymentResponse enum class on request of #560.

**Tested scenarios**

**Fixed issue**:  #560 
