### PR TITLE
Change POIStatus.PrinterStatus to be nullable

### DIFF
--- a/Adyen.Test/DeserializerTest.cs
+++ b/Adyen.Test/DeserializerTest.cs
@@ -1,0 +1,32 @@
+﻿using Adyen.ApiSerialization;
+using Adyen.Model.TerminalApi;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Adyen.Test
+{
+    [TestClass]
+    public class DeserializerTest
+    {
+        [TestMethod]
+        public void PrinterStatusSerializerTest()
+        {
+            string GetDiagnosisRequest(string poiStatusJson)
+            {
+                var diagnosisTemplate = "{\"SaleToPOIMessage\":{\"MessageHeader\":{\"MessageClass\":\"Service\",\"MessageCategory\":\"Diagnosis\",\"MessageType\":\"Response\",\"ServiceID\":\"12345678\",\"SaleID\":\"POSSystemID12345\",\"POIID\":\"V400m-284251016\",\"ProtocolVersion\":\"3.0\"},\"DiagnosisResponse\":{\"Response\":{\"Result\":\"Success\"},POI_STATUS,\"HostStatus\":[{\"IsReachableFlag\":true}]}}}";
+                return diagnosisTemplate.Replace("POI_STATUS", poiStatusJson);
+            }
+
+            var saleToPoiMessageSerializer = new SaleToPoiMessageSerializer();
+
+            var poiStatusPrinterOk = "\"POIStatus\":{\"CommunicationOKFlag\":true,\"GlobalStatus\":\"OK\",\"PrinterStatus\":\"OK\"}";
+            var poiStatusPrinterAbsent = "\"POIStatus\":{\"CommunicationOKFlag\":true,\"GlobalStatus\":\"OK\"}";
+
+            var parsedPrinterOk = saleToPoiMessageSerializer.Deserialize(GetDiagnosisRequest(poiStatusPrinterOk));
+            var parsedPrinterAbsent = saleToPoiMessageSerializer.Deserialize(GetDiagnosisRequest(poiStatusPrinterAbsent));
+
+            Assert.IsNotNull((parsedPrinterOk.MessagePayload as DiagnosisResponse).POIStatus.PrinterStatus);
+            Assert.AreEqual(PrinterStatusType.OK, (parsedPrinterOk.MessagePayload as DiagnosisResponse).POIStatus.PrinterStatus);
+            Assert.IsNull((parsedPrinterAbsent.MessagePayload as DiagnosisResponse).POIStatus.PrinterStatus);
+        }
+    }
+}

--- a/Adyen.Test/DeserializerTest.cs
+++ b/Adyen.Test/DeserializerTest.cs
@@ -10,19 +10,31 @@ namespace Adyen.Test
         [TestMethod]
         public void PrinterStatusSerializerTest()
         {
-            string GetDiagnosisRequest(string poiStatusJson)
-            {
-                var diagnosisTemplate = "{\"SaleToPOIMessage\":{\"MessageHeader\":{\"MessageClass\":\"Service\",\"MessageCategory\":\"Diagnosis\",\"MessageType\":\"Response\",\"ServiceID\":\"12345678\",\"SaleID\":\"POSSystemID12345\",\"POIID\":\"V400m-284251016\",\"ProtocolVersion\":\"3.0\"},\"DiagnosisResponse\":{\"Response\":{\"Result\":\"Success\"},POI_STATUS,\"HostStatus\":[{\"IsReachableFlag\":true}]}}}";
-                return diagnosisTemplate.Replace("POI_STATUS", poiStatusJson);
-            }
-
             var saleToPoiMessageSerializer = new SaleToPoiMessageSerializer();
+            string GetDiagnosisResponse(string poiStatusJson)
+            {
+                var diagnosisResponseMessage = new SaleToPOIMessage()
+                {
+                    MessageHeader = new MessageHeader() { 
+                        MessageClass = MessageClassType.Service, 
+                        MessageCategory = MessageCategoryType.Diagnosis, 
+                        MessageType = MessageType.Response, 
+                        ServiceID = "12345678", 
+                        SaleID = "POSSystemID12345", 
+                        POIID = "V400m-284251016" 
+                    },
+                    MessagePayload = new DiagnosisResponse() 
+                };
+                var diagnosisTemplate = saleToPoiMessageSerializer.Serialize(diagnosisResponseMessage);
+                var diagnosisStart = @"""DiagnosisResponse"":{";
+                var insertIndex = diagnosisTemplate.IndexOf(diagnosisStart) + diagnosisStart.Length;
+                return diagnosisTemplate.Insert(insertIndex, poiStatusJson);
+            }
+            var poiStatusPrinterOk = @"""POIStatus"":{""CommunicationOKFlag"":true,""GlobalStatus"":""OK"",""PrinterStatus"":""OK""}";
+            var poiStatusPrinterAbsent = @"""POIStatus"":{""CommunicationOKFlag"":true,""GlobalStatus"":""OK""}";
 
-            var poiStatusPrinterOk = "\"POIStatus\":{\"CommunicationOKFlag\":true,\"GlobalStatus\":\"OK\",\"PrinterStatus\":\"OK\"}";
-            var poiStatusPrinterAbsent = "\"POIStatus\":{\"CommunicationOKFlag\":true,\"GlobalStatus\":\"OK\"}";
-
-            var parsedPrinterOk = saleToPoiMessageSerializer.Deserialize(GetDiagnosisRequest(poiStatusPrinterOk));
-            var parsedPrinterAbsent = saleToPoiMessageSerializer.Deserialize(GetDiagnosisRequest(poiStatusPrinterAbsent));
+            var parsedPrinterOk = saleToPoiMessageSerializer.Deserialize(GetDiagnosisResponse(poiStatusPrinterOk));
+            var parsedPrinterAbsent = saleToPoiMessageSerializer.Deserialize(GetDiagnosisResponse(poiStatusPrinterAbsent));
 
             Assert.IsNotNull((parsedPrinterOk.MessagePayload as DiagnosisResponse).POIStatus.PrinterStatus);
             Assert.AreEqual(PrinterStatusType.OK, (parsedPrinterOk.MessagePayload as DiagnosisResponse).POIStatus.PrinterStatus);

--- a/Adyen/Model/TerminalApi/POIStatus.cs
+++ b/Adyen/Model/TerminalApi/POIStatus.cs
@@ -42,7 +42,7 @@
 
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute]
-        public PrinterStatusType PrinterStatus;
+        public PrinterStatusType? PrinterStatus;
 
         /// <remarks/>
         [System.Xml.Serialization.XmlIgnoreAttribute]


### PR DESCRIPTION
**Description**
Change TerminalAPI Model diagnosis response to allow null `PrinterStatus`, which can be returned from devices which lack a printer.

V400m with a printer: `"POIStatus":{"CommunicationOKFlag":true,"GlobalStatus":"OK","PrinterStatus":"OK"}`
P630 (has no printer): `"POIStatus":{"CommunicationOKFlag":true,"GlobalStatus":"OK"}`

**Tested scenarios**
Sending a DiagnosisRequest to a V400m and P630 device, and verifying that PrinterStatus from the response matches the data sent from the device - `PrinterStatus` is null when device doesn't sent it on the wire.

**Fixed issue**:  #1124 