### PR TITLE
Filter the marketpayaccounttest in the workflow

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
         dotnet build /p:TargetFrameworks=netcoreapp2.0
         dotnet test Adyen.Test/Adyen.Test.csproj
-        dotnet test Adyen.IntegrationTest/Adyen.IntegrationTest.csproj
+        dotnet test Adyen.IntegrationTest/Adyen.IntegrationTest.csproj --filter FullyQualifiedName!=Adyen.IntegrationTest/MarketPayAccountTest.cs
       env:
         INTEGRATION_MERCHANT_ACCOUNT: ${{ secrets.INTEGRATION_MERCHANT_ACCOUNT }}
         INTEGRATION_X_API_KEY: ${{ secrets.INTEGRATION_X_API_KEY }}


### PR DESCRIPTION
**Description**
I filtered the marketpayaccounttest.cs from the dotnet test workflow so that the automated unit and integration tests will actually run. @AlexandrosMor this is what we discussed right?