### PR TITLE
Fix/empty post request

### DIFF
--- a/Adyen.Test/HttpClientWrapperTest.cs
+++ b/Adyen.Test/HttpClientWrapperTest.cs
@@ -1,0 +1,27 @@
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Adyen.HttpClient;
+using Adyen.Model.Management;
+using Adyen.Model.TerminalApi;
+using Adyen.Service.Management;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace Adyen.Test
+{
+    [TestClass]
+    public class HttpClientWrapperTest : BaseTest
+    {
+        [TestMethod]
+        public async void EmptyRequestBodyTest()
+        {
+            var mockHttpMessageHandler = new MockHttpMessageHandler("{}", System.Net.HttpStatusCode.OK);
+            var httpClient = new System.Net.Http.HttpClient(mockHttpMessageHandler);
+            var httpClientWrapper = new HttpClientWrapper(MockPaymentData.CreateConfigApiKeyBasedMock(), httpClient);
+            await httpClientWrapper.RequestAsync("/test",null);
+            Assert.Equals(mockHttpMessageHandler.Input, "{}");
+        }
+
+      }
+}

--- a/Adyen.Test/HttpClientWrapperTest.cs
+++ b/Adyen.Test/HttpClientWrapperTest.cs
@@ -20,7 +20,7 @@ namespace Adyen.Test
             var httpClient = new System.Net.Http.HttpClient(mockHttpMessageHandler);
             var httpClientWrapper = new HttpClientWrapper(MockPaymentData.CreateConfigApiKeyBasedMock(), httpClient);
             var _ = httpClientWrapper.Request("https://test.com/testpath", null, null, HttpMethod.Post);
-            Assert.AreEqual(mockHttpMessageHandler.Input, "{}");
+            Assert.AreEqual("{}", mockHttpMessageHandler.Input);
         }
 
       }

--- a/Adyen.Test/HttpClientWrapperTest.cs
+++ b/Adyen.Test/HttpClientWrapperTest.cs
@@ -19,7 +19,7 @@ namespace Adyen.Test
             var mockHttpMessageHandler = new MockHttpMessageHandler("{}", System.Net.HttpStatusCode.OK);
             var httpClient = new System.Net.Http.HttpClient(mockHttpMessageHandler);
             var httpClientWrapper = new HttpClientWrapper(MockPaymentData.CreateConfigApiKeyBasedMock(), httpClient);
-            var _ = httpClientWrapper.Request("/test", null, null, HttpMethod.Post);
+            var _ = httpClientWrapper.Request("https://test.com/testpath", null, null, HttpMethod.Post);
             Assert.Equals(mockHttpMessageHandler.Input, "{}");
         }
 

--- a/Adyen.Test/HttpClientWrapperTest.cs
+++ b/Adyen.Test/HttpClientWrapperTest.cs
@@ -20,7 +20,7 @@ namespace Adyen.Test
             var httpClient = new System.Net.Http.HttpClient(mockHttpMessageHandler);
             var httpClientWrapper = new HttpClientWrapper(MockPaymentData.CreateConfigApiKeyBasedMock(), httpClient);
             var _ = httpClientWrapper.Request("https://test.com/testpath", null, null, HttpMethod.Post);
-            Assert.Equals(mockHttpMessageHandler.Input, "{}");
+            Assert.AreEqual(mockHttpMessageHandler.Input, "{}");
         }
 
       }

--- a/Adyen.Test/HttpClientWrapperTest.cs
+++ b/Adyen.Test/HttpClientWrapperTest.cs
@@ -14,12 +14,12 @@ namespace Adyen.Test
     public class HttpClientWrapperTest : BaseTest
     {
         [TestMethod]
-        public void EmptyRequestBodyTest()
+        public void EmptyRequestBodyPostTest()
         {
             var mockHttpMessageHandler = new MockHttpMessageHandler("{}", System.Net.HttpStatusCode.OK);
             var httpClient = new System.Net.Http.HttpClient(mockHttpMessageHandler);
             var httpClientWrapper = new HttpClientWrapper(MockPaymentData.CreateConfigApiKeyBasedMock(), httpClient);
-            var _ = httpClientWrapper.Request("/test", null);
+            var _ = httpClientWrapper.Request("/test", null, null, HttpMethod.Post);
             Assert.Equals(mockHttpMessageHandler.Input, "{}");
         }
 

--- a/Adyen.Test/HttpClientWrapperTest.cs
+++ b/Adyen.Test/HttpClientWrapperTest.cs
@@ -14,12 +14,12 @@ namespace Adyen.Test
     public class HttpClientWrapperTest : BaseTest
     {
         [TestMethod]
-        public async void EmptyRequestBodyTest()
+        public void EmptyRequestBodyTest()
         {
             var mockHttpMessageHandler = new MockHttpMessageHandler("{}", System.Net.HttpStatusCode.OK);
             var httpClient = new System.Net.Http.HttpClient(mockHttpMessageHandler);
             var httpClientWrapper = new HttpClientWrapper(MockPaymentData.CreateConfigApiKeyBasedMock(), httpClient);
-            await httpClientWrapper.RequestAsync("/test",null);
+            var _ = httpClientWrapper.Request("/test", null);
             Assert.Equals(mockHttpMessageHandler.Input, "{}");
         }
 

--- a/Adyen.Test/mockHttpClient.cs
+++ b/Adyen.Test/mockHttpClient.cs
@@ -1,0 +1,34 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class MockHttpMessageHandler : HttpMessageHandler
+{
+    private readonly string _response;
+    private readonly HttpStatusCode _statusCode;
+
+    public string Input { get; private set; }
+    public int NumberOfCalls { get; private set; }
+
+    public MockHttpMessageHandler(string response, HttpStatusCode statusCode)
+    {
+        _response = response;
+        _statusCode = statusCode;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        NumberOfCalls++;
+        if (request.Content != null) // Could be a GET-request without a body
+        {
+            Input = await request.Content.ReadAsStringAsync();
+        }
+        return new HttpResponseMessage
+        {
+            StatusCode = _statusCode,
+            Content = new StringContent(_response)
+        };
+    }
+}

--- a/Adyen/HttpClient/HttpClientWrapper.cs
+++ b/Adyen/HttpClient/HttpClientWrapper.cs
@@ -33,7 +33,7 @@ namespace Adyen.HttpClient
         {
             if (requestBody == null && (httpMethod == HttpMethod.Post || httpMethod == new HttpMethod("PATCH")))
             {
-                requestBody = "";
+                requestBody = "{}";
             }
 
             using (var request = GetHttpRequestMessage(endpoint, requestBody, requestOptions, httpMethod))


### PR DESCRIPTION
**Description**
This fix ensures empty post requests will always get an empty Json string.  

**Tested scenarios**
Unit tests

**Fixed issue**:  #943 
