### PR TITLE
Update schema and add System.Text.Json support for Notification Requests

### DIFF
--- a/Adyen.Test/NotificationTest.cs
+++ b/Adyen.Test/NotificationTest.cs
@@ -41,10 +41,10 @@ namespace Adyen.Test
             var jsonRequest = MockFileToString(mockPath);
             var notificationHandler = new NotificationHandler();
             var handleNotificationRequest = notificationHandler.HandleNotificationRequest(jsonRequest);
-            var notificationRequestItemContainer = handleNotificationRequest.NotificationItems.FirstOrDefault();
+            var notificationRequestItemContainer = handleNotificationRequest.NotificationItemContainers.FirstOrDefault();
             if (notificationRequestItemContainer == null)
                 Assert.Fail("NotificationRequestItemContainer is null");
-            var notificationItem = notificationRequestItemContainer.NotificationRequestItem;
+            var notificationItem = notificationRequestItemContainer.NotificationItem;
             Assert.AreEqual("AUTHORISATION", notificationItem.EventCode);
             Assert.AreEqual("1234", notificationItem.AdditionalData["authCode"]);
             Assert.AreEqual("123456789", notificationItem.PspReference);
@@ -57,10 +57,10 @@ namespace Adyen.Test
             var jsonRequest = MockFileToString(mockPath);
             var notificationHandler = new NotificationHandler();
             var handleNotificationRequest = notificationHandler.HandleNotificationRequest(jsonRequest);
-            var notificationRequestItemContainer = handleNotificationRequest.NotificationItems.FirstOrDefault();
+            var notificationRequestItemContainer = handleNotificationRequest.NotificationItemContainers.FirstOrDefault();
             if (notificationRequestItemContainer == null)
                 Assert.Fail("NotificationRequestItemContainer is null");
-            var notificationItem = notificationRequestItemContainer.NotificationRequestItem;
+            var notificationItem = notificationRequestItemContainer.NotificationItem;
             Assert.AreEqual("CAPTURE", notificationItem.EventCode);
             Assert.AreEqual("qvS6I3Gdi1jx+jSh7IopAgcHtMoxvXlNL7DYQ+j1hd0=", notificationItem.AdditionalData["hmacSignature"]);
             Assert.AreEqual("PSP_REFERENCE", notificationItem.PspReference);
@@ -75,10 +75,10 @@ namespace Adyen.Test
             var jsonRequest = MockFileToString(mockPath);
             var notificationHandler = new NotificationHandler();
             var handleNotificationRequest = notificationHandler.HandleNotificationRequest(jsonRequest);
-            var notificationRequestItemContainer = handleNotificationRequest.NotificationItems.FirstOrDefault();
+            var notificationRequestItemContainer = handleNotificationRequest.NotificationItemContainers.FirstOrDefault();
             if (notificationRequestItemContainer == null)
                 Assert.Fail("NotificationRequestItemContainer is null");
-            var notificationItem = notificationRequestItemContainer.NotificationRequestItem;
+            var notificationItem = notificationRequestItemContainer.NotificationItem;
             Assert.AreEqual("CAPTURE", notificationItem.EventCode);
             Assert.AreEqual("KujHNqpyCAMdGefj7lfQ8AeD0Jke9Zs2bVAqScQDWi4=", notificationItem.AdditionalData["hmacSignature"]);
             Assert.AreEqual("PSP_REFERENCE", notificationItem.PspReference);
@@ -94,10 +94,10 @@ namespace Adyen.Test
             var jsonRequest = MockFileToString(mockPath);
             var notificationHandler = new NotificationHandler();
             var handleNotificationRequest = notificationHandler.HandleNotificationRequest(jsonRequest);
-            var notificationRequestItemContainer = handleNotificationRequest.NotificationItems.FirstOrDefault();
+            var notificationRequestItemContainer = handleNotificationRequest.NotificationItemContainers.FirstOrDefault();
             if (notificationRequestItemContainer == null)
                 Assert.Fail("NotificationRequestItemContainer is null");
-            var notificationItem = notificationRequestItemContainer.NotificationRequestItem;
+            var notificationItem = notificationRequestItemContainer.NotificationItem;
             Assert.AreEqual("REFUND", notificationItem.EventCode);
             Assert.AreEqual("KJFhURWP8Pv9m8k+7NGHNJAupBj6X6J/VWAikFxeWhA=", notificationItem.AdditionalData["hmacSignature"]);
             Assert.AreEqual("PSP_REFERENCE", notificationItem.PspReference);
@@ -113,10 +113,10 @@ namespace Adyen.Test
             var jsonRequest = MockFileToString(mockPath);
             var notificationHandler = new NotificationHandler();
             var handleNotificationRequest = notificationHandler.HandleNotificationRequest(jsonRequest);
-            var notificationRequestItemContainer = handleNotificationRequest.NotificationItems.FirstOrDefault();
+            var notificationRequestItemContainer = handleNotificationRequest.NotificationItemContainers.FirstOrDefault();
             if (notificationRequestItemContainer == null)
                 Assert.Fail("NotificationRequestItemContainer is null");
-            var notificationItem = notificationRequestItemContainer.NotificationRequestItem;
+            var notificationItem = notificationRequestItemContainer.NotificationItem;
             Assert.AreEqual("REFUND", notificationItem.EventCode);
             Assert.AreEqual("HZXziBYopfDIzDhk49iC//yCfxmy/z0xWuvvTxFNUSA=", notificationItem.AdditionalData["hmacSignature"]);
             Assert.AreEqual("PSP_REFERENCE", notificationItem.PspReference);

--- a/Adyen.Test/NotificationTest.cs
+++ b/Adyen.Test/NotificationTest.cs
@@ -41,10 +41,10 @@ namespace Adyen.Test
             var jsonRequest = MockFileToString(mockPath);
             var notificationHandler = new NotificationHandler();
             var handleNotificationRequest = notificationHandler.HandleNotificationRequest(jsonRequest);
-            var notificationRequestItemContainer = handleNotificationRequest.NotificationItemContainers.FirstOrDefault();
+            var notificationRequestItemContainer = handleNotificationRequest.NotificationItems.FirstOrDefault();
             if (notificationRequestItemContainer == null)
                 Assert.Fail("NotificationRequestItemContainer is null");
-            var notificationItem = notificationRequestItemContainer.NotificationItem;
+            var notificationItem = notificationRequestItemContainer.NotificationRequestItem;
             Assert.AreEqual("AUTHORISATION", notificationItem.EventCode);
             Assert.AreEqual("1234", notificationItem.AdditionalData["authCode"]);
             Assert.AreEqual("123456789", notificationItem.PspReference);
@@ -57,15 +57,15 @@ namespace Adyen.Test
             var jsonRequest = MockFileToString(mockPath);
             var notificationHandler = new NotificationHandler();
             var handleNotificationRequest = notificationHandler.HandleNotificationRequest(jsonRequest);
-            var notificationRequestItemContainer = handleNotificationRequest.NotificationItemContainers.FirstOrDefault();
+            var notificationRequestItemContainer = handleNotificationRequest.NotificationItems.FirstOrDefault();
             if (notificationRequestItemContainer == null)
                 Assert.Fail("NotificationRequestItemContainer is null");
-            var notificationItem = notificationRequestItemContainer.NotificationItem;
+            var notificationItem = notificationRequestItemContainer.NotificationRequestItem;
             Assert.AreEqual("CAPTURE", notificationItem.EventCode);
             Assert.AreEqual("qvS6I3Gdi1jx+jSh7IopAgcHtMoxvXlNL7DYQ+j1hd0=", notificationItem.AdditionalData["hmacSignature"]);
             Assert.AreEqual("PSP_REFERENCE", notificationItem.PspReference);
             Assert.AreEqual(23623, notificationItem.Amount.Value);
-            Assert.IsTrue(notificationItem.Success);
+            Assert.IsTrue(bool.Parse(notificationItem.Success));
         }
 
         [TestMethod]
@@ -75,15 +75,15 @@ namespace Adyen.Test
             var jsonRequest = MockFileToString(mockPath);
             var notificationHandler = new NotificationHandler();
             var handleNotificationRequest = notificationHandler.HandleNotificationRequest(jsonRequest);
-            var notificationRequestItemContainer = handleNotificationRequest.NotificationItemContainers.FirstOrDefault();
+            var notificationRequestItemContainer = handleNotificationRequest.NotificationItems.FirstOrDefault();
             if (notificationRequestItemContainer == null)
                 Assert.Fail("NotificationRequestItemContainer is null");
-            var notificationItem = notificationRequestItemContainer.NotificationItem;
+            var notificationItem = notificationRequestItemContainer.NotificationRequestItem;
             Assert.AreEqual("CAPTURE", notificationItem.EventCode);
             Assert.AreEqual("KujHNqpyCAMdGefj7lfQ8AeD0Jke9Zs2bVAqScQDWi4=", notificationItem.AdditionalData["hmacSignature"]);
             Assert.AreEqual("PSP_REFERENCE", notificationItem.PspReference);
             Assert.AreEqual(23623, notificationItem.Amount.Value);
-            Assert.IsFalse(notificationItem.Success);
+            Assert.IsFalse(bool.Parse(notificationItem.Success));
             Assert.AreEqual("Insufficient balance on payment", notificationItem.Reason);
         }
 
@@ -94,16 +94,16 @@ namespace Adyen.Test
             var jsonRequest = MockFileToString(mockPath);
             var notificationHandler = new NotificationHandler();
             var handleNotificationRequest = notificationHandler.HandleNotificationRequest(jsonRequest);
-            var notificationRequestItemContainer = handleNotificationRequest.NotificationItemContainers.FirstOrDefault();
+            var notificationRequestItemContainer = handleNotificationRequest.NotificationItems.FirstOrDefault();
             if (notificationRequestItemContainer == null)
                 Assert.Fail("NotificationRequestItemContainer is null");
-            var notificationItem = notificationRequestItemContainer.NotificationItem;
+            var notificationItem = notificationRequestItemContainer.NotificationRequestItem;
             Assert.AreEqual("REFUND", notificationItem.EventCode);
             Assert.AreEqual("KJFhURWP8Pv9m8k+7NGHNJAupBj6X6J/VWAikFxeWhA=", notificationItem.AdditionalData["hmacSignature"]);
             Assert.AreEqual("PSP_REFERENCE", notificationItem.PspReference);
             Assert.AreEqual(1500, notificationItem.Amount.Value);
             Assert.AreEqual("MagentoMerchantTest2", notificationItem.MerchantAccountCode);
-            Assert.IsTrue(notificationItem.Success);
+            Assert.IsTrue(bool.Parse(notificationItem.Success));
         }
 
         [TestMethod]
@@ -113,15 +113,15 @@ namespace Adyen.Test
             var jsonRequest = MockFileToString(mockPath);
             var notificationHandler = new NotificationHandler();
             var handleNotificationRequest = notificationHandler.HandleNotificationRequest(jsonRequest);
-            var notificationRequestItemContainer = handleNotificationRequest.NotificationItemContainers.FirstOrDefault();
+            var notificationRequestItemContainer = handleNotificationRequest.NotificationItems.FirstOrDefault();
             if (notificationRequestItemContainer == null)
                 Assert.Fail("NotificationRequestItemContainer is null");
-            var notificationItem = notificationRequestItemContainer.NotificationItem;
+            var notificationItem = notificationRequestItemContainer.NotificationRequestItem;
             Assert.AreEqual("REFUND", notificationItem.EventCode);
             Assert.AreEqual("HZXziBYopfDIzDhk49iC//yCfxmy/z0xWuvvTxFNUSA=", notificationItem.AdditionalData["hmacSignature"]);
             Assert.AreEqual("PSP_REFERENCE", notificationItem.PspReference);
             Assert.AreEqual(1500, notificationItem.Amount.Value);
-            Assert.IsFalse(notificationItem.Success);
+            Assert.IsFalse(bool.Parse(notificationItem.Success));
             Assert.AreEqual("Insufficient balance on payment", notificationItem.Reason);
         }
 

--- a/Adyen.Test/UtilTest.cs
+++ b/Adyen.Test/UtilTest.cs
@@ -93,7 +93,7 @@ namespace Adyen.Test
             var response = MockFileToString(mockPath);
             var hmacValidator = new HmacValidator();
             var notificationRequest = JsonOperation.Deserialize<NotificationRequest>(response);
-            var notificationItem = notificationRequest.NotificationItems[0].NotificationRequestItem;
+            var notificationItem = notificationRequest.NotificationItemContainers[0].NotificationItem;
             var isValidHmac = hmacValidator.IsValidHmac(notificationItem, key);
             Assert.IsTrue(isValidHmac);
         }

--- a/Adyen.Test/UtilTest.cs
+++ b/Adyen.Test/UtilTest.cs
@@ -72,7 +72,7 @@ namespace Adyen.Test
                 MerchantReference = "reference",
                 Amount = new Model.Checkout.Amount("EUR", 1000),
                 EventCode = "EVENT",
-                Success = true,
+                Success = "true",
                 AdditionalData = additionalData
             };
             var hmacValidator = new HmacValidator();
@@ -93,7 +93,7 @@ namespace Adyen.Test
             var response = MockFileToString(mockPath);
             var hmacValidator = new HmacValidator();
             var notificationRequest = JsonOperation.Deserialize<NotificationRequest>(response);
-            var notificationItem = notificationRequest.NotificationItemContainers[0].NotificationItem;
+            var notificationItem = notificationRequest.NotificationItems[0].NotificationRequestItem;
             var isValidHmac = hmacValidator.IsValidHmac(notificationItem, key);
             Assert.IsTrue(isValidHmac);
         }
@@ -118,7 +118,7 @@ namespace Adyen.Test
                 MerchantReference = "reference",
                 Amount = new Model.Checkout.Amount("EUR", 1000),
                 EventCode = "EVENT",
-                Success = true,
+                Success = "true",
                 AdditionalData = null
             };
             var isValidHmacAdditionalDataNull = hmacValidator.IsValidHmac(notificationRequestItem, "key");

--- a/Adyen.WebApi/Controllers/AdyenController.cs
+++ b/Adyen.WebApi/Controllers/AdyenController.cs
@@ -1,0 +1,6 @@
+﻿namespace Adyen.WebApi.Controllers;
+
+public class AdyenController
+{
+    
+}

--- a/Adyen.WebApi/Controllers/AdyenController.cs
+++ b/Adyen.WebApi/Controllers/AdyenController.cs
@@ -1,6 +1,0 @@
-﻿namespace Adyen.WebApi.Controllers;
-
-public class AdyenController
-{
-    
-}

--- a/Adyen/Adyen.csproj
+++ b/Adyen/Adyen.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.Json" Version="7.0.2" />
   </ItemGroup>
   <!-- .NET 4.5 references, compilation flags and build options -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">

--- a/Adyen/Model/Notification/NotificationRequest.cs
+++ b/Adyen/Model/Notification/NotificationRequest.cs
@@ -32,7 +32,7 @@ namespace Adyen.Model.Notification
         public string Live { get; set; }
 
         [JsonProperty("NotificationItems")]
-        public List<NotificationRequestItemContainer> NotificationItemContainers { get; set; }
+        public List<NotificationRequestItemContainer> NotificationItems { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -43,7 +43,7 @@ namespace Adyen.Model.Notification
             var sb = new StringBuilder();
             sb.Append("class NotificationRequest {\n");
             sb.Append("  Live: ").Append(this.Live).Append("\n");
-            sb.Append("  NotificationItemContainers: ").Append(this.NotificationItemContainers).Append("\n");
+            sb.Append("  NotificationItemContainers: ").Append(this.NotificationItems).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }

--- a/Adyen/Model/Notification/NotificationRequest.cs
+++ b/Adyen/Model/Notification/NotificationRequest.cs
@@ -24,6 +24,7 @@
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Text;
+using System.Text.Json.Serialization;
 
 namespace Adyen.Model.Notification
 {
@@ -32,7 +33,8 @@ namespace Adyen.Model.Notification
         public string Live { get; set; }
 
         [JsonProperty("NotificationItems")]
-        public List<NotificationRequestItemContainer> NotificationItems { get; set; }
+        [JsonPropertyName("NotificationItems")]
+        public List<NotificationRequestItemContainer> NotificationItemContainers { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -43,7 +45,7 @@ namespace Adyen.Model.Notification
             var sb = new StringBuilder();
             sb.Append("class NotificationRequest {\n");
             sb.Append("  Live: ").Append(this.Live).Append("\n");
-            sb.Append("  NotificationItemContainers: ").Append(this.NotificationItems).Append("\n");
+            sb.Append("  NotificationItemContainers: ").Append(this.NotificationItemContainers).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }

--- a/Adyen/Model/Notification/NotificationRequestItem.cs
+++ b/Adyen/Model/Notification/NotificationRequestItem.cs
@@ -36,7 +36,7 @@ namespace Adyen.Model.Notification
         public string OriginalReference { get; set; }
         public string PspReference { get; set; }
         public string Reason { get; set; }
-        public bool Success { get; set; }
+        public string Success { get; set; }
         public string PaymentMethod { get; set; }
         public List<string> Operations { get; set; }
         public Dictionary<string, string> AdditionalData { get; set; }

--- a/Adyen/Model/Notification/NotificationRequestItemContainer.cs
+++ b/Adyen/Model/Notification/NotificationRequestItemContainer.cs
@@ -31,14 +31,14 @@ namespace Adyen.Model.Notification
     public class NotificationRequestItemContainer
     {
         [JsonProperty("NotificationRequestItem")]
-        public NotificationRequestItem NotificationItem { get; set; }
+        public NotificationRequestItem NotificationRequestItem { get; set; }
 
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
             sb.Append("class NotificationRequestItemContainer {\n");
 
-            sb.Append("  notificationItem: ").Append(NotificationItem.ToIndentedString()).Append("\n");
+            sb.Append("  notificationItem: ").Append(NotificationRequestItem.ToIndentedString()).Append("\n");
             sb.Append("}");
             return sb.ToString();
         }

--- a/Adyen/Model/Notification/NotificationRequestItemContainer.cs
+++ b/Adyen/Model/Notification/NotificationRequestItemContainer.cs
@@ -23,6 +23,7 @@
 
 using Adyen.Util;
 using System.Text;
+using System.Text.Json.Serialization;
 
 namespace Adyen.Model.Notification
 {
@@ -31,14 +32,15 @@ namespace Adyen.Model.Notification
     public class NotificationRequestItemContainer
     {
         [JsonProperty("NotificationRequestItem")]
-        public NotificationRequestItem NotificationRequestItem { get; set; }
+        [JsonPropertyName("NotificationRequestItem")]
+        public NotificationRequestItem NotificationItem { get; set; }
 
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
             sb.Append("class NotificationRequestItemContainer {\n");
 
-            sb.Append("  notificationItem: ").Append(NotificationRequestItem.ToIndentedString()).Append("\n");
+            sb.Append("  notificationItem: ").Append(NotificationItem.ToIndentedString()).Append("\n");
             sb.Append("}");
             return sb.ToString();
         }


### PR DESCRIPTION
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
The purpose of this PR is to make it accessible for ASP.NET WebAPI's using `System.Text.Json`.
After generating blank ASP.NET WebAPI with such a dummy Webhook Controller Action:

```csharp
[HttpPost]
public async Task<ActionResult> AdyenConfirmAsync([FromBody] NotificationRequest request)
{
    return Ok(request);
}
```

I noticed that most of the fields in payload are missing. Short session with debugger helped me investigate that there were the following issues:

1. `NotificationRequestItem.Success` field was of type boolean while the Adyen sends it as string.
2. `NotificationRequest.NotificationItemContainers` field was improperly mapped because in Json payload it's named as `notificationItems`.
3.  `NotificationRequestItemContainer.NotificationItem` field was improperly mapped because in Json payload it's named `NotificationRequestItem`.

To solve issue `1` I have changed the type to `string`.
I have added `System.Text.Json` and used it's attribute equivalent to `JsonProperty` of `Newtonsoft.Json` in order to fix last 2 isues.

My previous commit has more invasive solution for this problem by renaming fields, but I've decided that this will be better.


**Tested scenarios**
After making these changes my test WebAPI could get the payload and I could browse it in debugger. Unit tests were also updated and they are green, I was not able to run integration tests neither on my branch or on develop.

**Fixed issue**:  <!-- #-prefixed issue number -->
I did not find any related issue on this repository
