### PR TITLE
Fix cloud live api endpoints

### DIFF
--- a/Adyen.Test/CloudApiPosRequestTest.cs
+++ b/Adyen.Test/CloudApiPosRequestTest.cs
@@ -1,9 +1,13 @@
 ﻿using System;
+using System.Net.Http;
 using Adyen.ApiSerialization;
+using Adyen.Model;
 using Adyen.Model.Nexo;
 using Adyen.Model.Nexo.Message;
 using Adyen.Service;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using Environment = Adyen.Model.Environment;
 
 namespace Adyen.Test
 {
@@ -252,6 +256,42 @@ namespace Adyen.Test
             {
                 Assert.Fail();
             }
+        }
+        
+        /// <summary>
+        /// TestCloudApiEndpoint 
+        /// </summary>
+        [TestMethod]
+        public void TestTerminalCloudEndpointLiveSetRegionValue()
+        {
+            var config = new Config()
+            {
+                Environment = Environment.Live,
+                CloudApiLiveRegion = CloudApiLiveRegionEnum.US
+            };
+            var client = CreateMockForAdyenClientTest(config);
+            var service = new TerminalCloudApi(client);
+            service.TerminalRequestAsync(_paymentRequest);
+            ClientInterfaceSubstitute.Received().Request(
+                "https://terminal-api-live-us.adyen.com/async", Arg.Any<String>(), Arg.Any<RequestOptions>(), null);
+        }
+        
+        /// <summary>
+        /// TestCloudApiEndpoint 
+        /// </summary>
+        [TestMethod]
+        public void TestTerminalCloudEndpointLiveSetCustomValue()
+        {
+            var config = new Config()
+            {
+                Environment = Environment.Live,
+                CloudApiEndPoint = "https://custom-value-endpoint"
+            };
+            var client = CreateMockForAdyenClientTest(config);
+            var service = new TerminalCloudApi(client);
+            service.TerminalRequestAsync(_paymentRequest);
+            ClientInterfaceSubstitute.Received().Request(
+                "https://custom-value-endpoint/async", Arg.Any<String>(), Arg.Any<RequestOptions>(), null);
         }
     }
 }

--- a/Adyen.Test/CloudApiPosRequestTest.cs
+++ b/Adyen.Test/CloudApiPosRequestTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using Adyen.ApiSerialization;
+using Adyen.Constants;
 using Adyen.Model;
 using Adyen.Model.Nexo;
 using Adyen.Model.Nexo.Message;
@@ -267,7 +268,7 @@ namespace Adyen.Test
             var config = new Config()
             {
                 Environment = Environment.Live,
-                CloudApiLiveRegion = CloudApiLiveRegionEnum.US
+                CloudApiEndPoint = ClientConfig.CloudApiEndPointUSLive
             };
             var client = CreateMockForAdyenClientTest(config);
             var service = new TerminalCloudApi(client);

--- a/Adyen/Client.cs
+++ b/Adyen/Client.cs
@@ -78,7 +78,7 @@ namespace Adyen
             {
                 return;
             }
-            // If not switch through environment and region
+            // If not switch through environment and set default EU
             switch (environment)
             {
                 case Environment.Test:

--- a/Adyen/Client.cs
+++ b/Adyen/Client.cs
@@ -85,22 +85,7 @@ namespace Adyen
                     Config.CloudApiEndPoint = ClientConfig.CloudApiEndPointTest;
                     break;
                 case Environment.Live:
-                    switch (Config.CloudApiLiveRegion)
-                    {
-                        // Default value
-                        case CloudApiLiveRegionEnum.EU:
-                            Config.CloudApiEndPoint = ClientConfig.CloudApiEndPointEULive;
-                            break;
-                        case CloudApiLiveRegionEnum.AU:
-                            Config.CloudApiEndPoint = ClientConfig.CloudApiEndPointAULive;
-                            break;
-                        case CloudApiLiveRegionEnum.US:
-                            Config.CloudApiEndPoint = ClientConfig.CloudApiEndPointUSLive;
-                            break;
-                        case CloudApiLiveRegionEnum.APSE:
-                            Config.CloudApiEndPoint = ClientConfig.CloudApiEndPointAPSELive;
-                            break;
-                    }
+                    Config.CloudApiEndPoint = ClientConfig.CloudApiEndPointEULive;
                     break;
             }
         }

--- a/Adyen/Client.cs
+++ b/Adyen/Client.cs
@@ -72,14 +72,35 @@ namespace Adyen
         {
             Config.Environment = environment;
             Config.LiveEndpointUrlPrefix = liveEndpointUrlPrefix;
-            
+    
+            // Check if the cloud api endpoint has not already been set
+            if (Config.CloudApiEndPoint != null)
+            {
+                return;
+            }
+            // If not switch through environment and region
             switch (environment)
             {
                 case Environment.Test:
                     Config.CloudApiEndPoint = ClientConfig.CloudApiEndPointTest;
                     break;
                 case Environment.Live:
-                    Config.CloudApiEndPoint = ClientConfig.CloudApiEndPointEULive;
+                    switch (Config.CloudApiLiveRegion)
+                    {
+                        // Default value
+                        case CloudApiLiveRegionEnum.EU:
+                            Config.CloudApiEndPoint = ClientConfig.CloudApiEndPointEULive;
+                            break;
+                        case CloudApiLiveRegionEnum.AU:
+                            Config.CloudApiEndPoint = ClientConfig.CloudApiEndPointAULive;
+                            break;
+                        case CloudApiLiveRegionEnum.US:
+                            Config.CloudApiEndPoint = ClientConfig.CloudApiEndPointUSLive;
+                            break;
+                        case CloudApiLiveRegionEnum.APSE:
+                            Config.CloudApiEndPoint = ClientConfig.CloudApiEndPointAPSELive;
+                            break;
+                    }
                     break;
             }
         }

--- a/Adyen/Config.cs
+++ b/Adyen/Config.cs
@@ -22,5 +22,14 @@ namespace Adyen
         public string LocalTerminalApiEndpoint { get; set; }
         public bool HasPassword => !string.IsNullOrEmpty(Password);
         public bool HasApiKey => !string.IsNullOrEmpty(XApiKey);
+
+        public CloudApiLiveRegionEnum CloudApiLiveRegion { get; set; }
+    }
+    
+    public enum CloudApiLiveRegionEnum {
+        EU = 0,
+        AU = 1,
+        APSE = 2,
+        US = 3
     }
 }

--- a/Adyen/Config.cs
+++ b/Adyen/Config.cs
@@ -22,14 +22,5 @@ namespace Adyen
         public string LocalTerminalApiEndpoint { get; set; }
         public bool HasPassword => !string.IsNullOrEmpty(Password);
         public bool HasApiKey => !string.IsNullOrEmpty(XApiKey);
-
-        public CloudApiLiveRegionEnum CloudApiLiveRegion { get; set; }
-    }
-    
-    public enum CloudApiLiveRegionEnum {
-        EU = 0,
-        AU = 1,
-        APSE = 2,
-        US = 3
     }
 }

--- a/Adyen/Constants/ClientConfig.cs
+++ b/Adyen/Constants/ClientConfig.cs
@@ -8,6 +8,7 @@
         public static string CloudApiEndPointEULive = "https://terminal-api-live.adyen.com";
         public static string CloudApiEndPointAULive = "https://terminal-api-live-au.adyen.com";
         public static string CloudApiEndPointUSLive = "https://terminal-api-live-us.adyen.com";
+        public static string CloudApiEndPointAPSELive = "https://terminal-api-live-apse.adyen.com";
         
         public static string UserAgentSuffix = "adyen-dotnet-api-library/";
         public static string NexoProtocolVersion = "3.0";


### PR DESCRIPTION
**Description**
This PR fixes the issue with the cloudterminal api endpoint getting overwritten in the client. Additionally it also support setting the live api region by setting an enum in the config.
