### PR TITLE
Adding support to update pay by link

### DIFF
--- a/Adyen.IntegrationTest/CheckoutTest.cs
+++ b/Adyen.IntegrationTest/CheckoutTest.cs
@@ -4,6 +4,7 @@ using Adyen.Model.Checkout.Action;
 using Adyen.Service;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using Adyen.Constants;
 
 namespace Adyen.IntegrationTest
 {
@@ -129,6 +130,31 @@ namespace Adyen.IntegrationTest
             Assert.IsNotNull(createPaymentLinkResponse.Amount);
             Assert.IsNotNull(createPaymentLinkResponse.Reference);
             Assert.IsNotNull(createPaymentLinkResponse.ExpiresAt);
+        }
+
+        [TestMethod]
+        public void PaymentLinkUpdateSuccessTest()
+        {
+            var amount = new Amount("EUR", 1000);
+            var address = new Address(country: "NL", city: "Amsterdam", houseNumberOrName: "11", postalCode: "1234AB",
+                street: "ams");
+            var createPaymentLinkRequest = new CreatePaymentLinkRequest(amount: amount,
+                merchantAccount: ClientConstants.MerchantAccount, reference: "Reference")
+            {
+                CountryCode = "NL",
+                ShopperReference = "Unique_shopper_reference",
+                ShopperEmail = "test@shopperEmail.com",
+                BillingAddress = address,
+                DeliveryAddress = address,
+                ExpiresAt = DateTime.Now.AddHours(4).ToString("yyyy-MM-ddTHH:mm:ss")
+            };
+            var createPaymentLinkResponse = _checkout.PaymentLinks(createPaymentLinkRequest);
+            var linkId = createPaymentLinkResponse.Id;
+            Assert.IsNotNull(linkId);
+
+            var updatePaymentLinkRequest = new UpdatePaymentLinkRequest(UpdatePaymentLinkRequest.StatusEnum.Expired);
+            var updatePaymentLinkResponse = _checkout.PaymentLinkUpdate(linkId, updatePaymentLinkRequest);
+            Assert.AreEqual(updatePaymentLinkRequest.Status, UpdatePaymentLinkRequest.StatusEnum.Expired);
         }
 
         /// <summary>

--- a/Adyen.Test/CheckoutTest.cs
+++ b/Adyen.Test/CheckoutTest.cs
@@ -547,6 +547,18 @@ namespace Adyen.Test
             Assert.IsNotNull(paymentLinksResponse.Amount);
         }
 
+        [TestMethod]
+        public void PaymentLinkUpdateSuccess()
+        {
+            var client = CreateMockTestClientApiKeyBasedRequest("Mocks/checkout/payment-link-update-success.json");
+            var checkout = new Checkout(client);
+            var updatePaymentLinkRequest =
+                new UpdatePaymentLinkRequest(status: UpdatePaymentLinkRequest.StatusEnum.Expired);
+            var updatePaymentLinkResponse = checkout.PaymentLinkUpdate(linkId: "LinkId", updatePaymentLinkRequest);
+            Assert.AreEqual(updatePaymentLinkResponse.Status, PaymentLinkResponse.StatusEnum.Expired);
+            Assert.AreEqual(updatePaymentLinkResponse.ExpiresAt, "2022-07-29T17:10:05Z");
+        }
+
         /// <summary>
         /// Test success flow for creation of a payment link with recurring payment
         /// POST /paymentLinks

--- a/Adyen.Test/Mocks/checkout/payment-link-update-success.json
+++ b/Adyen.Test/Mocks/checkout/payment-link-update-success.json
@@ -1,0 +1,11 @@
+{
+	"amount": {
+		"currency": "EUR",
+		"value": 4200
+	},
+	"countryCode": "NL",
+	"expiresAt": "2022-07-29T17:10:05Z",
+	"merchantAccount": "YOUR_MERCHANT_ACCOUNT",
+	"reference": "YOUR_ORDER_NUMBER",
+	"status": "expired"
+}

--- a/Adyen/HttpClient/HttpURLConnectionClient.cs
+++ b/Adyen/HttpClient/HttpURLConnectionClient.cs
@@ -171,7 +171,14 @@ namespace Adyen.HttpClient
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
             //Add default headers
             var httpWebRequest = (HttpWebRequest)WebRequest.Create(endpoint);
-            httpWebRequest.Method = "POST";
+            if (!string.IsNullOrEmpty(requestOptions?.HttpVerb))
+            {
+                httpWebRequest.Method = requestOptions.HttpVerb;
+            }
+            else
+            {
+                httpWebRequest.Method = "POST";
+            }
             httpWebRequest.ContentType = "application/json";
             httpWebRequest.Headers.Add("Accept-Charset", "UTF-8");
             httpWebRequest.Headers.Add("Cache-Control", "no-cache");

--- a/Adyen/HttpClient/HttpURLConnectionClient.cs
+++ b/Adyen/HttpClient/HttpURLConnectionClient.cs
@@ -25,6 +25,7 @@ using Adyen.Constants;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Security;
 using System.Text;
@@ -50,12 +51,19 @@ namespace Adyen.HttpClient
             {
                 httpWebRequest.Timeout = config.HttpRequestTimeout;
             }
-            using (var streamWriter = new StreamWriter(httpWebRequest.GetRequestStream()))
+
+            string[] httpVerbsWithPayload = new[] { "POST", "PUT", "PATCH" };
+            if (string.IsNullOrEmpty(requestOptions?.HttpVerb) ||
+                httpVerbsWithPayload.Contains(requestOptions.HttpVerb))
             {
-                streamWriter.Write(json);
-                streamWriter.Flush();
-                streamWriter.Close();
+                using (var streamWriter = new StreamWriter(httpWebRequest.GetRequestStream()))
+                {
+                    streamWriter.Write(json);
+                    streamWriter.Flush();
+                    streamWriter.Close();
+                }
             }
+
             try
             {
                 using (var response = (HttpWebResponse) httpWebRequest.GetResponse())

--- a/Adyen/Model/RequestOptions.cs
+++ b/Adyen/Model/RequestOptions.cs
@@ -26,5 +26,6 @@ namespace Adyen.Model
     public class RequestOptions
     {
         public string IdempotencyKey { get; set; }
+        public string HttpVerb { get; set; }
     }
 }

--- a/Adyen/Service/Checkout.cs
+++ b/Adyen/Service/Checkout.cs
@@ -196,6 +196,24 @@ namespace Adyen.Service
         }
 
         /// <summary>
+        /// PATCH /paymentLinks/{linkId} API call
+        /// </summary>
+        /// <param name="linkId"></param>
+        /// <param name="updatePaymentLinkRequest"></param>
+        /// <returns>PaymentLinkResponse</returns>
+        public PaymentLinkResponse PaymentLinkUpdate(string linkId, UpdatePaymentLinkRequest updatePaymentLinkRequest)
+        {
+            var paymentLinkUpdates = new PaymentLinkUpdates(this, linkId);
+            var jsonRequest = Util.JsonOperation.SerializeRequest(updatePaymentLinkRequest);
+            var requestOptions = new RequestOptions
+            {
+                HttpVerb = "PATCH"
+            };
+            var jsonResponse = paymentLinkUpdates.Request(jsonRequest, requestOptions);
+            return JsonConvert.DeserializeObject<PaymentLinkResponse>(jsonResponse);
+        }
+
+        /// <summary>
         /// POST /paymentsLinks API call async
         /// </summary>
         /// <param name="createPaymentLinkRequest"></param>

--- a/Adyen/Service/Checkout.cs
+++ b/Adyen/Service/Checkout.cs
@@ -214,6 +214,22 @@ namespace Adyen.Service
         }
 
         /// <summary>
+        /// GET /paymentLinks/{linkId} API call
+        /// </summary>
+        /// <param name="linkId"></param>
+        /// <returns>PaymentLinkResponse</returns>
+        public PaymentLinkResponse PaymentLinkStatus(string linkId)
+        {
+            var paymentLinkUpdates = new PaymentLinkUpdates(this, linkId);
+            var requestOptions = new RequestOptions
+            {
+                HttpVerb = "GET"
+            };
+            var jsonResponse = paymentLinkUpdates.Request(null, requestOptions);
+            return JsonConvert.DeserializeObject<PaymentLinkResponse>(jsonResponse);
+        }
+
+        /// <summary>
         /// POST /paymentsLinks API call async
         /// </summary>
         /// <param name="createPaymentLinkRequest"></param>
@@ -230,7 +246,7 @@ namespace Adyen.Service
         /// </summary>
         /// <param name="linkId"></param>
         /// <param name="updatePaymentLinkRequest"></param>
-        /// <returns></returns>
+        /// <returns>PaymentLinkResponse</returns>
         public async Task<PaymentLinkResponse> PaymentLinkUpdateAsync(string linkId,
             UpdatePaymentLinkRequest updatePaymentLinkRequest)
         {
@@ -241,6 +257,22 @@ namespace Adyen.Service
                 HttpVerb = "PATCH"
             };
             var jsonResponse = await paymentLinkUpdates.RequestAsync(jsonRequest, requestOptions);
+            return JsonConvert.DeserializeObject<PaymentLinkResponse>(jsonResponse);
+        }
+
+        /// <summary>
+        /// GET /paymentLinks/{linkId} API call async
+        /// </summary>
+        /// <param name="linkId"></param>
+        /// <returns>PaymentLinkResponse</returns>
+        public async Task<PaymentLinkResponse> PaymentLinkStatusAsync(string linkId)
+        {
+            var paymentLinkUpdates = new PaymentLinkUpdates(this, linkId);
+            var requestOptions = new RequestOptions
+            {
+                HttpVerb = "GET"
+            };
+            var jsonResponse = await paymentLinkUpdates.RequestAsync(null, requestOptions);
             return JsonConvert.DeserializeObject<PaymentLinkResponse>(jsonResponse);
         }
 

--- a/Adyen/Service/Checkout.cs
+++ b/Adyen/Service/Checkout.cs
@@ -226,6 +226,25 @@ namespace Adyen.Service
         }
 
         /// <summary>
+        /// PATCH /paymentLinks/{linkId} API call async
+        /// </summary>
+        /// <param name="linkId"></param>
+        /// <param name="updatePaymentLinkRequest"></param>
+        /// <returns></returns>
+        public async Task<PaymentLinkResponse> PaymentLinkUpdateAsync(string linkId,
+            UpdatePaymentLinkRequest updatePaymentLinkRequest)
+        {
+            var paymentLinkUpdates = new PaymentLinkUpdates(this, linkId);
+            var jsonRequest = Util.JsonOperation.SerializeRequest(updatePaymentLinkRequest);
+            var requestOptions = new RequestOptions
+            {
+                HttpVerb = "PATCH"
+            };
+            var jsonResponse = await paymentLinkUpdates.RequestAsync(jsonRequest, requestOptions);
+            return JsonConvert.DeserializeObject<PaymentLinkResponse>(jsonResponse);
+        }
+
+        /// <summary>
         /// POST /sessions API call 
         /// </summary>
         /// <param name="createCheckoutSessionRequest"></param>

--- a/Adyen/Service/Resource/Checkout/PaymentLinkUpdates.cs
+++ b/Adyen/Service/Resource/Checkout/PaymentLinkUpdates.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using Adyen.Constants;
+
+namespace Adyen.Service.Resource.Checkout
+{
+    public class PaymentLinkUpdates : ServiceResource
+    {
+        public PaymentLinkUpdates(AbstractService abstractService, string linkId) :
+            base(abstractService,
+                abstractService.Client.Config.CheckoutEndpoint + "/" + ClientConfig.CheckoutApiVersion + $"/paymentLinks/{linkId}",
+                new List<string> {"linkId"})
+        {
+        }
+    }
+}


### PR DESCRIPTION
**Description**
Include support for the /paymentLinks/{linkId} API endpoint, required to expire generated Pay by Link requests.

To minimise changes to existing areas of code I am utilising the existing RequestOptions and adding in a HttpVerb property.  This can be set and checked in HttpURLConnectionClient.GetHttpWebRequest, and if present overrides the HTTP Verb, otherwise POST is used, which is the current existing behaviour.

**Tested scenarios**
Tests have been made in Adyen.IntegrationTest\CheckoutTest and Adyen.Test\CheckoutTest

**Fixed issue**:  PW-2742
