### PR TITLE
Add support for proxies/certificates to the simple httpclient config

### DIFF
--- a/Adyen/Client.cs
+++ b/Adyen/Client.cs
@@ -108,7 +108,7 @@ namespace Adyen
         private System.Net.Http.HttpClient GetHttpClient()
         {
             // Set Timeout for HttpClient
-            var httpClient = new System.Net.Http.HttpClient();
+            var httpClient = new System.Net.Http.HttpClient(HttpClientExtensions.ConfigureHttpMessageHandler(Config));
             if (Config.Timeout != default)
             {
                 httpClient.Timeout = TimeSpan.FromMilliseconds(Config.Timeout);

--- a/Adyen/HttpClient/HttpClientWrapper.cs
+++ b/Adyen/HttpClient/HttpClientWrapper.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,6 +10,7 @@ using System.Web;
 using Adyen.Constants;
 using Adyen.HttpClient.Interfaces;
 using Adyen.Model;
+using Adyen.Security;
 
 namespace Adyen.HttpClient
 {
@@ -47,43 +50,43 @@ namespace Adyen.HttpClient
         {   
             if (httpMethod == null) {httpMethod = HttpMethod.Post;}
             
-            var httpWebRequest = new HttpRequestMessage(httpMethod, endpoint);
+            var httpRequestMessage = new HttpRequestMessage(httpMethod, endpoint);
             
             // Custom patch method for dotnet <2.1
             var patchMethod = new HttpMethod("PATCH");
             
             if (httpMethod == HttpMethod.Post || httpMethod == patchMethod)
             {
-                httpWebRequest.Content = new StringContent(requestBody, _encoding, "application/json");
+                httpRequestMessage.Content = new StringContent(requestBody, _encoding, "application/json");
             }
 
-            httpWebRequest.Headers.Add("ContentType", "application/json");
-            httpWebRequest.Headers.Add("Accept-Charset", "UTF-8");
-            httpWebRequest.Headers.Add("Cache-Control", "no-cache");
-            httpWebRequest.Headers.Add("UserAgent", $"{_config.ApplicationName} {ClientConfig.UserAgentSuffix}{ClientConfig.LibVersion}");
+            httpRequestMessage.Headers.Add("ContentType", "application/json");
+            httpRequestMessage.Headers.Add("Accept-Charset", "UTF-8");
+            httpRequestMessage.Headers.Add("Cache-Control", "no-cache");
+            httpRequestMessage.Headers.Add("UserAgent", $"{_config.ApplicationName} {ClientConfig.UserAgentSuffix}{ClientConfig.LibVersion}");
             if (!string.IsNullOrWhiteSpace(requestOptions?.IdempotencyKey))
             {
-                httpWebRequest.Headers.Add("Idempotency-Key", requestOptions.IdempotencyKey);
+                httpRequestMessage.Headers.Add("Idempotency-Key", requestOptions.IdempotencyKey);
             }
 
             //Use one of two authentication method.
             if (_config.HasApiKey)
             {
-                httpWebRequest.Headers.Add("x-api-key", _config.XApiKey);
+                httpRequestMessage.Headers.Add("x-api-key", _config.XApiKey);
             }
             else if (_config.HasPassword)
             {
                 var authString = _config.Username + ":" + _config.Password;
                 var bytes = Encoding.UTF8.GetBytes(authString);
                 var credentials = Convert.ToBase64String(bytes);
-                httpWebRequest.Headers.Add("Authorization", "Basic " + credentials);
+                httpRequestMessage.Headers.Add("Authorization", "Basic " + credentials);
             }
             
             // Add library name and version to request for analysis
-            httpWebRequest.Headers.Add(ApiConstants.AdyenLibraryName, ClientConfig.LibName);
-            httpWebRequest.Headers.Add(ApiConstants.AdyenLibraryVersion, ClientConfig.LibVersion);
+            httpRequestMessage.Headers.Add(ApiConstants.AdyenLibraryName, ClientConfig.LibName);
+            httpRequestMessage.Headers.Add(ApiConstants.AdyenLibraryVersion, ClientConfig.LibVersion);
 
-            return httpWebRequest;
+            return httpRequestMessage;
         }
 
         private static string QueryString(IDictionary<string, string> dict)

--- a/Adyen/HttpClient/HttpClientWrapper.cs
+++ b/Adyen/HttpClient/HttpClientWrapper.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Net.Security;
-using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,7 +8,6 @@ using System.Web;
 using Adyen.Constants;
 using Adyen.HttpClient.Interfaces;
 using Adyen.Model;
-using Adyen.Security;
 
 namespace Adyen.HttpClient
 {

--- a/Adyen/Security/TerminalCommonNameValidator.cs
+++ b/Adyen/Security/TerminalCommonNameValidator.cs
@@ -5,15 +5,15 @@ namespace Adyen.Security
 {
     public static class TerminalCommonNameValidator
     {
-        private static readonly string _environmentWildcard = "{environment}";
-        private static readonly string _terminalApiCnRegex = "[a-zA-Z0-9]{3,}-[0-9]{9,15}\\." + _environmentWildcard + "\\.terminal\\.adyen\\.com";
-        private static readonly string _terminalApiLegacy = "legacy-terminal-certificate." + _environmentWildcard + ".terminal.adyen.com";
+        private static readonly string EnvironmentWildcard = "{environment}";
+        private static readonly string TerminalApiCnRegex = "[a-zA-Z0-9]{3,}-[0-9]{9,15}\\." + EnvironmentWildcard + "\\.terminal\\.adyen\\.com";
+        private static readonly string TerminalApiLegacy = "legacy-terminal-certificate." + EnvironmentWildcard + ".terminal.adyen.com";
 
         public static bool ValidateCertificate(string certificateSubject, Model.Environment environment)
         {
             var environmentName = environment.ToString().ToLower();
-            var regexPatternTerminalSpecificCert = _terminalApiCnRegex.Replace(_environmentWildcard, environmentName);
-            var regexPatternLegacyCert = _terminalApiLegacy.Replace(_environmentWildcard, environmentName);
+            var regexPatternTerminalSpecificCert = TerminalApiCnRegex.Replace(EnvironmentWildcard, environmentName);
+            var regexPatternLegacyCert = TerminalApiLegacy.Replace(EnvironmentWildcard, environmentName);
             var subject = certificateSubject.Split(',')
                      .Select(x => x.Split('='))
                      .ToDictionary(x => x[0].Trim(' '), x => x[1]);


### PR DESCRIPTION
**Description**
In refactoring our client we forgot to add back the support for proxies and certificates. This will be added back with this PR for the simple AdyenClient configuration where the library creates the HttpClient object. In other cases it's up to the user to configure this as we should not override any settings, and setting it via HttpClient/Factory is industry standard.

This fixes #835 
