### PR TITLE
Fix mustache template: Only add the deprecation message to the Obsolete-tag if it exists

### DIFF
--- a/templates/csharp/api-single.mustache
+++ b/templates/csharp/api-single.mustache
@@ -23,7 +23,7 @@ namespace {{packageName}}.Service
         /// <returns><see cref="{{{returnType}}}"/>.</returns>
         {{/returnType}}
         {{#isDeprecated}}
-        [Obsolete]
+        [Obsolete{{#vendorExtensions.x-deprecatedInVersion}}("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} - {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}"){{/vendorExtensions.x-deprecatedInVersion}}]
         {{/isDeprecated}}
         {{#returnType}}{{modelPackage}}.{{{.}}}{{/returnType}}{{^returnType}}void{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}({{>api_parameters}});
         
@@ -32,7 +32,7 @@ namespace {{packageName}}.Service
         /// <param name="cancellationToken"> A CancellationToken enables cooperative cancellation between threads, thread pool work items, or Task objects.</param>{{#returnType}}
         /// <returns>Task of <see cref="{{{returnType}}}{{^returnType}}void{{/returnType}}"/>.</returns>{{/returnType}}
         {{#isDeprecated}}
-        [Obsolete]
+        [Obsolete{{#vendorExtensions.x-deprecatedInVersion}}("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} - {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}"){{/vendorExtensions.x-deprecatedInVersion}}]
         {{/isDeprecated}}
         {{#returnType}}Task<{{modelPackage}}.{{{.}}}>{{/returnType}}{{^returnType}}Task{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}Async({{>api_parameters_async}});
         
@@ -56,7 +56,7 @@ namespace {{packageName}}.Service
         {{#operation}}
         
         {{#isDeprecated}}
-        [Obsolete]
+        [Obsolete{{#vendorExtensions.x-deprecatedInVersion}}("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} - {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}"){{/vendorExtensions.x-deprecatedInVersion}}]
         {{/isDeprecated}}
         public {{#returnType}}{{modelPackage}}.{{{.}}}{{/returnType}}{{^returnType}}void{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}({{>api_parameters}})
         {
@@ -65,7 +65,7 @@ namespace {{packageName}}.Service
 
         {{#supportsAsync}}
         {{#isDeprecated}}
-        [Obsolete]
+        [Obsolete{{#vendorExtensions.x-deprecatedInVersion}}("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} - {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}"){{/vendorExtensions.x-deprecatedInVersion}}]
         {{/isDeprecated}}
         {{#returnType}}public async Task<{{modelPackage}}.{{{.}}}>{{/returnType}}{{^returnType}}public async Task{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}Async({{>api_parameters_async}})
         {

--- a/templates/csharp/api-single.mustache
+++ b/templates/csharp/api-single.mustache
@@ -23,7 +23,7 @@ namespace {{packageName}}.Service
         /// <returns><see cref="{{{returnType}}}"/>.</returns>
         {{/returnType}}
         {{#isDeprecated}}
-        [Obsolete{{#vendorExtensions.x-deprecatedInVersion}}("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} - {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}"){{/vendorExtensions.x-deprecatedInVersion}}]
+        [Obsolete("{{#vendorExtensions.x-deprecatedInVersion}}Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}.{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}")]
         {{/isDeprecated}}
         {{#returnType}}{{modelPackage}}.{{{.}}}{{/returnType}}{{^returnType}}void{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}({{>api_parameters}});
         
@@ -32,7 +32,7 @@ namespace {{packageName}}.Service
         /// <param name="cancellationToken"> A CancellationToken enables cooperative cancellation between threads, thread pool work items, or Task objects.</param>{{#returnType}}
         /// <returns>Task of <see cref="{{{returnType}}}{{^returnType}}void{{/returnType}}"/>.</returns>{{/returnType}}
         {{#isDeprecated}}
-        [Obsolete{{#vendorExtensions.x-deprecatedInVersion}}("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} - {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}"){{/vendorExtensions.x-deprecatedInVersion}}]
+        [Obsolete("{{#vendorExtensions.x-deprecatedInVersion}}Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}.{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}")]
         {{/isDeprecated}}
         {{#returnType}}Task<{{modelPackage}}.{{{.}}}>{{/returnType}}{{^returnType}}Task{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}Async({{>api_parameters_async}});
         
@@ -56,7 +56,7 @@ namespace {{packageName}}.Service
         {{#operation}}
         
         {{#isDeprecated}}
-        [Obsolete{{#vendorExtensions.x-deprecatedInVersion}}("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} - {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}"){{/vendorExtensions.x-deprecatedInVersion}}]
+        [Obsolete("{{#vendorExtensions.x-deprecatedInVersion}}Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}.{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}")]
         {{/isDeprecated}}
         public {{#returnType}}{{modelPackage}}.{{{.}}}{{/returnType}}{{^returnType}}void{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}({{>api_parameters}})
         {
@@ -65,7 +65,7 @@ namespace {{packageName}}.Service
 
         {{#supportsAsync}}
         {{#isDeprecated}}
-        [Obsolete{{#vendorExtensions.x-deprecatedInVersion}}("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} - {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}"){{/vendorExtensions.x-deprecatedInVersion}}]
+        [Obsolete("{{#vendorExtensions.x-deprecatedInVersion}}Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}.{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}")]
         {{/isDeprecated}}
         {{#returnType}}public async Task<{{modelPackage}}.{{{.}}}>{{/returnType}}{{^returnType}}public async Task{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}Async({{>api_parameters_async}})
         {

--- a/templates/csharp/api.mustache
+++ b/templates/csharp/api.mustache
@@ -22,7 +22,7 @@ namespace {{packageName}}.{{apiPackage}}
         /// <returns><see cref="{{{returnType}}}"/>.</returns>
         {{/returnType}}
         {{#isDeprecated}}
-        [Obsolete]
+        [Obsolete{{#vendorExtensions.x-deprecatedInVersion}}("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} - {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}"){{/vendorExtensions.x-deprecatedInVersion}}]
         {{/isDeprecated}}
         {{#returnType}}{{modelPackage}}.{{{.}}}{{/returnType}}{{^returnType}}void{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}({{>api_parameters}});
         
@@ -31,7 +31,7 @@ namespace {{packageName}}.{{apiPackage}}
         /// <param name="cancellationToken"> A CancellationToken enables cooperative cancellation between threads, thread pool work items, or Task objects.</param>{{#returnType}}
         /// <returns>Task of <see cref="{{{returnType}}}{{^returnType}}void{{/returnType}}"/>.</returns>{{/returnType}}
         {{#isDeprecated}}
-        [Obsolete]
+        [Obsolete{{#vendorExtensions.x-deprecatedInVersion}}("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} - {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}"){{/vendorExtensions.x-deprecatedInVersion}}]
         {{/isDeprecated}}
         {{#returnType}}Task<{{modelPackage}}.{{{.}}}>{{/returnType}}{{^returnType}}Task{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}Async({{>api_parameters_async}});
         
@@ -55,7 +55,7 @@ namespace {{packageName}}.{{apiPackage}}
         {{#operation}}
         
         {{#isDeprecated}}
-        [Obsolete]
+        [Obsolete{{#vendorExtensions.x-deprecatedInVersion}}("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} - {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}"){{/vendorExtensions.x-deprecatedInVersion}}]
         {{/isDeprecated}}
         public {{#returnType}}{{modelPackage}}.{{{.}}}{{/returnType}}{{^returnType}}void{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}({{>api_parameters}})
         {
@@ -64,7 +64,7 @@ namespace {{packageName}}.{{apiPackage}}
 
         {{#supportsAsync}}
         {{#isDeprecated}}
-        [Obsolete]
+        [Obsolete{{#vendorExtensions.x-deprecatedInVersion}}("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} - {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}"){{/vendorExtensions.x-deprecatedInVersion}}]
         {{/isDeprecated}}
         {{#returnType}}public async Task<{{modelPackage}}.{{{.}}}>{{/returnType}}{{^returnType}}public async Task{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}Async({{>api_parameters_async}})
         {

--- a/templates/csharp/api.mustache
+++ b/templates/csharp/api.mustache
@@ -22,7 +22,7 @@ namespace {{packageName}}.{{apiPackage}}
         /// <returns><see cref="{{{returnType}}}"/>.</returns>
         {{/returnType}}
         {{#isDeprecated}}
-        [Obsolete{{#vendorExtensions.x-deprecatedInVersion}}("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} - {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}"){{/vendorExtensions.x-deprecatedInVersion}}]
+        [Obsolete("{{#vendorExtensions.x-deprecatedInVersion}}Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}.{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}")]
         {{/isDeprecated}}
         {{#returnType}}{{modelPackage}}.{{{.}}}{{/returnType}}{{^returnType}}void{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}({{>api_parameters}});
         
@@ -31,7 +31,7 @@ namespace {{packageName}}.{{apiPackage}}
         /// <param name="cancellationToken"> A CancellationToken enables cooperative cancellation between threads, thread pool work items, or Task objects.</param>{{#returnType}}
         /// <returns>Task of <see cref="{{{returnType}}}{{^returnType}}void{{/returnType}}"/>.</returns>{{/returnType}}
         {{#isDeprecated}}
-        [Obsolete{{#vendorExtensions.x-deprecatedInVersion}}("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} - {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}"){{/vendorExtensions.x-deprecatedInVersion}}]
+        [Obsolete("{{#vendorExtensions.x-deprecatedInVersion}}Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}.{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}")]
         {{/isDeprecated}}
         {{#returnType}}Task<{{modelPackage}}.{{{.}}}>{{/returnType}}{{^returnType}}Task{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}Async({{>api_parameters_async}});
         
@@ -55,7 +55,7 @@ namespace {{packageName}}.{{apiPackage}}
         {{#operation}}
         
         {{#isDeprecated}}
-        [Obsolete{{#vendorExtensions.x-deprecatedInVersion}}("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} - {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}"){{/vendorExtensions.x-deprecatedInVersion}}]
+        [Obsolete("{{#vendorExtensions.x-deprecatedInVersion}}Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}.{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}")]
         {{/isDeprecated}}
         public {{#returnType}}{{modelPackage}}.{{{.}}}{{/returnType}}{{^returnType}}void{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}({{>api_parameters}})
         {
@@ -64,7 +64,7 @@ namespace {{packageName}}.{{apiPackage}}
 
         {{#supportsAsync}}
         {{#isDeprecated}}
-        [Obsolete{{#vendorExtensions.x-deprecatedInVersion}}("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} - {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}"){{/vendorExtensions.x-deprecatedInVersion}}]
+        [Obsolete("{{#vendorExtensions.x-deprecatedInVersion}}Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}.{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}")]
         {{/isDeprecated}}
         {{#returnType}}public async Task<{{modelPackage}}.{{{.}}}>{{/returnType}}{{^returnType}}public async Task{{/returnType}} {{#lambda.pascalcase}}{{vendorExtensions.x-methodName}}{{/lambda.pascalcase}}Async({{>api_parameters_async}})
         {

--- a/templates/csharp/modelGeneric.mustache
+++ b/templates/csharp/modelGeneric.mustache
@@ -40,7 +40,7 @@
         {{^conditionalSerialization}}
         [DataMember(Name = "{{baseName}}"{{#required}}, IsRequired = false{{/required}}, EmitDefaultValue = {{#vendorExtensions.x-emit-default-value}}true{{/vendorExtensions.x-emit-default-value}}{{^vendorExtensions.x-emit-default-value}}{{#required}}false{{/required}}{{^required}}{{#isBoolean}}false{{/isBoolean}}{{^isBoolean}}{{#isNullable}}false{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{/isBoolean}}{{/required}}{{/vendorExtensions.x-emit-default-value}})]
         {{#deprecated}}
-        [Obsolete("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}} - {{#vendorExtensions.x-deprecatedMessage}}{{{.}}}{{/vendorExtensions.x-deprecatedMessage}}")]
+        [Obsolete{{#vendorExtensions.x-deprecatedInVersion}}("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} - {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}"){{/vendorExtensions.x-deprecatedInVersion}}]
         {{/deprecated}}
         public {{{complexType}}}{{^complexType}}{{{datatypeWithEnum}}}{{/complexType}}{{^isContainer}}{{^required}}?{{/required}}{{/isContainer}} {{name}} { get; set; }
         {{#isReadOnly}}
@@ -59,7 +59,7 @@
         {{#isReadOnly}}
         [DataMember(Name = "{{baseName}}"{{#required}}, IsRequired = false{{/required}}, EmitDefaultValue = {{#vendorExtensions.x-emit-default-value}}true{{/vendorExtensions.x-emit-default-value}}{{^vendorExtensions.x-emit-default-value}}{{#required}}false{{/required}}{{^required}}{{#isBoolean}}false{{/isBoolean}}{{^isBoolean}}{{#isNullable}}false{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{/isBoolean}}{{/required}}{{/vendorExtensions.x-emit-default-value}})]
         {{#deprecated}}
-        [Obsolete("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}} - {{#vendorExtensions.x-deprecatedMessage}}{{{.}}}{{/vendorExtensions.x-deprecatedMessage}}")]
+        [Obsolete{{#vendorExtensions.x-deprecatedInVersion}}("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} - {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}"){{/vendorExtensions.x-deprecatedInVersion}}]
         {{/deprecated}}
         public {{{complexType}}}{{^complexType}}{{{datatypeWithEnum}}}{{/complexType}}{{^isContainer}}{{^required}}?{{/required}}{{/isContainer}} {{name}} { get; set; }
 
@@ -76,7 +76,7 @@
         {{^isReadOnly}}
         [DataMember(Name = "{{baseName}}"{{#required}}, IsRequired = false{{/required}}, EmitDefaultValue = {{#vendorExtensions.x-emit-default-value}}true{{/vendorExtensions.x-emit-default-value}}{{^vendorExtensions.x-emit-default-value}}{{#required}}true{{/required}}{{^required}}{{#isBoolean}}false{{/isBoolean}}{{^isBoolean}}{{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{/isBoolean}}{{/required}}{{/vendorExtensions.x-emit-default-value}})]
         {{#deprecated}}
-        [Obsolete("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}} - {{#vendorExtensions.x-deprecatedMessage}}{{{.}}}{{/vendorExtensions.x-deprecatedMessage}}")]
+        [Obsolete{{#vendorExtensions.x-deprecatedInVersion}}("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} - {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}"){{/vendorExtensions.x-deprecatedInVersion}}]
         {{/deprecated}}
         public {{{complexType}}}{{^complexType}}{{{datatypeWithEnum}}}{{/complexType}}{{^isContainer}}{{^required}}?{{/required}}{{/isContainer}} {{name}}
         {
@@ -203,7 +203,7 @@
         [JsonConverter(typeof(OpenAPIDateConverter))]
         {{/isDate}}
         {{#deprecated}}
-        [Obsolete("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}} - {{#vendorExtensions.x-deprecatedMessage}}{{{.}}}{{/vendorExtensions.x-deprecatedMessage}}")]
+        [Obsolete{{#vendorExtensions.x-deprecatedInVersion}}("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} - {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}"){{/vendorExtensions.x-deprecatedInVersion}}]
         {{/deprecated}}
         public {{{dataType}}}{{#isNumeric}}?{{/isNumeric}}{{#isBoolean}}{{^isNullable}}?{{/isNullable}}{{/isBoolean}} {{name}} { get; {{#isReadOnly}}private {{/isReadOnly}}set; }
 
@@ -215,7 +215,7 @@
         [JsonConverter(typeof(OpenAPIDateConverter))]
         {{/isDate}}
         {{#deprecated}}
-        [Obsolete("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}} - {{#vendorExtensions.x-deprecatedMessage}}{{{.}}}{{/vendorExtensions.x-deprecatedMessage}}")]
+        [Obsolete{{#vendorExtensions.x-deprecatedInVersion}}("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} - {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}"){{/vendorExtensions.x-deprecatedInVersion}}]
         {{/deprecated}}
         public {{{dataType}}} {{name}} { get; private set; }
 
@@ -226,7 +226,7 @@
         {{/isDate}}
         [DataMember(Name = "{{baseName}}"{{#required}}, IsRequired = false{{/required}}, EmitDefaultValue = {{#vendorExtensions.x-emit-default-value}}true{{/vendorExtensions.x-emit-default-value}}{{^vendorExtensions.x-emit-default-value}}{{#required}}false{{/required}}{{^required}}{{#isBoolean}}false{{/isBoolean}}{{^isBoolean}}{{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{/isBoolean}}{{/required}}{{/vendorExtensions.x-emit-default-value}})]
         {{#deprecated}}
-        [Obsolete("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}} - {{#vendorExtensions.x-deprecatedMessage}}{{{.}}}{{/vendorExtensions.x-deprecatedMessage}}")]
+        [Obsolete{{#vendorExtensions.x-deprecatedInVersion}}("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} - {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}"){{/vendorExtensions.x-deprecatedInVersion}}]
         {{/deprecated}}
         public {{{dataType}}} {{name}}
         {

--- a/templates/csharp/modelGeneric.mustache
+++ b/templates/csharp/modelGeneric.mustache
@@ -40,7 +40,7 @@
         {{^conditionalSerialization}}
         [DataMember(Name = "{{baseName}}"{{#required}}, IsRequired = false{{/required}}, EmitDefaultValue = {{#vendorExtensions.x-emit-default-value}}true{{/vendorExtensions.x-emit-default-value}}{{^vendorExtensions.x-emit-default-value}}{{#required}}false{{/required}}{{^required}}{{#isBoolean}}false{{/isBoolean}}{{^isBoolean}}{{#isNullable}}false{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{/isBoolean}}{{/required}}{{/vendorExtensions.x-emit-default-value}})]
         {{#deprecated}}
-        [Obsolete{{#vendorExtensions.x-deprecatedInVersion}}("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} - {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}"){{/vendorExtensions.x-deprecatedInVersion}}]
+        [Obsolete("{{#vendorExtensions.x-deprecatedInVersion}}Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}.{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}")]
         {{/deprecated}}
         public {{{complexType}}}{{^complexType}}{{{datatypeWithEnum}}}{{/complexType}}{{^isContainer}}{{^required}}?{{/required}}{{/isContainer}} {{name}} { get; set; }
         {{#isReadOnly}}
@@ -59,7 +59,7 @@
         {{#isReadOnly}}
         [DataMember(Name = "{{baseName}}"{{#required}}, IsRequired = false{{/required}}, EmitDefaultValue = {{#vendorExtensions.x-emit-default-value}}true{{/vendorExtensions.x-emit-default-value}}{{^vendorExtensions.x-emit-default-value}}{{#required}}false{{/required}}{{^required}}{{#isBoolean}}false{{/isBoolean}}{{^isBoolean}}{{#isNullable}}false{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{/isBoolean}}{{/required}}{{/vendorExtensions.x-emit-default-value}})]
         {{#deprecated}}
-        [Obsolete{{#vendorExtensions.x-deprecatedInVersion}}("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} - {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}"){{/vendorExtensions.x-deprecatedInVersion}}]
+        [Obsolete("{{#vendorExtensions.x-deprecatedInVersion}}Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}.{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}")]
         {{/deprecated}}
         public {{{complexType}}}{{^complexType}}{{{datatypeWithEnum}}}{{/complexType}}{{^isContainer}}{{^required}}?{{/required}}{{/isContainer}} {{name}} { get; set; }
 
@@ -76,7 +76,7 @@
         {{^isReadOnly}}
         [DataMember(Name = "{{baseName}}"{{#required}}, IsRequired = false{{/required}}, EmitDefaultValue = {{#vendorExtensions.x-emit-default-value}}true{{/vendorExtensions.x-emit-default-value}}{{^vendorExtensions.x-emit-default-value}}{{#required}}true{{/required}}{{^required}}{{#isBoolean}}false{{/isBoolean}}{{^isBoolean}}{{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{/isBoolean}}{{/required}}{{/vendorExtensions.x-emit-default-value}})]
         {{#deprecated}}
-        [Obsolete{{#vendorExtensions.x-deprecatedInVersion}}("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} - {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}"){{/vendorExtensions.x-deprecatedInVersion}}]
+        [Obsolete("{{#vendorExtensions.x-deprecatedInVersion}}Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}.{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}")]
         {{/deprecated}}
         public {{{complexType}}}{{^complexType}}{{{datatypeWithEnum}}}{{/complexType}}{{^isContainer}}{{^required}}?{{/required}}{{/isContainer}} {{name}}
         {
@@ -203,7 +203,7 @@
         [JsonConverter(typeof(OpenAPIDateConverter))]
         {{/isDate}}
         {{#deprecated}}
-        [Obsolete{{#vendorExtensions.x-deprecatedInVersion}}("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} - {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}"){{/vendorExtensions.x-deprecatedInVersion}}]
+        [Obsolete("{{#vendorExtensions.x-deprecatedInVersion}}Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}.{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}")]
         {{/deprecated}}
         public {{{dataType}}}{{#isNumeric}}?{{/isNumeric}}{{#isBoolean}}{{^isNullable}}?{{/isNullable}}{{/isBoolean}} {{name}} { get; {{#isReadOnly}}private {{/isReadOnly}}set; }
 
@@ -215,7 +215,7 @@
         [JsonConverter(typeof(OpenAPIDateConverter))]
         {{/isDate}}
         {{#deprecated}}
-        [Obsolete{{#vendorExtensions.x-deprecatedInVersion}}("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} - {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}"){{/vendorExtensions.x-deprecatedInVersion}}]
+        [Obsolete("{{#vendorExtensions.x-deprecatedInVersion}}Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}.{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}")]
         {{/deprecated}}
         public {{{dataType}}} {{name}} { get; private set; }
 
@@ -226,7 +226,7 @@
         {{/isDate}}
         [DataMember(Name = "{{baseName}}"{{#required}}, IsRequired = false{{/required}}, EmitDefaultValue = {{#vendorExtensions.x-emit-default-value}}true{{/vendorExtensions.x-emit-default-value}}{{^vendorExtensions.x-emit-default-value}}{{#required}}false{{/required}}{{^required}}{{#isBoolean}}false{{/isBoolean}}{{^isBoolean}}{{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{/isBoolean}}{{/required}}{{/vendorExtensions.x-emit-default-value}})]
         {{#deprecated}}
-        [Obsolete{{#vendorExtensions.x-deprecatedInVersion}}("Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} - {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}"){{/vendorExtensions.x-deprecatedInVersion}}]
+        [Obsolete("{{#vendorExtensions.x-deprecatedInVersion}}Deprecated since {{#appName}}{{{.}}}{{/appName}} v{{#vendorExtensions.x-deprecatedInVersion}}{{.}}{{/vendorExtensions.x-deprecatedInVersion}}.{{/vendorExtensions.x-deprecatedInVersion}}{{#vendorExtensions.x-deprecatedMessage}} {{{.}}}{{/vendorExtensions.x-deprecatedMessage}}")]
         {{/deprecated}}
         public {{{dataType}}} {{name}}
         {


### PR DESCRIPTION
**Description**
This PR addresses the `[Obsolete]`-tag in the model and service mustache templates. These should only be shown if the message is available in the specs. 

**Tested scenarios**

Example with `CardDetails.cupsecureplusSmscode` 

**Before:**
```csharp
[Obsolete("Deprecated since Adyen Checkout API v -")]
```

**After:**
```csharp
[Obsolete("")]
```
_I kept the template easy-to-read, I didn't want to make an exception for the empty case, e.g. just`[Obsolete]` without the double quotes and brackets `("")`_

___

**Example with just the deprecation version:**
```csharp
[Obsolete("Deprecated since Adyen Checkout API v37.")]
        Model.Checkout.PaymentSetupResponse PaymentSession(PaymentSetupRequest paymentSetupRequest = default, RequestOptions requestOptions = default);
```

___

**Example with the deprecation message and version:**
```csharp
[Obsolete("Deprecated since Adyen Checkout API v49. Use `storedPaymentMethodId` instead.")]
        public string RecurringDetailReference { get; set; }
```        
