### PR TITLE
Fix hard validation in oneOf models

### DIFF
--- a/Adyen.Test/CheckoutTest.cs
+++ b/Adyen.Test/CheckoutTest.cs
@@ -675,9 +675,21 @@ namespace Adyen.Test
         public void ApplePayDetailsDeserializationTest()
         {
             var json = "{\"type\": \"applepay\",\"applePayToken\": \"VNRWtuNlNEWkRCSm1xWndjMDFFbktkQU...\"}";
-            var result = Util.JsonOperation.Deserialize<ApplePayDetails>(json);
-            Assert.IsInstanceOfType<ApplePayDetails>(result);
-            Assert.AreEqual(result.Type, ApplePayDetails.TypeEnum.Applepay);
+            var result = CheckoutPaymentMethod.FromJson(json);
+            Assert.IsInstanceOfType<ApplePayDetails>(result.ActualInstance);
+            Assert.AreEqual(result.GetApplePayDetails().Type, ApplePayDetails.TypeEnum.Applepay);
+        }
+
+        [TestMethod]
+        public void CheckoutPaymentMethodDeserializationWithUnknownValuesTest()
+        {
+            var json = "{\"type\": \"applepay\",\"someValue\": \"notInSpec\",\"applePayToken\": \"VNRWtuNlNEWkRCSm1xWndjMDFFbktkQU...\"}";
+            var result = CheckoutPaymentMethod.FromJson(json);
+            var json2 = "{\"type\": \"paywithgoogle\",\"someValue\": \"notInSpec\",\"googlePayToken\": \"==Payload as retrieved from Google Pay response==\"}";
+            var result2 = CheckoutPaymentMethod.FromJson(json2);
+            Assert.IsInstanceOfType<ApplePayDetails>(result.ActualInstance);
+            Assert.IsInstanceOfType<PayWithGoogleDetails>(result2.ActualInstance);
+            Assert.AreEqual(result2.GetPayWithGoogleDetails().GooglePayToken, "==Payload as retrieved from Google Pay response==");
         }
 
         [TestMethod]

--- a/Adyen/Model/Checkout/AbstractOpenAPISchema.cs
+++ b/Adyen/Model/Checkout/AbstractOpenAPISchema.cs
@@ -10,6 +10,9 @@
 */
 
 using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -24,23 +27,6 @@ namespace Adyen.Model.Checkout
         ///  Custom JSON serializer
         /// </summary>
         static public readonly JsonSerializerSettings SerializerSettings = new JsonSerializerSettings
-        {
-            // OpenAPI generated types generally hide default constructors.
-            ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-            MissingMemberHandling = MissingMemberHandling.Error,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
-        };
-
-        /// <summary>
-        ///  Custom JSON serializer for objects with additional properties
-        /// </summary>
-        static public readonly JsonSerializerSettings AdditionalPropertiesSerializerSettings = new JsonSerializerSettings
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
@@ -73,5 +59,23 @@ namespace Adyen.Model.Checkout
         /// Converts the instance into JSON string.
         /// </summary>
         public abstract string ToJson();
+
+        // Check if the <T> contains TypeEnum value
+        protected static bool ContainsValue<T>(string type) where T : struct, IConvertible
+        {
+            // Search for type in <T>.TypeEnum
+            List<string> list = new List<string>();
+            var members = typeof(T).GetTypeInfo().DeclaredMembers;
+            foreach (var member in members)
+            {
+                var val = member?.GetCustomAttribute<EnumMemberAttribute>(false)?.Value;
+                if (!string.IsNullOrEmpty(val))
+                {
+                    list.Add(val);
+                }
+            }
+
+            return list.Contains(type);
+        }
     }
 }

--- a/Adyen/Model/Checkout/CheckoutPaymentMethod.cs
+++ b/Adyen/Model/Checkout/CheckoutPaymentMethod.cs
@@ -1106,986 +1106,300 @@ namespace Adyen.Model.Checkout
             }
             int match = 0;
             List<string> matchedTypes = new List<string>();
-            var type = (string)JObject.Parse(jsonString)["type"];
-
+            JToken typeToken = JObject.Parse(jsonString).GetValue("type");
+            string type = typeToken?.Value<string>();
+            // Throw exception if jsonString does not contain type param
+            if (type == null)
+            {
+                throw new InvalidDataException("JsonString does not contain required enum type for deserialization.");
+            }
             try
             {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(AchDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the AchDetails type enums
+                if (ContainsValue<AchDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<AchDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<AchDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((AchDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("AchDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(AfterpayDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the AfterpayDetails type enums
+                if (ContainsValue<AfterpayDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<AfterpayDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<AfterpayDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((AfterpayDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("AfterpayDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(AmazonPayDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the AmazonPayDetails type enums
+                if (ContainsValue<AmazonPayDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<AmazonPayDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<AmazonPayDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((AmazonPayDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("AmazonPayDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(AndroidPayDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the AndroidPayDetails type enums
+                if (ContainsValue<AndroidPayDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<AndroidPayDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<AndroidPayDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((AndroidPayDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("AndroidPayDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(ApplePayDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the ApplePayDetails type enums
+                if (ContainsValue<ApplePayDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<ApplePayDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<ApplePayDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((ApplePayDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("ApplePayDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(BacsDirectDebitDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the BacsDirectDebitDetails type enums
+                if (ContainsValue<BacsDirectDebitDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<BacsDirectDebitDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<BacsDirectDebitDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((BacsDirectDebitDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("BacsDirectDebitDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(BillDeskDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the BillDeskDetails type enums
+                if (ContainsValue<BillDeskDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<BillDeskDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<BillDeskDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((BillDeskDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("BillDeskDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(BlikDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the BlikDetails type enums
+                if (ContainsValue<BlikDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<BlikDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<BlikDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((BlikDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("BlikDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(CardDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the CardDetails type enums
+                if (ContainsValue<CardDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<CardDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<CardDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((CardDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("CardDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(CellulantDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the CellulantDetails type enums
+                if (ContainsValue<CellulantDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<CellulantDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<CellulantDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((CellulantDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("CellulantDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(DokuDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the DokuDetails type enums
+                if (ContainsValue<DokuDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<DokuDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<DokuDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((DokuDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("DokuDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(DotpayDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the DotpayDetails type enums
+                if (ContainsValue<DotpayDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<DotpayDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<DotpayDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((DotpayDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("DotpayDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(DragonpayDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the DragonpayDetails type enums
+                if (ContainsValue<DragonpayDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<DragonpayDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<DragonpayDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((DragonpayDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("DragonpayDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(EcontextVoucherDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the EcontextVoucherDetails type enums
+                if (ContainsValue<EcontextVoucherDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<EcontextVoucherDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<EcontextVoucherDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((EcontextVoucherDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("EcontextVoucherDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(GenericIssuerPaymentMethodDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the GenericIssuerPaymentMethodDetails type enums
+                if (ContainsValue<GenericIssuerPaymentMethodDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<GenericIssuerPaymentMethodDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<GenericIssuerPaymentMethodDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((GenericIssuerPaymentMethodDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("GenericIssuerPaymentMethodDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(GiropayDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the GiropayDetails type enums
+                if (ContainsValue<GiropayDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<GiropayDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<GiropayDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((GiropayDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("GiropayDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(GooglePayDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the GooglePayDetails type enums
+                if (ContainsValue<GooglePayDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<GooglePayDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<GooglePayDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((GooglePayDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("GooglePayDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(IdealDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the IdealDetails type enums
+                if (ContainsValue<IdealDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<IdealDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<IdealDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((IdealDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("IdealDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(KlarnaDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the KlarnaDetails type enums
+                if (ContainsValue<KlarnaDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<KlarnaDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<KlarnaDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((KlarnaDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("KlarnaDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(MasterpassDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the MasterpassDetails type enums
+                if (ContainsValue<MasterpassDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<MasterpassDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<MasterpassDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((MasterpassDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("MasterpassDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(MbwayDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the MbwayDetails type enums
+                if (ContainsValue<MbwayDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<MbwayDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<MbwayDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((MbwayDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("MbwayDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(MobilePayDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the MobilePayDetails type enums
+                if (ContainsValue<MobilePayDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<MobilePayDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<MobilePayDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((MobilePayDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("MobilePayDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(MolPayDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the MolPayDetails type enums
+                if (ContainsValue<MolPayDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<MolPayDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<MolPayDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((MolPayDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("MolPayDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(OpenInvoiceDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the OpenInvoiceDetails type enums
+                if (ContainsValue<OpenInvoiceDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<OpenInvoiceDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<OpenInvoiceDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((OpenInvoiceDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("OpenInvoiceDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(PayPalDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the PayPalDetails type enums
+                if (ContainsValue<PayPalDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<PayPalDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<PayPalDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((PayPalDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("PayPalDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(PayUUpiDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the PayUUpiDetails type enums
+                if (ContainsValue<PayUUpiDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<PayUUpiDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<PayUUpiDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((PayUUpiDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("PayUUpiDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(PayWithGoogleDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the PayWithGoogleDetails type enums
+                if (ContainsValue<PayWithGoogleDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<PayWithGoogleDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<PayWithGoogleDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((PayWithGoogleDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("PayWithGoogleDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(PaymentDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the PaymentDetails type enums
+                if (ContainsValue<PaymentDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<PaymentDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<PaymentDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((PaymentDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("PaymentDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(RatepayDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the RatepayDetails type enums
+                if (ContainsValue<RatepayDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<RatepayDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<RatepayDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((RatepayDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("RatepayDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(SamsungPayDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the SamsungPayDetails type enums
+                if (ContainsValue<SamsungPayDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<SamsungPayDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<SamsungPayDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((SamsungPayDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("SamsungPayDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(SepaDirectDebitDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the SepaDirectDebitDetails type enums
+                if (ContainsValue<SepaDirectDebitDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<SepaDirectDebitDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<SepaDirectDebitDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((SepaDirectDebitDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("SepaDirectDebitDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(StoredPaymentMethodDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the StoredPaymentMethodDetails type enums
+                if (ContainsValue<StoredPaymentMethodDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<StoredPaymentMethodDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<StoredPaymentMethodDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((StoredPaymentMethodDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("StoredPaymentMethodDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(UpiCollectDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the UpiCollectDetails type enums
+                if (ContainsValue<UpiCollectDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<UpiCollectDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<UpiCollectDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((UpiCollectDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("UpiCollectDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(UpiIntentDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the UpiIntentDetails type enums
+                if (ContainsValue<UpiIntentDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<UpiIntentDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<UpiIntentDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((UpiIntentDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("UpiIntentDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(VippsDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the VippsDetails type enums
+                if (ContainsValue<VippsDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<VippsDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<VippsDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((VippsDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("VippsDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(VisaCheckoutDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the VisaCheckoutDetails type enums
+                if (ContainsValue<VisaCheckoutDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<VisaCheckoutDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<VisaCheckoutDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((VisaCheckoutDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("VisaCheckoutDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(WeChatPayDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the WeChatPayDetails type enums
+                if (ContainsValue<WeChatPayDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<WeChatPayDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<WeChatPayDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((WeChatPayDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("WeChatPayDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(WeChatPayMiniProgramDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the WeChatPayMiniProgramDetails type enums
+                if (ContainsValue<WeChatPayMiniProgramDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<WeChatPayMiniProgramDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<WeChatPayMiniProgramDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((WeChatPayMiniProgramDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("WeChatPayMiniProgramDetails");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(ZipDetails).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the ZipDetails type enums
+                if (ContainsValue<ZipDetails.TypeEnum>(type))
                 {
                     newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<ZipDetails>(jsonString, CheckoutPaymentMethod.SerializerSettings));
-                }
-                else
-                {
-                    newCheckoutPaymentMethod = new CheckoutPaymentMethod(JsonConvert.DeserializeObject<ZipDetails>(jsonString, CheckoutPaymentMethod.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((ZipDetails.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("ZipDetails");
                     match++;
                 }
-            }
+            } 
             catch (Exception ex)
             {
                 if (!(ex is JsonSerializationException))
                 {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
+                     throw new InvalidDataException(string.Format("Failed to deserialize `{0}` into target: {1}", jsonString, ex.ToString()));
                 }
             }
 
-            if (match == 0)
+            if (match != 1)
             {
-                throw new InvalidDataException("The JSON string `" + jsonString + "` cannot be deserialized into any schema defined.");
+                throw new InvalidDataException("The JSON string `" + jsonString + "` cannot be deserialized into any schema defined. MatchedTypes are: " + matchedTypes);
             }
             
             // deserialization is considered successful at this point if no exception has been thrown.

--- a/Adyen/Model/Checkout/PaymentResponseAction.cs
+++ b/Adyen/Model/Checkout/PaymentResponseAction.cs
@@ -300,211 +300,83 @@ namespace Adyen.Model.Checkout
             }
             int match = 0;
             List<string> matchedTypes = new List<string>();
-            var type = (string)JObject.Parse(jsonString)["type"];
-
+            JToken typeToken = JObject.Parse(jsonString).GetValue("type");
+            string type = typeToken?.Value<string>();
+            // Throw exception if jsonString does not contain type param
+            if (type == null)
+            {
+                throw new InvalidDataException("JsonString does not contain required enum type for deserialization.");
+            }
             try
             {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(CheckoutAwaitAction).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the CheckoutAwaitAction type enums
+                if (ContainsValue<CheckoutAwaitAction.TypeEnum>(type))
                 {
                     newPaymentResponseAction = new PaymentResponseAction(JsonConvert.DeserializeObject<CheckoutAwaitAction>(jsonString, PaymentResponseAction.SerializerSettings));
-                }
-                else
-                {
-                    newPaymentResponseAction = new PaymentResponseAction(JsonConvert.DeserializeObject<CheckoutAwaitAction>(jsonString, PaymentResponseAction.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((CheckoutAwaitAction.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("CheckoutAwaitAction");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(CheckoutDelegatedAuthenticationAction).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the CheckoutDelegatedAuthenticationAction type enums
+                if (ContainsValue<CheckoutDelegatedAuthenticationAction.TypeEnum>(type))
                 {
                     newPaymentResponseAction = new PaymentResponseAction(JsonConvert.DeserializeObject<CheckoutDelegatedAuthenticationAction>(jsonString, PaymentResponseAction.SerializerSettings));
-                }
-                else
-                {
-                    newPaymentResponseAction = new PaymentResponseAction(JsonConvert.DeserializeObject<CheckoutDelegatedAuthenticationAction>(jsonString, PaymentResponseAction.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((CheckoutDelegatedAuthenticationAction.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("CheckoutDelegatedAuthenticationAction");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(CheckoutNativeRedirectAction).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the CheckoutNativeRedirectAction type enums
+                if (ContainsValue<CheckoutNativeRedirectAction.TypeEnum>(type))
                 {
                     newPaymentResponseAction = new PaymentResponseAction(JsonConvert.DeserializeObject<CheckoutNativeRedirectAction>(jsonString, PaymentResponseAction.SerializerSettings));
-                }
-                else
-                {
-                    newPaymentResponseAction = new PaymentResponseAction(JsonConvert.DeserializeObject<CheckoutNativeRedirectAction>(jsonString, PaymentResponseAction.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((CheckoutNativeRedirectAction.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("CheckoutNativeRedirectAction");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(CheckoutQrCodeAction).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the CheckoutQrCodeAction type enums
+                if (ContainsValue<CheckoutQrCodeAction.TypeEnum>(type))
                 {
                     newPaymentResponseAction = new PaymentResponseAction(JsonConvert.DeserializeObject<CheckoutQrCodeAction>(jsonString, PaymentResponseAction.SerializerSettings));
-                }
-                else
-                {
-                    newPaymentResponseAction = new PaymentResponseAction(JsonConvert.DeserializeObject<CheckoutQrCodeAction>(jsonString, PaymentResponseAction.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((CheckoutQrCodeAction.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("CheckoutQrCodeAction");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(CheckoutRedirectAction).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the CheckoutRedirectAction type enums
+                if (ContainsValue<CheckoutRedirectAction.TypeEnum>(type))
                 {
                     newPaymentResponseAction = new PaymentResponseAction(JsonConvert.DeserializeObject<CheckoutRedirectAction>(jsonString, PaymentResponseAction.SerializerSettings));
-                }
-                else
-                {
-                    newPaymentResponseAction = new PaymentResponseAction(JsonConvert.DeserializeObject<CheckoutRedirectAction>(jsonString, PaymentResponseAction.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((CheckoutRedirectAction.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("CheckoutRedirectAction");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(CheckoutSDKAction).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the CheckoutSDKAction type enums
+                if (ContainsValue<CheckoutSDKAction.TypeEnum>(type))
                 {
                     newPaymentResponseAction = new PaymentResponseAction(JsonConvert.DeserializeObject<CheckoutSDKAction>(jsonString, PaymentResponseAction.SerializerSettings));
-                }
-                else
-                {
-                    newPaymentResponseAction = new PaymentResponseAction(JsonConvert.DeserializeObject<CheckoutSDKAction>(jsonString, PaymentResponseAction.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((CheckoutSDKAction.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("CheckoutSDKAction");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(CheckoutThreeDS2Action).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the CheckoutThreeDS2Action type enums
+                if (ContainsValue<CheckoutThreeDS2Action.TypeEnum>(type))
                 {
                     newPaymentResponseAction = new PaymentResponseAction(JsonConvert.DeserializeObject<CheckoutThreeDS2Action>(jsonString, PaymentResponseAction.SerializerSettings));
-                }
-                else
-                {
-                    newPaymentResponseAction = new PaymentResponseAction(JsonConvert.DeserializeObject<CheckoutThreeDS2Action>(jsonString, PaymentResponseAction.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((CheckoutThreeDS2Action.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("CheckoutThreeDS2Action");
                     match++;
                 }
-            }
-            catch (Exception ex)
-            {
-                if (!(ex is JsonSerializationException))
-                {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
-                }
-            }
-
-            try
-            {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof(CheckoutVoucherAction).GetProperty("AdditionalProperties") == null)
+                // Check if the jsonString type enum matches the CheckoutVoucherAction type enums
+                if (ContainsValue<CheckoutVoucherAction.TypeEnum>(type))
                 {
                     newPaymentResponseAction = new PaymentResponseAction(JsonConvert.DeserializeObject<CheckoutVoucherAction>(jsonString, PaymentResponseAction.SerializerSettings));
-                }
-                else
-                {
-                    newPaymentResponseAction = new PaymentResponseAction(JsonConvert.DeserializeObject<CheckoutVoucherAction>(jsonString, PaymentResponseAction.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject((CheckoutVoucherAction.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("CheckoutVoucherAction");
                     match++;
                 }
-            }
+            } 
             catch (Exception ex)
             {
                 if (!(ex is JsonSerializationException))
                 {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
+                     throw new InvalidDataException(string.Format("Failed to deserialize `{0}` into target: {1}", jsonString, ex.ToString()));
                 }
             }
 
-            if (match == 0)
+            if (match != 1)
             {
-                throw new InvalidDataException("The JSON string `" + jsonString + "` cannot be deserialized into any schema defined.");
+                throw new InvalidDataException("The JSON string `" + jsonString + "` cannot be deserialized into any schema defined. MatchedTypes are: " + matchedTypes);
             }
             
             // deserialization is considered successful at this point if no exception has been thrown.

--- a/templates/csharp/AbstractOpenAPISchema.mustache
+++ b/templates/csharp/AbstractOpenAPISchema.mustache
@@ -1,5 +1,8 @@
 {{>partial_header}}
 using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -14,23 +17,6 @@ namespace {{packageName}}.{{modelPackage}}
         ///  Custom JSON serializer
         /// </summary>
         static public readonly JsonSerializerSettings SerializerSettings = new JsonSerializerSettings
-        {
-            // OpenAPI generated types generally hide default constructors.
-            ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-            MissingMemberHandling = MissingMemberHandling.Error,
-            ContractResolver = new DefaultContractResolver
-            {
-                NamingStrategy = new CamelCaseNamingStrategy
-                {
-                    OverrideSpecifiedNames = false
-                }
-            }
-        };
-
-        /// <summary>
-        ///  Custom JSON serializer for objects with additional properties
-        /// </summary>
-        static public readonly JsonSerializerSettings AdditionalPropertiesSerializerSettings = new JsonSerializerSettings
         {
             // OpenAPI generated types generally hide default constructors.
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
@@ -63,5 +49,23 @@ namespace {{packageName}}.{{modelPackage}}
         /// Converts the instance into JSON string.
         /// </summary>
         public abstract string ToJson();
+
+        // Check if the <T> contains TypeEnum value
+        protected static bool ContainsValue<T>(string type) where T : struct, IConvertible
+        {
+            // Search for type in <T>.TypeEnum
+            List<string> list = new List<string>();
+            var members = typeof(T).GetTypeInfo().DeclaredMembers;
+            foreach (var member in members)
+            {
+                var val = member?.GetCustomAttribute<EnumMemberAttribute>(false)?.Value;
+                if (!string.IsNullOrEmpty(val))
+                {
+                    list.Add(val);
+                }
+            }
+
+            return list.Contains(type);
+        }
     }
 }

--- a/templates/csharp/modelOneOf.mustache
+++ b/templates/csharp/modelOneOf.mustache
@@ -143,38 +143,36 @@
             {{/useOneOfDiscriminatorLookup}}
             int match = 0;
             List<string> matchedTypes = new List<string>();
-            var type = (string)JObject.Parse(jsonString)["type"];
-            {{#oneOf}}
-
+            JToken typeToken = JObject.Parse(jsonString).GetValue("type");
+            string type = typeToken?.Value<string>();
+            // Throw exception if jsonString does not contain type param
+            if (type == null)
+            {
+                throw new InvalidDataException("JsonString does not contain required enum type for deserialization.");
+            }
             try
             {
-                // if it does not contains "AdditionalProperties", use SerializerSettings to deserialize
-                if (typeof({{{.}}}).GetProperty("AdditionalProperties") == null)
+            {{#oneOf}}
+                // Check if the jsonString type enum matches the {{{.}}} type enums
+                if (ContainsValue<{{{.}}}.TypeEnum>(type))
                 {
                     new{{classname}} = new {{classname}}(JsonConvert.DeserializeObject<{{{.}}}>(jsonString, {{classname}}.SerializerSettings));
-                }
-                else
-                {
-                    new{{classname}} = new {{classname}}(JsonConvert.DeserializeObject<{{{.}}}>(jsonString, {{classname}}.AdditionalPropertiesSerializerSettings));
-                }
-                if (type != null || JsonConvert.SerializeObject(({{{.}}}.TypeEnum) 1).Contains(type))
-                {
                     matchedTypes.Add("{{{.}}}");
                     match++;
                 }
-            }
+            {{/oneOf}}
+            } 
             catch (Exception ex)
             {
                 if (!(ex is JsonSerializationException))
                 {
-                    throw new Exception(string.Format("Failed to deserialize `{0}` into CheckoutThreeDS2Action: {1}", jsonString, ex.ToString()));
+                     throw new InvalidDataException(string.Format("Failed to deserialize `{0}` into target: {1}", jsonString, ex.ToString()));
                 }
             }
-            {{/oneOf}}
 
-            if (match == 0)
+            if (match != 1)
             {
-                throw new InvalidDataException("The JSON string `" + jsonString + "` cannot be deserialized into any schema defined.");
+                throw new InvalidDataException("The JSON string `" + jsonString + "` cannot be deserialized into any schema defined. MatchedTypes are: " + matchedTypes);
             }
             
             // deserialization is considered successful at this point if no exception has been thrown.


### PR DESCRIPTION
This PR changes the templates to include soft oneOf validation and removes the prior method of finding a type-enum and also trying to deserialize (which is quite costly). This is tested with all oneOfs and I merged the changes in checkout as an example to show how it looks like in the code. I'm using some reflection, but from what I'm seeing it's not costly computing wise. 
