### PR TITLE
[ITT-540] Improve .NET service templates

### DIFF
--- a/templates/csharp/api-single.mustache
+++ b/templates/csharp/api-single.mustache
@@ -74,7 +74,7 @@ namespace {{packageName}}.Service
             // Build the query string
             var queryParams = new Dictionary<string, string>();
             {{#queryParams}}
-            if ({{paramName}} != null) queryParams.Add("{{baseName}}", {{paramName}}{{^isString}}.ToString(){{/isString}});
+            {{^required}}if ({{paramName}} != null) {{/required}}queryParams.Add("{{baseName}}", {{paramName}}{{^isString}}.ToString(){{/isString}});
             {{/queryParams}}
             {{/hasQueryParams}}
             var endpoint = _baseUrl + {{#hasPathParams}}${{/hasPathParams}}"{{{path}}}"{{#hasQueryParams}} + ToQueryString(queryParams){{/hasQueryParams}};

--- a/templates/csharp/api-single.mustache
+++ b/templates/csharp/api-single.mustache
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Adyen.Constants;
 using Adyen.Model;
-using Adyen.Service.Resource;
 {{#hasImport}}using Adyen.{{modelPackage}};
 {{/hasImport}}
 
@@ -26,7 +25,7 @@ namespace {{packageName}}.Service
         {{#isDeprecated}}
         [Obsolete]
         {{/isDeprecated}}
-        {{{returnType}}}{{^returnType}}void{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}({{>api_parameters}});
+        {{#returnType}}{{modelPackage}}.{{{.}}}{{/returnType}}{{^returnType}}void{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}({{>api_parameters}});
         
         {{#supportsAsync}}
 {{>method_documentation}}
@@ -35,7 +34,7 @@ namespace {{packageName}}.Service
         {{#isDeprecated}}
         [Obsolete]
         {{/isDeprecated}}
-        {{#returnType}}Task<{{{.}}}>{{/returnType}}{{^returnType}}Task{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}Async({{>api_parameters_async}});
+        {{#returnType}}Task<{{modelPackage}}.{{{.}}}>{{/returnType}}{{^returnType}}Task{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}Async({{>api_parameters_async}});
         
         {{/supportsAsync}}
         {{/operation}}
@@ -59,7 +58,7 @@ namespace {{packageName}}.Service
         {{#isDeprecated}}
         [Obsolete]
         {{/isDeprecated}}
-        public {{{returnType}}}{{^returnType}}void{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}({{>api_parameters}})
+        public {{#returnType}}{{modelPackage}}.{{{.}}}{{/returnType}}{{^returnType}}void{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}({{>api_parameters}})
         {
             {{#returnType}}return {{/returnType}}{{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}Async({{>api_invoke}}).ConfigureAwait(false).GetAwaiter().GetResult();
         }
@@ -68,7 +67,7 @@ namespace {{packageName}}.Service
         {{#isDeprecated}}
         [Obsolete]
         {{/isDeprecated}}
-        {{#returnType}}public async Task<{{{.}}}>{{/returnType}}{{^returnType}}public async Task{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}Async({{>api_parameters_async}})
+        {{#returnType}}public async Task<{{modelPackage}}.{{{.}}}>{{/returnType}}{{^returnType}}public async Task{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}Async({{>api_parameters_async}})
         {
             {{#hasQueryParams}}
             // Build the query string
@@ -79,7 +78,7 @@ namespace {{packageName}}.Service
             {{/hasQueryParams}}
             var endpoint = _baseUrl + {{#hasPathParams}}${{/hasPathParams}}"{{{path}}}"{{#hasQueryParams}} + ToQueryString(queryParams){{/hasQueryParams}};
             var resource = new ServiceResource(this, endpoint);
-            {{#returnType}}return {{/returnType}}await resource.RequestAsync{{#returnType}}<{{returnType}}>{{/returnType}}({{#bodyParam}}{{paramName}}.ToJson(){{/bodyParam}}{{^bodyParam}}null{{/bodyParam}}, requestOptions, new HttpMethod("{{httpMethod}}"), cancellationToken).ConfigureAwait(false);
+            {{#returnType}}return {{/returnType}}await resource.RequestAsync{{#returnType}}<{{modelPackage}}.{{returnType}}>{{/returnType}}({{#bodyParam}}{{paramName}}.ToJson(){{/bodyParam}}{{^bodyParam}}null{{/bodyParam}}, requestOptions, new HttpMethod("{{httpMethod}}"), cancellationToken).ConfigureAwait(false);
         }
         {{/supportsAsync}}
         {{/operation}}

--- a/templates/csharp/api.mustache
+++ b/templates/csharp/api.mustache
@@ -4,9 +4,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Adyen.Constants;
 using Adyen.Model;
-using Adyen.Service.Resource;
 {{#hasImport}}using Adyen.{{modelPackage}};
 {{/hasImport}}
 
@@ -26,7 +24,7 @@ namespace {{packageName}}.{{apiPackage}}
         {{#isDeprecated}}
         [Obsolete]
         {{/isDeprecated}}
-        {{{returnType}}}{{^returnType}}void{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}({{>api_parameters}});
+        {{#returnType}}{{modelPackage}}.{{{.}}}{{/returnType}}{{^returnType}}void{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}({{>api_parameters}});
         
         {{#supportsAsync}}
 {{>method_documentation}}
@@ -35,7 +33,7 @@ namespace {{packageName}}.{{apiPackage}}
         {{#isDeprecated}}
         [Obsolete]
         {{/isDeprecated}}
-        {{#returnType}}Task<{{{.}}}>{{/returnType}}{{^returnType}}Task{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}Async({{>api_parameters_async}});
+        {{#returnType}}Task<{{modelPackage}}.{{{.}}}>{{/returnType}}{{^returnType}}Task{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}Async({{>api_parameters_async}});
         
         {{/supportsAsync}}
         {{/operation}}
@@ -59,7 +57,7 @@ namespace {{packageName}}.{{apiPackage}}
         {{#isDeprecated}}
         [Obsolete]
         {{/isDeprecated}}
-        public {{{returnType}}}{{^returnType}}void{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}({{>api_parameters}})
+        public {{#returnType}}{{modelPackage}}.{{{.}}}{{/returnType}}{{^returnType}}void{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}({{>api_parameters}})
         {
             {{#returnType}}return {{/returnType}}{{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}Async({{>api_invoke}}).ConfigureAwait(false).GetAwaiter().GetResult();
         }
@@ -68,7 +66,7 @@ namespace {{packageName}}.{{apiPackage}}
         {{#isDeprecated}}
         [Obsolete]
         {{/isDeprecated}}
-        {{#returnType}}public async Task<{{{.}}}>{{/returnType}}{{^returnType}}public async Task{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}Async({{>api_parameters_async}})
+        {{#returnType}}public async Task<{{modelPackage}}.{{{.}}}>{{/returnType}}{{^returnType}}public async Task{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}Async({{>api_parameters_async}})
         {
             {{#hasQueryParams}}
             // Build the query string
@@ -79,7 +77,7 @@ namespace {{packageName}}.{{apiPackage}}
             {{/hasQueryParams}}
             var endpoint = _baseUrl + {{#hasPathParams}}${{/hasPathParams}}"{{{path}}}"{{#hasQueryParams}} + ToQueryString(queryParams){{/hasQueryParams}};
             var resource = new ServiceResource(this, endpoint);
-            {{#returnType}}return {{/returnType}}await resource.RequestAsync{{#returnType}}<{{returnType}}>{{/returnType}}({{#bodyParam}}{{paramName}}.ToJson(){{/bodyParam}}{{^bodyParam}}null{{/bodyParam}}, requestOptions, new HttpMethod("{{httpMethod}}"), cancellationToken).ConfigureAwait(false);
+            {{#returnType}}return {{/returnType}}await resource.RequestAsync{{#returnType}}<{{modelPackage}}.{{returnType}}>{{/returnType}}({{#bodyParam}}{{paramName}}.ToJson(){{/bodyParam}}{{^bodyParam}}null{{/bodyParam}}, requestOptions, new HttpMethod("{{httpMethod}}"), cancellationToken).ConfigureAwait(false);
         }
         {{/supportsAsync}}
         {{/operation}}

--- a/templates/csharp/api.mustache
+++ b/templates/csharp/api.mustache
@@ -74,7 +74,7 @@ namespace {{packageName}}.{{apiPackage}}
             // Build the query string
             var queryParams = new Dictionary<string, string>();
             {{#queryParams}}
-            if ({{paramName}} != null) queryParams.Add("{{baseName}}", {{paramName}}{{^isString}}.ToString(){{/isString}});
+            {{^required}}if ({{paramName}} != null) {{/required}}queryParams.Add("{{baseName}}", {{paramName}}{{^isString}}.ToString(){{/isString}});
             {{/queryParams}}
             {{/hasQueryParams}}
             var endpoint = _baseUrl + {{#hasPathParams}}${{/hasPathParams}}"{{{path}}}"{{#hasQueryParams}} + ToQueryString(queryParams){{/hasQueryParams}};

--- a/templates/csharp/api_invoke.mustache
+++ b/templates/csharp/api_invoke.mustache
@@ -1,1 +1,1 @@
-{{#requiredParams}}{{paramName}}, {{/requiredParams}}{{#optionalParams}}{{paramName}}, {{/optionalParams}}requestOptions
+{{#requiredParams}}{{#isPathParam}}{{paramName}}, {{/isPathParam}}{{#isBodyParam}}{{paramName}}, {{/isBodyParam}}{{#isQueryParam}}{{paramName}}, {{/isQueryParam}}{{/requiredParams}}{{#optionalParams}}{{#isPathParam}}{{paramName}}, {{/isPathParam}}{{#isBodyParam}}{{paramName}}, {{/isBodyParam}}{{#isQueryParam}}{{paramName}}, {{/isQueryParam}}{{/optionalParams}}requestOptions

--- a/templates/csharp/api_invoke.mustache
+++ b/templates/csharp/api_invoke.mustache
@@ -1,1 +1,1 @@
-{{#pathParams}}{{paramName}}, {{/pathParams}}{{#bodyParams}}{{paramName}}, {{/bodyParams}}{{#queryParams}}{{paramName}}, {{/queryParams}}requestOptions
+{{#requiredParams}}{{paramName}}, {{/requiredParams}}{{#optionalParams}}{{paramName}}, {{/optionalParams}}requestOptions

--- a/templates/csharp/api_parameter_ordering.mustache
+++ b/templates/csharp/api_parameter_ordering.mustache
@@ -1,0 +1,1 @@
+{{#isPathParam}}{{{dataType}}} {{paramName}} = default, {{/isPathParam}}{{#isBodyParam}}{{{dataType}}} {{paramName}} = default, {{/isBodyParam}}{{#isQueryParam}}{{{dataType}}} {{paramName}} = default, {{/isQueryParam}}

--- a/templates/csharp/api_parameter_ordering_required.mustache
+++ b/templates/csharp/api_parameter_ordering_required.mustache
@@ -1,0 +1,1 @@
+{{#isPathParam}}{{{dataType}}} {{paramName}}, {{/isPathParam}}{{#isBodyParam}}{{{dataType}}} {{paramName}}, {{/isBodyParam}}{{#isQueryParam}}{{{dataType}}} {{paramName}}, {{/isQueryParam}}

--- a/templates/csharp/api_parameters.mustache
+++ b/templates/csharp/api_parameters.mustache
@@ -1,2 +1,2 @@
 {{! Path and body are required, followed by optional query string and request options }}
-{{#requiredParams}}{{{dataType}}} {{paramName}}, {{/requiredParams}}{{#optionalParams}}{{{dataType}}} {{paramName}} = default, {{/optionalParams}}RequestOptions requestOptions = default
+{{#requiredParams}}{{>api_parameter_ordering_required}}{{/requiredParams}}{{#optionalParams}}{{>api_parameter_ordering}}{{/optionalParams}}RequestOptions requestOptions = default

--- a/templates/csharp/api_parameters.mustache
+++ b/templates/csharp/api_parameters.mustache
@@ -1,2 +1,2 @@
 {{! Path and body are required, followed by optional query string and request options }}
-{{#pathParams}}{{{dataType}}} {{paramName}}, {{/pathParams}}{{#bodyParams}}{{{dataType}}} {{paramName}}, {{/bodyParams}}{{#queryParams}}{{{dataType}}} {{paramName}}{{^required}} = default{{/required}}, {{/queryParams}}RequestOptions requestOptions = default
+{{#requiredParams}}{{{dataType}}} {{paramName}}, {{/requiredParams}}{{#optionalParams}}{{{dataType}}} {{paramName}} = default, {{/optionalParams}}RequestOptions requestOptions = default

--- a/templates/csharp/api_parameters_async.mustache
+++ b/templates/csharp/api_parameters_async.mustache
@@ -1,2 +1,2 @@
 {{! Path and body are required, followed by optional query string and request options }}
-{{#requiredParams}}{{{dataType}}} {{paramName}}, {{/requiredParams}}{{#optionalParams}}{{{dataType}}} {{paramName}} = default, {{/optionalParams}}RequestOptions requestOptions = default, CancellationToken cancellationToken = default
+{{#requiredParams}}{{>api_parameter_ordering_required}}{{/requiredParams}}{{#optionalParams}}{{>api_parameter_ordering}}{{/optionalParams}}RequestOptions requestOptions = default, CancellationToken cancellationToken = default

--- a/templates/csharp/api_parameters_async.mustache
+++ b/templates/csharp/api_parameters_async.mustache
@@ -1,2 +1,2 @@
 {{! Path and body are required, followed by optional query string and request options }}
-{{#pathParams}}{{{dataType}}} {{paramName}}, {{/pathParams}}{{#bodyParams}}{{{dataType}}} {{paramName}}, {{/bodyParams}}{{#queryParams}}{{{dataType}}} {{paramName}}{{^required}} = default{{/required}}, {{/queryParams}}RequestOptions requestOptions = default, CancellationToken cancellationToken = default
+{{#requiredParams}}{{{dataType}}} {{paramName}}, {{/requiredParams}}{{#optionalParams}}{{{dataType}}} {{paramName}} = default, {{/optionalParams}}RequestOptions requestOptions = default, CancellationToken cancellationToken = default


### PR DESCRIPTION
**Description**
This PR improves the ordering of the method params, based on required/optional and the path->body->query ordering. Next to that it uses the full import for models in the service classes to prevent overlapping classnames between service classes and model classes. 

Tested by:
Generating full library and verifying the unit tests run and all method param orderings are correct.
