### PR TITLE
Add region selection for cloud terminal API endpoints

### DIFF
--- a/Adyen.Test/ClientTest.cs
+++ b/Adyen.Test/ClientTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using Adyen.Constants;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Adyen.Test
@@ -26,7 +27,6 @@ namespace Adyen.Test
 
             client.SetEnvironment(Model.Environment.Test, "");
             Assert.AreEqual("https://terminal-api-test.adyen.com", client.GetCloudApiEndpoint());
-
         }
 
         Client testClient;
@@ -46,6 +46,25 @@ namespace Adyen.Test
         {
             testClient.LogLine("testMessage");
             Assert.AreEqual("testMessage", logLine);
+        }
+
+        [TestMethod]
+        public void TestSetTerminalApiRegion()
+        {
+            var clientAU = new Client(new Config
+                {Environment = Adyen.Model.Environment.Live, TerminalApiRegion = Region.AU});
+            Assert.AreEqual(clientAU.GetCloudApiEndpoint(), ClientConfig.CloudApiEndPointAULive);
+            var clientEU = new Client(new Config
+                {Environment = Adyen.Model.Environment.Live, TerminalApiRegion = Region.EU});
+            Assert.AreEqual(clientEU.GetCloudApiEndpoint(), ClientConfig.CloudApiEndPointEULive);
+            var clientUS = new Client(new Config
+                {Environment = Adyen.Model.Environment.Live, TerminalApiRegion = Region.US});
+            Assert.AreEqual(clientUS.GetCloudApiEndpoint(), ClientConfig.CloudApiEndPointUSLive);
+            var clientAPSE = new Client(new Config
+                {Environment = Adyen.Model.Environment.Live, TerminalApiRegion = Region.APSE});
+            Assert.AreEqual(clientAPSE.GetCloudApiEndpoint(), ClientConfig.CloudApiEndPointAPSELive);
+            var clientDefault = new Client(new Config {Environment = Adyen.Model.Environment.Live});
+            Assert.AreEqual(clientDefault.GetCloudApiEndpoint(), ClientConfig.CloudApiEndPointEULive);
         }
     }
 }

--- a/Adyen/Client.cs
+++ b/Adyen/Client.cs
@@ -4,6 +4,7 @@ using Adyen.Constants;
 using Adyen.Exceptions;
 using Adyen.HttpClient;
 using Adyen.HttpClient.Interfaces;
+using Adyen.Service.Resource.Terminal;
 using Environment = Adyen.Model.Environment;
 
 namespace Adyen
@@ -80,12 +81,23 @@ namespace Adyen
             {
                 return Config.CloudApiEndPoint;
             }
-
+            
             // If not switch through environment and return default EU
-            if(Config.Environment == Environment.Live) {
-                return ClientConfig.CloudApiEndPointEULive;
+            if (Config.Environment == Environment.Live)
+            {
+                switch (Config.TerminalApiRegion)
+                {
+                    case Region.AU:
+                        return ClientConfig.CloudApiEndPointAULive;
+                    case Region.US:
+                        return ClientConfig.CloudApiEndPointUSLive;
+                    case Region.APSE:
+                        return ClientConfig.CloudApiEndPointAPSELive;
+                    case Region.EU:
+                    default:
+                        return ClientConfig.CloudApiEndPointEULive;
+                }
             }
-
             return ClientConfig.CloudApiEndPointTest;
         }
         

--- a/Adyen/Client.cs
+++ b/Adyen/Client.cs
@@ -81,7 +81,6 @@ namespace Adyen
             {
                 return Config.CloudApiEndPoint;
             }
-            
             // If not switch through environment and return default EU
             if (Config.Environment == Environment.Live)
             {

--- a/Adyen/Config.cs
+++ b/Adyen/Config.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Adyen.Constants;
 using Adyen.Model;
 
 namespace Adyen
@@ -22,5 +23,7 @@ namespace Adyen
         public bool HasPassword => !string.IsNullOrEmpty(Password);
         public bool HasApiKey => !string.IsNullOrEmpty(XApiKey);
         public BaseUrlConfig BaseUrlConfig { get; set; }
+        
+        public Region TerminalApiRegion { get; set; }
     }
 }

--- a/Adyen/Constants/ClientConfig.cs
+++ b/Adyen/Constants/ClientConfig.cs
@@ -3,17 +3,18 @@
     public class ClientConfig
     {
         //Test cloud api endpoints
-        public static string CloudApiEndPointTest = "https://terminal-api-test.adyen.com";
-        //Live cloud api endpoints
-        public static string CloudApiEndPointEULive = "https://terminal-api-live.adyen.com";
-        public static string CloudApiEndPointAULive = "https://terminal-api-live-au.adyen.com";
-        public static string CloudApiEndPointUSLive = "https://terminal-api-live-us.adyen.com";
-        public static string CloudApiEndPointAPSELive = "https://terminal-api-live-apse.adyen.com";
-        
-        public static string UserAgentSuffix = "adyen-dotnet-api-library/";
-        public static string NexoProtocolVersion = "3.0";
+        public const string CloudApiEndPointTest = "https://terminal-api-test.adyen.com";
 
-        public static string LibName = "adyen-dotnet-api-library";
-        public static string LibVersion = "13.0.0";
+        //Live cloud api endpoints
+        public const string CloudApiEndPointEULive = "https://terminal-api-live.adyen.com";
+        public const string CloudApiEndPointAULive = "https://terminal-api-live-au.adyen.com";
+        public const string CloudApiEndPointUSLive = "https://terminal-api-live-us.adyen.com";
+        public const string CloudApiEndPointAPSELive = "https://terminal-api-live-apse.adyen.com";
+        
+        public const string UserAgentSuffix = "adyen-dotnet-api-library/";
+        public const string NexoProtocolVersion = "3.0";
+
+        public const string LibName = "adyen-dotnet-api-library";
+        public const string LibVersion = "13.0.0";
     }
 }

--- a/Adyen/Constants/Region.cs
+++ b/Adyen/Constants/Region.cs
@@ -1,0 +1,21 @@
+namespace Adyen.Constants
+{
+    /// <summary>
+    /// Enum to set region based urls for terminal api
+    /// https://docs.adyen.com/point-of-sale/design-your-integration/terminal-api/
+    /// </summary>
+    public enum Region
+    {
+        //Europe
+        EU = 0,
+
+        //Australia
+        AU = 1,
+
+        //US
+        US = 2,
+
+        //East Asia
+        APSE = 3
+    }
+}


### PR DESCRIPTION
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Currently we have a few constants containing cloud API urls, yet we have no selection mechanism for merchants to actually select the right region. In this pull request merchants could pass the region using the `Config` and `TerminalApiRegion` field. Default is `EU` as it was if no value is passed. 

**Tested scenarios**
Add test covering all the new region enums
