### PR TITLE
Fix Async Tests

### DIFF
--- a/Adyen.Test/CheckoutTest.cs
+++ b/Adyen.Test/CheckoutTest.cs
@@ -23,19 +23,19 @@
 
 #endregion
 
+using Adyen.Model;
 using Adyen.Model.ApplicationInformation;
 using Adyen.Model.Checkout;
-using Adyen.Model.Checkout.Details;
 using Adyen.Model.Checkout.Action;
+using Adyen.Model.Checkout.Details;
 using Adyen.Service;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using static Adyen.Model.Checkout.PaymentResponse;
-using Newtonsoft.Json.Linq;
-using Newtonsoft.Json;
-using System.Collections.Generic;
-using Adyen.Model;
 using Amount = Adyen.Model.Checkout.Amount;
 using Environment = Adyen.Model.Enum.Environment;
 using PaymentRequest = Adyen.Model.Checkout.PaymentRequest;
@@ -55,7 +55,7 @@ namespace Adyen.Test
         {
             var config = new Config();
             var client = new Client(config);
-            client.SetEnvironment(Model.Enum.Environment.Test, "companyUrl");
+            client.SetEnvironment(Environment.Test, "companyUrl");
             Assert.AreEqual(config.CheckoutEndpoint, @"https://checkout-test.adyen.com");
             Assert.AreEqual(config.Endpoint, @"https://pal-test.adyen.com");
         }
@@ -68,7 +68,7 @@ namespace Adyen.Test
         {
             var config = new Config();
             var client = new Client(config);
-            client.SetEnvironment(Model.Enum.Environment.Live, "companyUrl");
+            client.SetEnvironment(Environment.Live, "companyUrl");
             Assert.AreEqual(config.CheckoutEndpoint, @"https://companyUrl-checkout-live.adyenpayments.com/checkout");
             Assert.AreEqual(config.Endpoint, @"https://companyUrl-pal-live.adyenpayments.com");
         }
@@ -77,22 +77,20 @@ namespace Adyen.Test
         /// Tests unsuccessful checkout client Live URL generation.
         /// </summary>
         [TestMethod]
-        [ExpectedException(typeof(InvalidOperationException), "Missing liveEndpointUrlPrefix for endpoint generation")]
         public void CheckoutEndpointLiveErrorTest()
         {
             var config = new Config();
             var client = new Client(config);
-            client.SetEnvironment(Model.Enum.Environment.Live,null);
+            Assert.ThrowsException<InvalidOperationException>(() => client.SetEnvironment(Environment.Live, null));
         }
         
         /// <summary>
         /// Tests unsuccessful checkout client Live URL generation.
         /// </summary>
         [TestMethod]
-        [ExpectedException(typeof(InvalidOperationException), "Missing liveEndpointUrlPrefix for endpoint generation")]
         public void CheckoutEndpointLiveWithBasicAuthErrorTest()
         {
-            var client = new Client("ws_*******", "******", Adyen.Model.Enum.Environment.Live);
+            Assert.ThrowsException<InvalidOperationException>(() => new Client("ws_*******", "******", Environment.Live));
         }
         
         /// <summary>

--- a/Adyen.Test/MarketPayTests/MarketpayAccountTest.cs
+++ b/Adyen.Test/MarketPayTests/MarketpayAccountTest.cs
@@ -20,10 +20,10 @@
 //  * See the LICENSE file for more info.
 //  */
 #endregion
-using System.Threading.Tasks;
 using Adyen.Model.MarketPay;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Account = Adyen.Service.Account;
 
 namespace Adyen.Test.MarketPayTest
@@ -381,7 +381,7 @@ namespace Adyen.Test.MarketPayTest
             var client = CreateMockTestClientNullRequiredFieldsRequest("Mocks/marketpay/account/get-uploaded-documents-success.json");
             var account = new Account(client);
             var getUploadedDocumentsRequest = new GetUploadedDocumentsRequest(accountHolderCode: "123456");
-            var getUploadedDocumentsResponse = account.GetUploadedDocuments(getUploadedDocumentsRequest);
+            var getUploadedDocumentsResponse = await account.GetUploadedDocumentsAsync(getUploadedDocumentsRequest);
             Assert.AreEqual(getUploadedDocumentsResponse.PspReference, "9914694369860322");
             Assert.AreEqual(getUploadedDocumentsResponse.DocumentDetails[0].AccountHolderCode, "TestAccountHolder8031");
             Assert.AreEqual(getUploadedDocumentsResponse.DocumentDetails[0].BankAccountUUID, "EXAMPLE_UUID");
@@ -448,7 +448,7 @@ namespace Adyen.Test.MarketPayTest
             var client = CreateMockTestClientNullRequiredFieldsRequest("Mocks/marketpay/account/un-suspend-account-holder-success.json");
             var account = new Account(client);
             var unSuspendAccountHolderRequest = new UnSuspendAccountHolderRequest(accountHolderCode: "123456");
-            var unSuspendAccountHolderResponse = account.UnSuspendAccountHolder(unSuspendAccountHolderRequest);
+            var unSuspendAccountHolderResponse = await account.UnSuspendAccountHolderAsync(unSuspendAccountHolderRequest);
             Assert.AreEqual(unSuspendAccountHolderResponse.PspReference, "8815813528286482");
             Assert.AreEqual(unSuspendAccountHolderResponse.AccountHolderStatus.Status, AccountHolderStatus.StatusEnum.Active);
             Assert.AreEqual(unSuspendAccountHolderResponse.AccountHolderStatus.PayoutState.AllowPayout, false);

--- a/Adyen.Test/MarketPayTests/MarketpayAccountTest.cs
+++ b/Adyen.Test/MarketPayTests/MarketpayAccountTest.cs
@@ -416,7 +416,7 @@ namespace Adyen.Test.MarketPayTest
             var client = CreateMockTestClientNullRequiredFieldsRequest("Mocks/marketpay/account/suspend-account-holder-success.json");
             var account = new Account(client);
             var suspendAccountHolderRequest = new SuspendAccountHolderRequest(accountHolderCode: "123456");
-            var suspendAccountHolderResponse = account.SuspendAccountHolder(suspendAccountHolderRequest);
+            var suspendAccountHolderResponse = await account.SuspendAccountHolderAsync(suspendAccountHolderRequest);
             Assert.AreEqual(suspendAccountHolderResponse.PspReference, "8515813523937793");
             Assert.AreEqual(suspendAccountHolderResponse.AccountHolderStatus.Status, AccountHolderStatus.StatusEnum.Suspended);
             Assert.AreEqual(suspendAccountHolderResponse.AccountHolderStatus.PayoutState.AllowPayout, false);

--- a/Adyen/Model/Checkout/CreateCheckoutSessionRequest.cs
+++ b/Adyen/Model/Checkout/CreateCheckoutSessionRequest.cs
@@ -23,17 +23,16 @@
 #endregion
 
 
-using System;
-using System.Linq;
-using System.Text;
-using System.Collections.Generic;
 using Adyen.Model.ApplicationInformation;
-using System.Runtime.Serialization;
+using Adyen.Util;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using Adyen.Service.Resource.Modification;
-using Adyen.Util;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
 
 namespace Adyen.Model.Checkout
 {
@@ -250,28 +249,12 @@ namespace Adyen.Model.Checkout
             this.ShopperReference = shopperReference;
             this.ShopperStatement = shopperStatement;
             this.SocialSecurityNumber = socialSecurityNumber;
-            // use default value if no "splitCardFundingSources" provided
-            if (splitCardFundingSources == null)
-            {
-                this.SplitCardFundingSources = false;
-            }
-            else
-            {
-                this.SplitCardFundingSources = splitCardFundingSources;
-            }
+            this.SplitCardFundingSources = splitCardFundingSources;
             this.Splits = splits;
             this.Store = store;
             this.StorePaymentMethod = storePaymentMethod;
             this.TelephoneNumber = telephoneNumber;
-            // use default value if no "threeDSAuthenticationOnly" provided
-            if (threeDsAuthenticationOnly == null)
-            {
-                this.ThreeDsAuthenticationOnly = false;
-            }
-            else
-            {
-                this.ThreeDsAuthenticationOnly = threeDsAuthenticationOnly;
-            }
+            this.ThreeDsAuthenticationOnly = threeDsAuthenticationOnly;
             this.TrustedShopper = trustedShopper;
         }
 

--- a/Adyen/Model/Checkout/GenericIssuerPaymentMethodDetails.cs
+++ b/Adyen/Model/Checkout/GenericIssuerPaymentMethodDetails.cs
@@ -84,7 +84,7 @@ namespace Adyen.Model.Checkout
                 this.Issuer = issuer;
             }
             // to ensure "type" is required (not null)
-            if (type == null)
+            if (type == default(TypeEnum))
             {
                 throw new InvalidDataException("type is a required property for GenericIssuerPaymentMethodDetails and cannot be null");
             }

--- a/Adyen/Model/Checkout/Mandate.cs
+++ b/Adyen/Model/Checkout/Mandate.cs
@@ -187,7 +187,7 @@ namespace Adyen.Model.Checkout
             }
 
             // to ensure "frequency" is required (not null)
-            if (frequency == null)
+            if (frequency == default(FrequencyEnum))
             {
                 throw new InvalidDataException("frequency is a required property for Mandate and cannot be null");
             }


### PR DESCRIPTION
**Description**

- CheckoutTest now throws and asserts the InvalidOperationException properly, instead of catching the exception using Attributes

- MarketPayAccountTest now calls the async method properly

- Assigning bool values in CreateCheckoutSessionRequest can never be null, just assign the variables directly

- InvalidDataException can now be thrown, by comparing it to the defaultEnum in GenericIssuerPaymentMethodDetails.cs instead of null

- FrequencyEnum can throw InvalidDataException by comparing it to the default(FrequencyEnum) as it could never be null in Mandate.cs

- TestSuspendAccountHolderSuccessAsync now calls its async request in MarketpayAccountTest.cs