### PR TITLE
Update HttpURLConnectionClient.cs

### DIFF
--- a/Adyen/HttpClient/HttpURLConnectionClient.cs
+++ b/Adyen/HttpClient/HttpURLConnectionClient.cs
@@ -86,6 +86,10 @@ namespace Adyen.HttpClient
         {
             string responseText = null;
             var httpWebRequest = GetHttpWebRequest(endpoint, config, isApiKeyRequired, requestOptions);
+            if (config.HttpRequestTimeout > 0)
+            {
+                httpWebRequest.Timeout = config.HttpRequestTimeout;
+            }
             using (var streamWriter = new StreamWriter(httpWebRequest.GetRequestStream()))
             {
                 streamWriter.Write(json);


### PR DESCRIPTION
**Description**
Add ability to set timeout for RequestAsync, currently defaults to 100000ms. Which is less that Adyen guides suggest for Cloud integrations. 150sec (150000ms) min required.

