### PR TITLE
In-person Payments - Adyen HttpClient throws a 400: BadRequest, ResponseBody: {"errors":["At toplevel: Missing"]} 

### DIFF
--- a/Adyen/Service/TerminalApiAsyncService.cs
+++ b/Adyen/Service/TerminalApiAsyncService.cs
@@ -14,36 +14,36 @@ namespace Adyen.Service
     public interface ITerminalApiAsyncService
     {
         /// <summary>
-        /// Sends an encrypted <see cref="SaleToPOIRequest"/> or <see cref="SaleToPOIMessage"/> to the terminal-api `/async` endpoint.
+        /// Sends an encrypted <see cref="SaleToPOIRequest"/> to the terminal-api `/async` endpoint.
         /// </summary>
-        /// <param name="saleToPoiRequest"><see cref="SaleToPOIRequest"/> or <see cref="SaleToPOIMessage"/>.</param>
+        /// <param name="saleToPoiRequest"><see cref="SaleToPOIRequest"/>.</param>
         /// <param name="encryptionCredentialDetails"><see cref="EncryptionCredentialDetails"/>. These must match the credentials that you configured in the Customer Area. Make sure your terminal is updated to latest version.</param>
         /// <param name="cancellationToken"><see cref="CancellationToken"/>.</param>
         /// <returns>A <see cref="Task{TValue}"/> that represents the <see cref="string"/>.</returns>
-        Task<string> RequestEncryptedAsync(SaleToPOIMessage saleToPoiRequest, EncryptionCredentialDetails encryptionCredentialDetails, CancellationToken cancellationToken);
+        Task<string> RequestEncryptedAsync(SaleToPOIRequest saleToPoiRequest, EncryptionCredentialDetails encryptionCredentialDetails, CancellationToken cancellationToken);
         
         /// <summary>
-        /// Sends an encrypted <see cref="SaleToPOIRequest"/> or <see cref="SaleToPOIMessage"/> to the terminal-api `/async` endpoint.
+        /// Sends an encrypted <see cref="SaleToPOIRequest"/> to the terminal-api `/async` endpoint.
         /// </summary>
-        /// <param name="saleToPoiRequest"><see cref="SaleToPOIRequest"/> or <see cref="SaleToPOIMessage"/>.</param>
+        /// <param name="saleToPoiRequest"><see cref="SaleToPOIRequest"/>.</param>
         /// <param name="encryptionCredentialDetails"><see cref="EncryptionCredentialDetails"/>. These must match the credentials that you configured in the Customer Area. Make sure your terminal is updated to latest version.</param>
         /// <returns>Response <see cref="string"/>.</returns>
-        string RequestEncrypted(SaleToPOIMessage saleToPoiRequest, EncryptionCredentialDetails encryptionCredentialDetails);
+        string RequestEncrypted(SaleToPOIRequest saleToPoiRequest, EncryptionCredentialDetails encryptionCredentialDetails);
         
         /// <summary>
-        /// Sends a <see cref="SaleToPOIRequest"/> or <see cref="SaleToPOIMessage"/> to the terminal-api `/async` endpoint.
+        /// Sends a <see cref="SaleToPOIRequest"/> to the terminal-api `/async` endpoint.
         /// </summary>
-        /// <param name="saleToPoiRequest"><see cref="SaleToPOIRequest"/> or <see cref="SaleToPOIMessage"/>.</param>
+        /// <param name="saleToPoiRequest"><see cref="SaleToPOIRequest"/>.</param>
         /// <param name="cancellationToken"><see cref="CancellationToken"/>.</param>
         /// <returns>A <see cref="Task{TValue}"/> that represents the <see cref="string"/>.</returns>
-        Task<string> RequestAsync(SaleToPOIMessage saleToPoiRequest, CancellationToken cancellationToken);
+        Task<string> RequestAsync(SaleToPOIRequest saleToPoiRequest, CancellationToken cancellationToken);
         
         /// <summary>
-        /// Sends a <see cref="SaleToPOIRequest"/> or <see cref="SaleToPOIMessage"/> to the terminal-api `/async` endpoint.
+        /// Sends a <see cref="SaleToPOIRequest"/> to the terminal-api `/async` endpoint.
         /// </summary>
-        /// <param name="saleToPoiRequest"><see cref="SaleToPOIRequest"/> or <see cref="SaleToPOIMessage"/>.</param>
+        /// <param name="saleToPoiRequest"><see cref="SaleToPOIRequest"/>.</param>
         /// <returns>Response <see cref="string"/>.</returns>
-        string Request(SaleToPOIMessage saleToPoiRequest);
+        string Request(SaleToPOIRequest saleToPoiRequest);
 
         /// <summary>
         /// Used to decrypt the notification received.
@@ -76,7 +76,7 @@ namespace Adyen.Service
         }
         
         /// <inheritdoc/>
-        public async Task<string> RequestEncryptedAsync(SaleToPOIMessage saleToPoiRequest, EncryptionCredentialDetails encryptionCredentialDetails, CancellationToken cancellationToken)
+        public async Task<string> RequestEncryptedAsync(SaleToPOIRequest saleToPoiRequest, EncryptionCredentialDetails encryptionCredentialDetails, CancellationToken cancellationToken)
         {
             string serializedMessage = _saleToPoiMessageSerializer.Serialize(saleToPoiRequest);
             Client.LogLine("Request: \n"+ serializedMessage);
@@ -88,7 +88,7 @@ namespace Adyen.Service
         }
         
         /// <inheritdoc/>
-        public  string RequestEncrypted(SaleToPOIMessage saleToPoiRequest, EncryptionCredentialDetails encryptionCredentialDetails)
+        public  string RequestEncrypted(SaleToPOIRequest saleToPoiRequest, EncryptionCredentialDetails encryptionCredentialDetails)
         {
             string serializedMessage = _saleToPoiMessageSerializer.Serialize(saleToPoiRequest);
             Client.LogLine("Request: \n"+ serializedMessage);
@@ -100,7 +100,7 @@ namespace Adyen.Service
         }
 
         /// <inheritdoc/> 
-        public async Task<string> RequestAsync(SaleToPOIMessage saleToPoiRequest, CancellationToken cancellationToken)
+        public async Task<string> RequestAsync(SaleToPOIRequest saleToPoiRequest, CancellationToken cancellationToken)
         {
             string serializedMessage = _saleToPoiMessageSerializer.Serialize(saleToPoiRequest);
             Client.LogLine("Request: \n" + serializedMessage);
@@ -110,7 +110,7 @@ namespace Adyen.Service
         }
         
         /// <inheritdoc/> 
-        public string Request(SaleToPOIMessage saleToPoiRequest)
+        public string Request(SaleToPOIRequest saleToPoiRequest)
         {
             string serializedMessage = _saleToPoiMessageSerializer.Serialize(saleToPoiRequest);
             Client.LogLine("Request: \n" + serializedMessage);

--- a/Adyen/Service/TerminalApiLocalService.cs
+++ b/Adyen/Service/TerminalApiLocalService.cs
@@ -14,26 +14,26 @@ namespace Adyen.Service
     public interface ITerminalApiLocalService
     {
         /// <summary>
-        /// Sends an encrypted <see cref="SaleToPOIRequest"/> or <see cref="SaleToPOIMessage"/> to the endpoint specified in <see cref="Config.LocalTerminalApiEndpoint"/> (e.g. `https://198.51.100.1:8443/nexo`).
+        /// Sends an encrypted <see cref="SaleToPOIRequest"/> to the endpoint specified in <see cref="Config.LocalTerminalApiEndpoint"/> (e.g. `https://198.51.100.1:8443/nexo`).
         /// To protect local communications, you need to add and validate Adyen's certificate (see docs) and encrypt your messages.
         /// </summary>
-        /// <param name="saleToPoiRequest"><see cref="SaleToPOIRequest"/> or <see cref="SaleToPOIMessage"/>.</param>
+        /// <param name="saleToPoiRequest"><see cref="SaleToPOIRequest"/>.</param>
         /// <param name="encryptionCredentialDetails"><see cref="EncryptionCredentialDetails"/>. These must match the credentials that you configured in the Customer Area. Make sure your terminal is updated to latest version.</param>
         /// <param name="cancellationToken"><see cref="CancellationToken"/>.</param>
         /// <returns>A <see cref="Task{TValue}"/> that represents the <see cref="SaleToPOIResponse"/>.</returns>
-        Task<SaleToPOIResponse> RequestEncryptedAsync(SaleToPOIMessage saleToPoiRequest, EncryptionCredentialDetails encryptionCredentialDetails, CancellationToken cancellationToken);
+        Task<SaleToPOIResponse> RequestEncryptedAsync(SaleToPOIRequest saleToPoiRequest, EncryptionCredentialDetails encryptionCredentialDetails, CancellationToken cancellationToken);
         
         /// <summary>
-        /// Sends an encrypted <see cref="SaleToPOIRequest"/> or <see cref="SaleToPOIMessage"/> to the endpoint specified in <see cref="Config.LocalTerminalApiEndpoint"/> (e.g. `https://198.51.100.1:8443/nexo`).
+        /// Sends an encrypted <see cref="SaleToPOIRequest"/> to the endpoint specified in <see cref="Config.LocalTerminalApiEndpoint"/> (e.g. `https://198.51.100.1:8443/nexo`).
         /// To protect local communications, you need to add and validate Adyen's certificate (see docs) and encrypt your messages.
         /// </summary>
-        /// <param name="saleToPoiRequest"><see cref="SaleToPOIRequest"/> or <see cref="SaleToPOIMessage"/>.</param>
+        /// <param name="saleToPoiRequest"><see cref="SaleToPOIRequest"/>.</param>
         /// <param name="encryptionCredentialDetails"><see cref="EncryptionCredentialDetails"/>. These must match the credentials that you configured in the Customer Area. Make sure your terminal is updated to latest version.</param>
         /// <returns><see cref="SaleToPOIResponse"/>.</returns>
-        SaleToPOIResponse RequestEncrypted(SaleToPOIMessage saleToPoiRequest, EncryptionCredentialDetails encryptionCredentialDetails);
+        SaleToPOIResponse RequestEncrypted(SaleToPOIRequest saleToPoiRequest, EncryptionCredentialDetails encryptionCredentialDetails);
 
         /// <summary>
-        /// Sends a <see cref="SaleToPOIRequest"/> or <see cref="SaleToPOIMessage"/> to the endpoint specified in <see cref="Config.LocalTerminalApiEndpoint"/> (e.g. `https://198.51.100.1:8443/nexo`) .
+        /// Sends a <see cref="SaleToPOIRequest"/> to the endpoint specified in <see cref="Config.LocalTerminalApiEndpoint"/> (e.g. `https://198.51.100.1:8443/nexo`) .
         /// If you want to send unencrypted requests for local testing purposes, override the <see cref="System.Net.Http.HttpClientHandler"/> that is passed in the constructor of <see cref="System.Net.Http.HttpClient"/>.
         ///
         /// Example:
@@ -41,13 +41,13 @@ namespace Adyen.Service
         /// var httpClient = new <see cref="Adyen.Client"/>(<see cref="Adyen.Config"/>, new <see cref="System.Net.Http.HttpClient"/>(handler));
         /// var terminalApiLocalService = new <see cref="TerminalApiLocalService"/>(httpClient, <see cref="SaleToPoiMessageSerializer"/>, <see cref="SaleToPoiMessageSecuredEncryptor"/>, <see cref="SaleToPoiMessageSecuredSerializer"/>);
         /// </summary>
-        /// <param name="saleToPoiRequest"><see cref="SaleToPOIRequest"/> or <see cref="SaleToPOIMessage"/>.</param>
+        /// <param name="saleToPoiRequest"><see cref="SaleToPOIRequest"/>.</param>
         /// <param name="cancellationToken"><see cref="CancellationToken"/>.</param>
         /// <returns>A <see cref="Task{TValue}"/> that represents the <see cref="SaleToPOIResponse"/>.</returns>
-        Task<SaleToPOIResponse> RequestAsync(SaleToPOIMessage saleToPoiRequest, CancellationToken cancellationToken);
+        Task<SaleToPOIResponse> RequestAsync(SaleToPOIRequest saleToPoiRequest, CancellationToken cancellationToken);
         
         /// <summary>
-        /// Sends a <see cref="SaleToPOIRequest"/> or <see cref="SaleToPOIMessage"/> to the endpoint specified in <see cref="Config.LocalTerminalApiEndpoint"/> (e.g. `https://198.51.100.1:8443/nexo`).
+        /// Sends a <see cref="SaleToPOIRequest"/> to the endpoint specified in <see cref="Config.LocalTerminalApiEndpoint"/> (e.g. `https://198.51.100.1:8443/nexo`).
         /// If you want to send unencrypted requests for local testing purposes, override the <see cref="System.Net.Http.HttpClientHandler"/> that is passed in the constructor of <see cref="System.Net.Http.HttpClient"/>.
         ///
         /// Example:
@@ -55,9 +55,9 @@ namespace Adyen.Service
         /// var httpClient = new <see cref="Adyen.Client"/>(<see cref="Adyen.Config"/>, new <see cref="System.Net.Http.HttpClient"/>(handler));
         /// var terminalApiLocalService = new <see cref="TerminalApiLocalService"/>(httpClient, <see cref="SaleToPoiMessageSerializer"/>, <see cref="SaleToPoiMessageSecuredEncryptor"/>, <see cref="SaleToPoiMessageSecuredSerializer"/>);
         /// </summary>
-        /// <param name="saleToPoiRequest"><see cref="SaleToPOIRequest"/> or <see cref="SaleToPOIMessage"/>.</param>
+        /// <param name="saleToPoiRequest"><see cref="SaleToPOIRequest"/>.</param>
         /// <returns><see cref="SaleToPOIResponse"/>.</returns>
-        SaleToPOIResponse Request(SaleToPOIMessage saleToPoiRequest);
+        SaleToPOIResponse Request(SaleToPOIRequest saleToPoiRequest);
 
         /// <summary>
         /// Decrypts a <see cref="SaleToPoiMessageSecured"/> and returns the <see cref="SaleToPOIResponse"/>.
@@ -90,7 +90,7 @@ namespace Adyen.Service
         }
         
         /// <inheritdoc/>
-        public async Task<SaleToPOIResponse> RequestEncryptedAsync(SaleToPOIMessage saleToPoiRequest, EncryptionCredentialDetails encryptionCredentialDetails, CancellationToken cancellationToken)
+        public async Task<SaleToPOIResponse> RequestEncryptedAsync(SaleToPOIRequest saleToPoiRequest, EncryptionCredentialDetails encryptionCredentialDetails, CancellationToken cancellationToken)
         {
             string serializedMessage = _saleToPoiMessageSerializer.Serialize(saleToPoiRequest);
             Client.LogLine("Request: \n" + serializedMessage);
@@ -108,7 +108,7 @@ namespace Adyen.Service
         }
            
         /// <inheritdoc/>
-        public SaleToPOIResponse RequestEncrypted(SaleToPOIMessage saleToPoiRequest, EncryptionCredentialDetails encryptionCredentialDetails)
+        public SaleToPOIResponse RequestEncrypted(SaleToPOIRequest saleToPoiRequest, EncryptionCredentialDetails encryptionCredentialDetails)
         {
             string serializedMessage = _saleToPoiMessageSerializer.Serialize(saleToPoiRequest);
             Client.LogLine("Request: \n" + serializedMessage);
@@ -126,7 +126,7 @@ namespace Adyen.Service
         }
         
         /// <inheritdoc/>
-        public async Task<SaleToPOIResponse> RequestAsync(SaleToPOIMessage saleToPoiRequest, CancellationToken cancellationToken)
+        public async Task<SaleToPOIResponse> RequestAsync(SaleToPOIRequest saleToPoiRequest, CancellationToken cancellationToken)
         {
             string serializedMessage = _saleToPoiMessageSerializer.Serialize(saleToPoiRequest);
             Client.LogLine("Request: \n" + serializedMessage);
@@ -140,7 +140,7 @@ namespace Adyen.Service
         }
         
         /// <inheritdoc/>
-        public SaleToPOIResponse Request(SaleToPOIMessage saleToPoiRequest)
+        public SaleToPOIResponse Request(SaleToPOIRequest saleToPoiRequest)
         {
             string serializedMessage = _saleToPoiMessageSerializer.Serialize(saleToPoiRequest);
             Client.LogLine("Request: \n" + serializedMessage);

--- a/Adyen/Service/TerminalApiSyncService.cs
+++ b/Adyen/Service/TerminalApiSyncService.cs
@@ -14,36 +14,36 @@ namespace Adyen.Service
     public interface ITerminalApiSyncService
     {
         /// <summary>
-        /// Sends an encrypted <see cref="SaleToPOIRequest"/> or <see cref="SaleToPOIMessage"/> to the terminal-api `/sync` endpoint.
+        /// Sends an encrypted <see cref="SaleToPOIRequest"/> to the terminal-api `/sync` endpoint.
         /// </summary>
-        /// <param name="saleToPoiRequest"><see cref="SaleToPOIRequest"/> or <see cref="SaleToPOIMessage"/>.</param>
+        /// <param name="saleToPoiRequest"><see cref="SaleToPOIRequest"/>.</param>
         /// <param name="encryptionCredentialDetails"><see cref="EncryptionCredentialDetails"/>. These must match the credentials that you configured in the Customer Area. Make sure your terminal is updated to latest version.</param>
         /// <param name="cancellationToken"><see cref="CancellationToken"/>.</param>
         /// <returns>A <see cref="Task{TValue}"/> that represents the <see cref="SaleToPOIResponse"/>.</returns>
-        Task<SaleToPOIResponse> RequestEncryptedAsync(SaleToPOIMessage saleToPoiRequest, EncryptionCredentialDetails encryptionCredentialDetails, CancellationToken cancellationToken);
+        Task<SaleToPOIResponse> RequestEncryptedAsync(SaleToPOIRequest saleToPoiRequest, EncryptionCredentialDetails encryptionCredentialDetails, CancellationToken cancellationToken);
         
         /// <summary>
-        /// Sends an encrypted <see cref="SaleToPOIRequest"/> or <see cref="SaleToPOIMessage"/> to the terminal-api `/sync` endpoint.
+        /// Sends an encrypted <see cref="SaleToPOIRequest"/> to the terminal-api `/sync` endpoint.
         /// </summary>
-        /// <param name="saleToPoiRequest"><see cref="SaleToPOIRequest"/> or <see cref="SaleToPOIMessage"/>.</param>
+        /// <param name="saleToPoiRequest"><see cref="SaleToPOIRequest"/>.</param>
         /// <param name="encryptionCredentialDetails"><see cref="EncryptionCredentialDetails"/>. These must match the credentials that you configured in the Customer Area. Make sure your terminal is updated to latest version.</param>
         /// <returns><see cref="SaleToPOIResponse"/>.</returns>
-        SaleToPOIResponse RequestEncrypted(SaleToPOIMessage saleToPoiRequest, EncryptionCredentialDetails encryptionCredentialDetails);
+        SaleToPOIResponse RequestEncrypted(SaleToPOIRequest saleToPoiRequest, EncryptionCredentialDetails encryptionCredentialDetails);
 
         /// <summary>
-        /// Sends a <see cref="SaleToPOIRequest"/> or <see cref="SaleToPOIMessage"/> to the terminal-api `/sync` endpoint.
+        /// Sends a <see cref="SaleToPOIRequest"/> to the terminal-api `/sync` endpoint.
         /// </summary>
-        /// <param name="saleToPoiRequest"><see cref="SaleToPOIRequest"/> or <see cref="SaleToPOIMessage"/>.</param>
+        /// <param name="saleToPoiRequest"><see cref="SaleToPOIRequest"/>.</param>
         /// <param name="cancellationToken"><see cref="CancellationToken"/>.</param>
         /// <returns>A <see cref="Task{TValue}"/> that represents the <see cref="SaleToPOIResponse"/>.</returns>
-        Task<SaleToPOIResponse> RequestAsync(SaleToPOIMessage saleToPoiRequest, CancellationToken cancellationToken);
+        Task<SaleToPOIResponse> RequestAsync(SaleToPOIRequest saleToPoiRequest, CancellationToken cancellationToken);
         
         /// <summary>
-        /// Sends a <see cref="SaleToPOIRequest"/> or <see cref="SaleToPOIMessage"/> to the terminal-api `/sync` endpoint.
+        /// Sends a <see cref="SaleToPOIRequest"/> to the terminal-api `/sync` endpoint.
         /// </summary>
-        /// <param name="saleToPoiRequest"><see cref="SaleToPOIRequest"/> or <see cref="SaleToPOIMessage"/>.</param>
+        /// <param name="saleToPoiRequest"><see cref="SaleToPOIRequest"/>.</param>
         /// <returns><see cref="SaleToPOIResponse"/>.</returns>
-        SaleToPOIResponse Request(SaleToPOIMessage saleToPoiRequest);
+        SaleToPOIResponse Request(SaleToPOIRequest saleToPoiRequest);
 
         /// <summary>
         /// Decrypts a <see cref="SaleToPoiMessageSecured"/> and returns the <see cref="SaleToPOIResponse"/>.
@@ -76,7 +76,7 @@ namespace Adyen.Service
         }
         
         /// <inheritdoc/>
-        public async Task<SaleToPOIResponse> RequestEncryptedAsync(SaleToPOIMessage saleToPoiRequest, EncryptionCredentialDetails encryptionCredentialDetails, CancellationToken cancellationToken)
+        public async Task<SaleToPOIResponse> RequestEncryptedAsync(SaleToPOIRequest saleToPoiRequest, EncryptionCredentialDetails encryptionCredentialDetails, CancellationToken cancellationToken)
         {
             string serializedMessage = _saleToPoiMessageSerializer.Serialize(saleToPoiRequest);
             Client.LogLine("Request: \n" + serializedMessage);
@@ -94,7 +94,7 @@ namespace Adyen.Service
         }
            
         /// <inheritdoc/>
-        public SaleToPOIResponse RequestEncrypted(SaleToPOIMessage saleToPoiRequest, EncryptionCredentialDetails encryptionCredentialDetails)
+        public SaleToPOIResponse RequestEncrypted(SaleToPOIRequest saleToPoiRequest, EncryptionCredentialDetails encryptionCredentialDetails)
         {
             string serializedMessage = _saleToPoiMessageSerializer.Serialize(saleToPoiRequest);
             Client.LogLine("Request: \n" + serializedMessage);
@@ -112,7 +112,7 @@ namespace Adyen.Service
         }
         
         /// <inheritdoc/>
-        public async Task<SaleToPOIResponse> RequestAsync(SaleToPOIMessage saleToPoiRequest, CancellationToken cancellationToken)
+        public async Task<SaleToPOIResponse> RequestAsync(SaleToPOIRequest saleToPoiRequest, CancellationToken cancellationToken)
         {
             string serializedMessage = _saleToPoiMessageSerializer.Serialize(saleToPoiRequest);
             Client.LogLine("Request: \n" + serializedMessage);
@@ -126,7 +126,7 @@ namespace Adyen.Service
         }
         
         /// <inheritdoc/>
-        public SaleToPOIResponse Request(SaleToPOIMessage saleToPoiRequest)
+        public SaleToPOIResponse Request(SaleToPOIRequest saleToPoiRequest)
         {
             string serializedMessage = _saleToPoiMessageSerializer.Serialize(saleToPoiRequest);
             Client.LogLine("Request: \n" + serializedMessage);

--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ var client = new Client(config);
 To parse the terminal API notifications, you can use the following custom deserializer. This method will throw an exception for non-notification requests.
 
 ```csharp
-var serializer = new SaleToPoiMessageSerializer();
-var saleToPoiRequest = serializer.DeserializeNotification(your_terminal_notification);
+SaleToPoiMessageSerializer serializer = new SaleToPoiMessageSerializer();
+SaleToPOIRequest saleToPoiRequest = serializer.DeserializeNotification(your_terminal_notification);
 ```
 
 ### Example Cloud Terminal API integration `/sync`-endpoint
@@ -198,7 +198,7 @@ namespace Adyen.Terminal
             var saleID = "SALE_ID";
             var POIID = "SERIAL_NUMBER";
             var transactionID = "123459";
-            var saleToPOIRequest = new SaleToPOIRequest()
+            SaleToPOIRequest saleToPOIRequest = new SaleToPOIRequest()
             {
                 MessageHeader = new MessageHeader()
                 {


### PR DESCRIPTION
**Description**
 Adyen HttpClient throws a 400: BadRequest, ResponseBody: {"errors":["At toplevel: Missing"]} when a `SaleToPoiMessage` is provided as parameter, this PR addresses the overloaded interface

**Tested scenarios**
Terminal-api for: `local` (custom endpoint), `/async` and `/sync` are tested

**Fixed issue**:  <!-- #-prefixed issue number -->
#1077
