### PR TITLE
CodeQL job now only runs on schedule

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,8 +1,6 @@
 name: "Code scanning - action"
 
 on:
-  push:
-  pull_request:
   schedule:
     - cron: '0 1 * * 0'
 


### PR DESCRIPTION
CodeQL job ran on every PR/Push twice, let's save resources
