### PR TITLE
Moved paywithgoogle to legacy and added googlepay type

### DIFF
--- a/Adyen.Test/PaymentMethodDetailsTest.cs
+++ b/Adyen.Test/PaymentMethodDetailsTest.cs
@@ -103,6 +103,30 @@ namespace Adyen.Test
         }
 
         [TestMethod]
+        public void TestLegacyGooglePayPaymentMethod()
+        {
+            var paymentRequest = new PaymentRequest
+            {
+                MerchantAccount = "YOUR_MERCHANT_ACCOUNT",
+                Amount = new Amount("EUR", 1000),
+                Reference = "google pay test",
+                PaymentMethod = new GooglePayDetailsLegacy
+                {
+                    GooglePayToken = "==Payload as retrieved from Google Pay response==",
+                    FundingSource = GooglePayDetailsLegacy.FundingSourceEnum.Credit
+                },
+                ReturnUrl = "https://your-company.com/checkout?shopperOrder=12xy.."
+            };
+            var paymentMethodDetails = (GooglePayDetailsLegacy)paymentRequest.PaymentMethod;
+            Assert.AreEqual(paymentMethodDetails.Type, "paywithgoogle");
+            Assert.AreEqual(paymentMethodDetails.GooglePayToken, "==Payload as retrieved from Google Pay response==");
+            Assert.AreEqual(paymentMethodDetails.FundingSource, GooglePayDetailsLegacy.FundingSourceEnum.Credit);
+            Assert.AreEqual(paymentRequest.MerchantAccount, "YOUR_MERCHANT_ACCOUNT");
+            Assert.AreEqual(paymentRequest.Reference, "google pay test");
+            Assert.AreEqual(paymentRequest.ReturnUrl, "https://your-company.com/checkout?shopperOrder=12xy..");
+        }
+
+        [TestMethod]
         public void TestGooglePayPaymentMethod()
         {
             var paymentRequest = new PaymentRequest
@@ -118,7 +142,7 @@ namespace Adyen.Test
                 ReturnUrl = "https://your-company.com/checkout?shopperOrder=12xy.."
             };
             var paymentMethodDetails = (GooglePayDetails)paymentRequest.PaymentMethod;
-            Assert.AreEqual(paymentMethodDetails.Type, "paywithgoogle");
+            Assert.AreEqual(paymentMethodDetails.Type, "googlepay");
             Assert.AreEqual(paymentMethodDetails.GooglePayToken, "==Payload as retrieved from Google Pay response==");
             Assert.AreEqual(paymentMethodDetails.FundingSource, GooglePayDetails.FundingSourceEnum.Credit);
             Assert.AreEqual(paymentRequest.MerchantAccount, "YOUR_MERCHANT_ACCOUNT");

--- a/Adyen/Model/Checkout/Details/GooglePayDetailsLegacy.cs
+++ b/Adyen/Model/Checkout/Details/GooglePayDetailsLegacy.cs
@@ -34,7 +34,7 @@ namespace Adyen.Model.Checkout.Details
     public class GooglePayDetails : IPaymentMethodDetails
     {
         //Possible types
-        public const string GooglePay = "googlepay";
+        public const string GooglePay = "paywithgoogle";
 
         /// <summary>
         /// Defines FundingSource
@@ -75,9 +75,9 @@ namespace Adyen.Model.Checkout.Details
         public string GooglePayToken { get; set; }
 
         /// <summary>
-        /// **googlepay**
+        /// **paywithgoogle**
         /// </summary>
-        /// <value>**googlepay**</value>
+        /// <value>**paywithgoogle**</value>
         [DataMember(Name = "type", EmitDefaultValue = false)]
         [JsonProperty(PropertyName = "type")]
         public string Type { get; set; } = GooglePay; 

--- a/Adyen/Model/Checkout/Details/GooglePayDetailsLegacy.cs
+++ b/Adyen/Model/Checkout/Details/GooglePayDetailsLegacy.cs
@@ -31,7 +31,7 @@ namespace Adyen.Model.Checkout.Details
     /// 
     /// </summary>
     [DataContract]
-    public class GooglePayDetails : IPaymentMethodDetails
+    public class GooglePayDetailsLegacy : IPaymentMethodDetails
     {
         //Possible types
         public const string GooglePay = "paywithgoogle";
@@ -90,7 +90,7 @@ namespace Adyen.Model.Checkout.Details
         public override string ToString()
         {
             var sb = new StringBuilder();
-            sb.Append("class GooglePayDetails {\n");
+            sb.Append("class GooglePayDetailsLegacy {\n");
             sb.Append("  FundingSource: ").Append(FundingSource).Append("\n");
             sb.Append("  GooglePayCardNetwork: ").Append(GooglePayCardNetwork).Append("\n");
             sb.Append("  GooglePayToken: ").Append(GooglePayToken).Append("\n");

--- a/Adyen/Util/PaymentMethodDetailsConverter.cs
+++ b/Adyen/Util/PaymentMethodDetailsConverter.cs
@@ -125,6 +125,9 @@ namespace Adyen.Util
                 case GiropayDetails.Giropay:
                     paymentMethodDetails = new GiropayDetails();
                     break;
+                case GooglePayDetailsLegacy.GooglePay:
+                    paymentMethodDetails = new GooglePayDetailsLegacy();
+                    break;
                 case GooglePayDetails.GooglePay:
                     paymentMethodDetails = new GooglePayDetails();
                     break;


### PR DESCRIPTION
**Description**
Moved the "paywithgoogle" type to a legacy object and changed the original GooglePayDetails object to work with "googlepay" type

**Tested scenarios**
Not really tested, only added and ran the unit tests!

**Fixes #657**
