### PR TITLE
Removed netstandard2.0 from Adyen.Test and Adyen.IntegrationTest

### DIFF
--- a/Adyen.IntegrationTest/Adyen.IntegrationTest.csproj
+++ b/Adyen.IntegrationTest/Adyen.IntegrationTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net6.0</TargetFrameworks>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/Adyen.Test/Adyen.Test.csproj
+++ b/Adyen.Test/Adyen.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 


### PR DESCRIPTION
**Description**
A .NET standard library cannot execute your test. You need a run-time e.g. the .NET Framework or .NET Core (examples: net6.0, net5.0, netcoreapp3.1, netcoreapp2.1, net framework 4.7.1).

I've removed these from `Adyen.Test` and `Adyen.IntegrationTest` respectively
