### PR TITLE
support CancellationToken passing to base API

### DIFF
--- a/Adyen/Service/TerminalCloudApi.cs
+++ b/Adyen/Service/TerminalCloudApi.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using Adyen.ApiSerialization;
 using Adyen.Model.TerminalApi;
@@ -25,15 +26,17 @@ namespace Adyen.Service
         ///  Task async CloudApi asynchronous call
         /// </summary>
         /// <param name="saleToPoiRequest"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<SaleToPOIResponse> TerminalRequestAsynchronousAsync(SaleToPOIMessage saleToPoiRequest);
+        Task<SaleToPOIResponse> TerminalRequestAsynchronousAsync(SaleToPOIMessage saleToPoiRequest, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///  Task async CloudApi synchronous call
         /// </summary>
         /// <param name="saleToPoiRequest"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<SaleToPOIResponse> TerminalRequestSynchronousAsync(SaleToPOIMessage saleToPoiRequest);
+        Task<SaleToPOIResponse> TerminalRequestSynchronousAsync(SaleToPOIMessage saleToPoiRequest, CancellationToken cancellationToken = default);
     }
     public class TerminalCloudApi : AbstractService, ITerminalCloudApi 
     {
@@ -79,11 +82,11 @@ namespace Adyen.Service
             return _saleToPoiMessageSerializer.Deserialize(response);
         }
         
-        public async Task<SaleToPOIResponse> TerminalRequestAsynchronousAsync(SaleToPOIMessage saleToPoiRequest)
+        public async Task<SaleToPOIResponse> TerminalRequestAsynchronousAsync(SaleToPOIMessage saleToPoiRequest, CancellationToken cancellationToken = default)
         {
             var serializedMessage = _saleToPoiMessageSerializer.Serialize(saleToPoiRequest);
             Client.LogLine("Request: \n" + serializedMessage);
-            var response = await _terminalApiAsync.RequestAsync(serializedMessage);
+            var response = await _terminalApiAsync.RequestAsync(serializedMessage, cancellationToken: cancellationToken);
             Client.LogLine("Response: \n" + response);
             if (string.IsNullOrEmpty(response) || string.Equals("ok", response))
             {
@@ -92,11 +95,11 @@ namespace Adyen.Service
             return _saleToPoiMessageSerializer.Deserialize(response);
         }
         
-        public async Task<SaleToPOIResponse> TerminalRequestSynchronousAsync(SaleToPOIMessage saleToPoiRequest)
+        public async Task<SaleToPOIResponse> TerminalRequestSynchronousAsync(SaleToPOIMessage saleToPoiRequest, CancellationToken cancellationToken = default)
         {
             var serializedMessage = _saleToPoiMessageSerializer.Serialize(saleToPoiRequest);
             Client.LogLine("Request: \n" + serializedMessage);
-            var response = await _terminalApiSync.RequestAsync(serializedMessage);
+            var response = await _terminalApiSync.RequestAsync(serializedMessage, cancellationToken: cancellationToken);
             Client.LogLine("Response: \n" + response);
             if (string.IsNullOrEmpty(response) || string.Equals("ok", response))
             {


### PR DESCRIPTION
**Description**
When I'm using Terminal Cloud API, I make HTTP requests under-the-hood which are cancellable by client.
I also use Terminal Cloud API as a client. Requests to me may be cancelled by browser our due to my internal policies (e.g. expected response time).

To save efforts on maintaining connection when the client no longer needs them, Microsoft recommends [CancellationToken](https://learn.microsoft.com/en-us/dotnet/standard/threading/cancellation-in-managed-threads)s. In fact, it's a built-in .NET standart for cancellable i/o operations, such as HTTP requests, database connectivity and such.
There's a general [recommendation](https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AsyncGuidance.md#always-flow-cancellationtokens-to-apis-that-take-a-cancellationtoken) to pass it on whenever possible.



**Tested scenarios**
I did not provide any additional test scenarios.
I could write a unit test to prove that indeed the HTTP request is cancellable from the outside, but first, I need to install libraries like Moq to do that; second, I doubt that pretty common .NET functionality requires testing other than existing suite.

**Fixed issue**: https://github.com/Adyen/adyen-dotnet-api-library/issues/936