### PR TITLE
[ITT-506] Fix Local TAPI endpoint

### DIFF
--- a/Adyen.Test/BaseTest.cs
+++ b/Adyen.Test/BaseTest.cs
@@ -384,7 +384,11 @@ namespace Adyen.Test
         /// <returns>IClient implementation</returns>
         protected Client CreateMockTestClientPosLocalApiRequest(string fileName)
         {
-            var config = new Config { Endpoint = @"https://_terminal_:8443/nexo/" };
+            var config = new Config
+            {
+                Environment = Model.Environment.Live,
+                LocalTerminalApiEndpoint = @"https://_terminal_:8443/nexo/"
+            };
             var mockPath = GetMockFilePath(fileName);
             var response = MockFileToString(mockPath);
             //Create a mock interface

--- a/Adyen.Test/TerminalApiPosRequestTest.cs
+++ b/Adyen.Test/TerminalApiPosRequestTest.cs
@@ -52,7 +52,7 @@ namespace Adyen.Test
                 //create a mock client
                 var client = CreateMockTestClientPosLocalApiRequest("Mocks/terminalapi/pospayment-encrypted-success.json");
                 var posPaymentLocalApi = new PosPaymentLocalApi(client);
-                var configEndpoint = posPaymentLocalApi.Client.Config.Endpoint;
+                var configEndpoint = posPaymentLocalApi.Client.Config.LocalTerminalApiEndpoint;
                 var saleToPoiResponse = posPaymentLocalApi.TerminalApiLocalAsync(paymentRequest, _encryptionCredentialDetails);
                 Assert.AreEqual(configEndpoint, @"https://_terminal_:8443/nexo/");
                 Assert.IsNotNull(saleToPoiResponse);

--- a/Adyen.Test/TerminalApiPosRequestTest.cs
+++ b/Adyen.Test/TerminalApiPosRequestTest.cs
@@ -31,7 +31,7 @@ namespace Adyen.Test
                 //create a mock client
                 var client = CreateMockTestClientPosLocalApiRequest("Mocks/terminalapi/pospayment-encrypted-success.json");
                 var posPaymentLocalApi = new PosPaymentLocalApi(client);
-                var configEndpoint = posPaymentLocalApi.Client.Config.Endpoint;
+                var configEndpoint = posPaymentLocalApi.Client.Config.LocalTerminalApiEndpoint;
                 var saleToPoiResponse = posPaymentLocalApi.TerminalApiLocal(paymentRequest, _encryptionCredentialDetails);
                 Assert.AreEqual(configEndpoint, @"https://_terminal_:8443/nexo/");
                 Assert.IsNotNull(saleToPoiResponse);

--- a/Adyen/Config.cs
+++ b/Adyen/Config.cs
@@ -29,6 +29,8 @@ namespace Adyen
         public string CloudApiEndPoint { get; set; }
         //POS Terminal Management 
         public string PosTerminalManagementEndpoint { get; set; }
+        // Local TAPI endpoint
+        public string LocalTerminalApiEndpoint { get; set; }
         public bool HasPassword => !string.IsNullOrEmpty(Password);
         public bool HasApiKey => !string.IsNullOrEmpty(XApiKey);
     }

--- a/Adyen/Service/Resource/Terminal/TerminalApiLocal.cs
+++ b/Adyen/Service/Resource/Terminal/TerminalApiLocal.cs
@@ -3,7 +3,7 @@
     public class TerminalApiLocal: ServiceResource
     {
         public TerminalApiLocal(AbstractService abstractService) 
-            : base(abstractService, abstractService.Client.Config.Endpoint)
+            : base(abstractService, abstractService.Client.Config.LocalTerminalApiEndpoint)
         {
         }
     }

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ Navigate to adyen-dotnet-api-library folder and run the following commands.
 dotnet build
 dotnet test
 ```
-## Using the Cloud API 
-In order to submit POS request with Cloud API you need to initialize the client with the Endpoints that it is closer to your region. The Endpoints are available as contacts in [ClientConfig](https://github.com/Adyen/adyen-dotnet-api-library/blob/develop/Adyen/Constants/ClientConfig.cs#L35)
+## Using the Cloud Terminal API 
+In order to submit POS request with Cloud Terminal API you need to initialize the client with the Endpoints that it is closer to your region. The Endpoints are available as contacts in [ClientConfig](https://github.com/Adyen/adyen-dotnet-api-library/blob/develop/Adyen/Constants/ClientConfig.cs#L35)
 For more information please read our [documentation](https://docs.adyen.com/point-of-sale/terminal-api-fundamentals#cloud)
 ```c#
 //Example for EU based Endpoint Syncronous
@@ -108,7 +108,7 @@ var serializer = new SaleToPoiMessageSerializer();
 var saleToPoiRequest = serializer.DeserializeNotification(your_terminal_notification);
 ~~~~
 
-## Example cloud API integration
+## Example Cloud Terminal API integration
 ```c#
 using System;
 using Adyen.Model.Nexo;
@@ -173,12 +173,30 @@ namespace Adyen.Terminal
 }
 ```
 
+## Using the Local Terminal API
+The request and response payloads are identical to the Cloud Terminal API, however an additional encryption details object is required to send the requests.
+~~~~ csharp
+var encryptionCredentialDetails = new EncryptionCredentialDetails
+    {
+        AdyenCryptoVersion = 1,
+        KeyIdentifier = "CryptoKeyIdentifier12345",
+        Password = "p@ssw0rd123456"
+    };
+var config = new Config
+    {
+        Environment = Model.Environment.Live,
+        LocalTerminalApiEndpoint = @"https://_terminal_:8443/nexo/"
+    };
+var client = new Client(config);
+var posPaymentLocalApi = new PosPaymentLocalApi(client);
+var saleToPOIResponse = posPaymentLocalApi.TerminalApiLocal(paymentRequest, encryptionCredentialDetails);
+~~~~
 To parse the terminal API notifications, please use the following custom deserializer. This method will throw an exception for non-notification requests.
 ~~~~ csharp
 var serializer = new SaleToPoiMessageSerializer();
 var saleToPoiRequest = serializer.DeserializeNotification(your_terminal_notification);
-
 ~~~~
+
 ## Contributing
 We encourage you to contribute to this repository, so everyone can benefit from new features, bug fixes, and any other improvements.
 Have a look at our [contributing guidelines](https://github.com/Adyen/adyen-dotnet-api-library/blob/develop/CONTRIBUTING.md) to find out how to raise a pull request.


### PR DESCRIPTION
**Description**
The local TAPI endpoint in the config would be overwritten if people would instantiate it with an environment enum, as the endpoint object was shared with PAL. Fixed this by creating separate endpoint for local TAPI and added example in README.
