### PR TITLE
Add missing fields to IPaymentResponseAction

### DIFF
--- a/Adyen/Model/Checkout/Action/IPaymentResponseAction.cs
+++ b/Adyen/Model/Checkout/Action/IPaymentResponseAction.cs
@@ -27,7 +27,16 @@ namespace Adyen.Model.Checkout.Action
 {
     public interface IPaymentResponseAction
     {
+        [JsonProperty(PropertyName = "paymentMethodType")]
+        string PaymentMethodType { get; set; }
+
+        [JsonProperty(PropertyName = "url")]
+        string Url { get; set; }
+
         [JsonProperty(PropertyName = "type")]
         string Type { get; set; }
+
+        [JsonProperty(PropertyName = "method")]
+        string Method { get; set; }
     }
 }


### PR DESCRIPTION
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Add fields in IPaymentResponseAction for:
- paymentMethodType
- url
- method

These should be included in the response when creating a [Trustly payout](https://docs.adyen.com/payment-methods/trustly/payouts#page-introduction). In step 1, a post request is sent to /payments and the response should include the form url in  IPaymentResponseAction. 

**Tested scenarios**
<!-- Description of tested scenarios -->

**Fixed issue**:  <!-- #-prefixed issue number -->
 #612