### PR TITLE
Add util class for CardAcquisition Encoding/Decoding

### DIFF
--- a/Adyen.Test/UtilTest.cs
+++ b/Adyen.Test/UtilTest.cs
@@ -2,6 +2,7 @@
 using Adyen.Model.Notification;
 using Adyen.Model.Payment;
 using Adyen.Util;
+using Adyen.Util.TerminalApi;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 
@@ -162,5 +163,50 @@ namespace Adyen.Test
             var isValidHmac = hmacValidator.IsValidHmac(notificationRequestItem, "74F490DD33F7327BAECC88B2947C011FC02D014A473AAA33A8EC93E4DC069174");
             Assert.IsTrue(isValidHmac);
         }
+
+        [TestMethod]
+        public void TestCardAcquisitionAdditionalResponse()
+        {
+            string jsonString = @"{
+            ""additionalData"": {
+                ""PaymentAccountReference"": ""Yv6zs1234567890ASDFGHJKL"",
+                ""alias"": ""G12345678"",
+                ""aliasType"": ""Default"",
+                ""applicationLabel"": ""ASDFGHJKL"",
+                ""applicationPreferredName"": ""ASDFGHJKL"",
+                ""backendGiftcardIndicator"": ""false"",
+                ""cardBin"": ""4111111"",
+                ""cardHolderName"": ""John Smith""
+            },
+            ""message"": ""CARD_ACQ_COMPLETED"",
+            ""store"": ""NL""
+         }";
+            string responseBased64 = "ewoiYWRkaXRpb25hbERhdGEiOnsKICJQYXltZW50QWNjb3VudFJlZmVyZW5jZSI6Ill2NnpzMTIzNDU2Nzg5MEFTREZHSEpLTCIsCiJhbGlhcyI6IkcxMjM0NTY3OCIsCiJhbGlhc1R5cGUiOiJEZWZhdWx0IiwKImFwcGxpY2F0aW9uTGFiZWwiOiJBU0RGR0hKS0wiLAoiYXBwbGljYXRpb25QcmVmZXJyZWROYW1lIjoiQVNERkdISktMIiwKICJiYWNrZW5kR2lmdGNhcmRJbmRpY2F0b3IiOiJmYWxzZSIsCiJjYXJkQmluIjoiNDExMTExMSIsCiJjYXJkSG9sZGVyTmFtZSI6IkpvaG4gU21pdGgiCgp9LAoibWVzc2FnZSI6IkNBUkRfQUNRX0NPTVBMRVRFRCIsCiJzdG9yZSI6Ik5MIgp9";
+            var additionalResponse = CardAcquisitionUtil.AdditionalResponse(responseBased64);
+            Assert.AreEqual(additionalResponse.Message,"CARD_ACQ_COMPLETED");
+            Assert.AreEqual(additionalResponse.Store,"NL");
+            Assert.AreEqual(additionalResponse.AdditionalData["PaymentAccountReference"],"Yv6zs1234567890ASDFGHJKL");
+            Assert.AreEqual(additionalResponse.AdditionalData["alias"],"G12345678");
+            Assert.AreEqual(additionalResponse.AdditionalData["aliasType"],"Default");
+            Assert.AreEqual(additionalResponse.AdditionalData["applicationLabel"],"ASDFGHJKL");
+            Assert.AreEqual(additionalResponse.AdditionalData["applicationPreferredName"],"ASDFGHJKL");
+            Assert.AreEqual(additionalResponse.AdditionalData["backendGiftcardIndicator"],"false");
+            Assert.AreEqual(additionalResponse.AdditionalData["cardHolderName"],"John Smith");
+            Assert.AreEqual(additionalResponse.AdditionalData["cardBin"],"4111111");
+            
+            var additionalResponseFromJson = CardAcquisitionUtil.AdditionalResponse(jsonString);
+            Assert.AreEqual(additionalResponseFromJson.Message,"CARD_ACQ_COMPLETED");
+            Assert.AreEqual(additionalResponseFromJson.Store,"NL");
+            Assert.AreEqual(additionalResponseFromJson.AdditionalData["PaymentAccountReference"],"Yv6zs1234567890ASDFGHJKL");
+            Assert.AreEqual(additionalResponseFromJson.AdditionalData["alias"],"G12345678");
+            Assert.AreEqual(additionalResponseFromJson.AdditionalData["aliasType"],"Default");
+            Assert.AreEqual(additionalResponseFromJson.AdditionalData["applicationLabel"],"ASDFGHJKL");
+            Assert.AreEqual(additionalResponseFromJson.AdditionalData["applicationPreferredName"],"ASDFGHJKL");
+            Assert.AreEqual(additionalResponseFromJson.AdditionalData["backendGiftcardIndicator"],"false");
+            Assert.AreEqual(additionalResponseFromJson.AdditionalData["cardHolderName"],"John Smith");
+            Assert.AreEqual(additionalResponseFromJson.AdditionalData["cardBin"],"4111111");
+            
+        }
+        
     }
 }

--- a/Adyen/Util/TerminalApi/AdditionalResponse.cs
+++ b/Adyen/Util/TerminalApi/AdditionalResponse.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace Adyen.Util.TerminalApi
+{
+
+    public class AdditionalResponse
+    {
+        public Dictionary<string, string> AdditionalData { get; set; }
+        public string Message { get; set; }
+        public string Store { get; set; }
+    }
+}

--- a/Adyen/Util/TerminalApi/CardAcquisitionUtil.cs
+++ b/Adyen/Util/TerminalApi/CardAcquisitionUtil.cs
@@ -1,0 +1,33 @@
+using System;
+using Newtonsoft.Json;
+
+namespace Adyen.Util.TerminalApi
+{
+    public static class CardAcquisitionUtil
+    {
+        public static AdditionalResponse AdditionalResponse(string input)
+        {
+            if (IsBase64String(input))
+            {
+                var base64Bytes = Convert.FromBase64String(input);
+
+                // Convert byte array to string (assuming it was originally UTF-8 encoded)
+                input = System.Text.Encoding.UTF8.GetString(base64Bytes);
+            }
+            return JsonConvert.DeserializeObject<AdditionalResponse>(input);
+        }
+
+        private static bool IsBase64String(string input)
+        {
+            try
+            {
+                var fromBase64String = Convert.FromBase64String(input);
+                return true;
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -223,6 +223,12 @@ To parse the terminal API notifications, please use the following custom deseria
 var serializer = new SaleToPoiMessageSerializer();
 var saleToPoiRequest = serializer.DeserializeNotification(your_terminal_notification);
 ```
+Since the terminal API CardAcquisition AdditionalResponse could be either based64 encoded string or key-value pair, there is a helper class to deserialise it to a custom model AdditionalResponse. 
+```c#
+AdditionalResponse additionalResponse = CardAcquisitionUtil.AdditionalResponse(jsonString);
+```
+
+
 
 ## Parsing BalancePlatform and Management Webhooks
 In order to parse banking webhooks, first validate the webhooks (recommended) by retrieving the hmac key from the webhook header and the hmac signature from the Balance Platform CA configuration page respectively.


### PR DESCRIPTION
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

Since AdditionalResponse could be a base64 encoded string, or a string with key-value pair, which depends on an ADP settings, we added an util class whichdeserializes in a `Dictionary<string,string>` for AdditionalData based on the format (base64 or plain string). 

The class is just a helper that can be used optionally by the merchant/partner.

**Tested scenarios**
Test for both cases base64 encoded string, or a string with key-value pair
