### PR TITLE
Delete dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: nuget
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "04:00"
-  open-pull-requests-limit: 10


### PR DESCRIPTION
**Description**
Remove Dependabot.yml in favor of Renovate.
This will stop duplicate PRs from being opened.

