### PR TITLE
Fix: Remove [deprecation] mark on Adyen Recurring API - The API is still supported

### DIFF
--- a/Adyen/Model/Recurring/AbstractOpenAPISchema.cs
+++ b/Adyen/Model/Recurring/AbstractOpenAPISchema.cs
@@ -1,5 +1,5 @@
 /*
-* Adyen Recurring API (deprecated)
+* Adyen Recurring API
 *
 *
 * The version of the OpenAPI document: 68

--- a/Adyen/Model/Recurring/Address.cs
+++ b/Adyen/Model/Recurring/Address.cs
@@ -1,5 +1,5 @@
 /*
-* Adyen Recurring API (deprecated)
+* Adyen Recurring API
 *
 *
 * The version of the OpenAPI document: 68

--- a/Adyen/Model/Recurring/Amount.cs
+++ b/Adyen/Model/Recurring/Amount.cs
@@ -1,5 +1,5 @@
 /*
-* Adyen Recurring API (deprecated)
+* Adyen Recurring API
 *
 *
 * The version of the OpenAPI document: 68

--- a/Adyen/Model/Recurring/BankAccount.cs
+++ b/Adyen/Model/Recurring/BankAccount.cs
@@ -1,5 +1,5 @@
 /*
-* Adyen Recurring API (deprecated)
+* Adyen Recurring API
 *
 *
 * The version of the OpenAPI document: 68

--- a/Adyen/Model/Recurring/Card.cs
+++ b/Adyen/Model/Recurring/Card.cs
@@ -1,5 +1,5 @@
 /*
-* Adyen Recurring API (deprecated)
+* Adyen Recurring API
 *
 *
 * The version of the OpenAPI document: 68

--- a/Adyen/Model/Recurring/CreatePermitRequest.cs
+++ b/Adyen/Model/Recurring/CreatePermitRequest.cs
@@ -1,5 +1,5 @@
 /*
-* Adyen Recurring API (deprecated)
+* Adyen Recurring API
 *
 *
 * The version of the OpenAPI document: 68

--- a/Adyen/Model/Recurring/CreatePermitResult.cs
+++ b/Adyen/Model/Recurring/CreatePermitResult.cs
@@ -1,5 +1,5 @@
 /*
-* Adyen Recurring API (deprecated)
+* Adyen Recurring API
 *
 *
 * The version of the OpenAPI document: 68

--- a/Adyen/Model/Recurring/DisablePermitRequest.cs
+++ b/Adyen/Model/Recurring/DisablePermitRequest.cs
@@ -1,5 +1,5 @@
 /*
-* Adyen Recurring API (deprecated)
+* Adyen Recurring API
 *
 *
 * The version of the OpenAPI document: 68

--- a/Adyen/Model/Recurring/DisablePermitResult.cs
+++ b/Adyen/Model/Recurring/DisablePermitResult.cs
@@ -1,5 +1,5 @@
 /*
-* Adyen Recurring API (deprecated)
+* Adyen Recurring API
 *
 *
 * The version of the OpenAPI document: 68

--- a/Adyen/Model/Recurring/DisableRequest.cs
+++ b/Adyen/Model/Recurring/DisableRequest.cs
@@ -1,5 +1,5 @@
 /*
-* Adyen Recurring API (deprecated)
+* Adyen Recurring API
 *
 *
 * The version of the OpenAPI document: 68

--- a/Adyen/Model/Recurring/DisableResult.cs
+++ b/Adyen/Model/Recurring/DisableResult.cs
@@ -1,5 +1,5 @@
 /*
-* Adyen Recurring API (deprecated)
+* Adyen Recurring API
 *
 *
 * The version of the OpenAPI document: 68

--- a/Adyen/Model/Recurring/Name.cs
+++ b/Adyen/Model/Recurring/Name.cs
@@ -1,5 +1,5 @@
 /*
-* Adyen Recurring API (deprecated)
+* Adyen Recurring API
 *
 *
 * The version of the OpenAPI document: 68

--- a/Adyen/Model/Recurring/NotifyShopperRequest.cs
+++ b/Adyen/Model/Recurring/NotifyShopperRequest.cs
@@ -1,5 +1,5 @@
 /*
-* Adyen Recurring API (deprecated)
+* Adyen Recurring API
 *
 *
 * The version of the OpenAPI document: 68

--- a/Adyen/Model/Recurring/NotifyShopperResult.cs
+++ b/Adyen/Model/Recurring/NotifyShopperResult.cs
@@ -1,5 +1,5 @@
 /*
-* Adyen Recurring API (deprecated)
+* Adyen Recurring API
 *
 *
 * The version of the OpenAPI document: 68

--- a/Adyen/Model/Recurring/Permit.cs
+++ b/Adyen/Model/Recurring/Permit.cs
@@ -1,5 +1,5 @@
 /*
-* Adyen Recurring API (deprecated)
+* Adyen Recurring API
 *
 *
 * The version of the OpenAPI document: 68

--- a/Adyen/Model/Recurring/PermitRestriction.cs
+++ b/Adyen/Model/Recurring/PermitRestriction.cs
@@ -1,5 +1,5 @@
 /*
-* Adyen Recurring API (deprecated)
+* Adyen Recurring API
 *
 *
 * The version of the OpenAPI document: 68

--- a/Adyen/Model/Recurring/PermitResult.cs
+++ b/Adyen/Model/Recurring/PermitResult.cs
@@ -1,5 +1,5 @@
 /*
-* Adyen Recurring API (deprecated)
+* Adyen Recurring API
 *
 *
 * The version of the OpenAPI document: 68

--- a/Adyen/Model/Recurring/Recurring.cs
+++ b/Adyen/Model/Recurring/Recurring.cs
@@ -1,5 +1,5 @@
 /*
-* Adyen Recurring API (deprecated)
+* Adyen Recurring API
 *
 *
 * The version of the OpenAPI document: 68

--- a/Adyen/Model/Recurring/RecurringDetail.cs
+++ b/Adyen/Model/Recurring/RecurringDetail.cs
@@ -1,5 +1,5 @@
 /*
-* Adyen Recurring API (deprecated)
+* Adyen Recurring API
 *
 *
 * The version of the OpenAPI document: 68

--- a/Adyen/Model/Recurring/RecurringDetailWrapper.cs
+++ b/Adyen/Model/Recurring/RecurringDetailWrapper.cs
@@ -1,5 +1,5 @@
 /*
-* Adyen Recurring API (deprecated)
+* Adyen Recurring API
 *
 *
 * The version of the OpenAPI document: 68

--- a/Adyen/Model/Recurring/RecurringDetailsRequest.cs
+++ b/Adyen/Model/Recurring/RecurringDetailsRequest.cs
@@ -1,5 +1,5 @@
 /*
-* Adyen Recurring API (deprecated)
+* Adyen Recurring API
 *
 *
 * The version of the OpenAPI document: 68

--- a/Adyen/Model/Recurring/RecurringDetailsResult.cs
+++ b/Adyen/Model/Recurring/RecurringDetailsResult.cs
@@ -1,5 +1,5 @@
 /*
-* Adyen Recurring API (deprecated)
+* Adyen Recurring API
 *
 *
 * The version of the OpenAPI document: 68

--- a/Adyen/Model/Recurring/ScheduleAccountUpdaterRequest.cs
+++ b/Adyen/Model/Recurring/ScheduleAccountUpdaterRequest.cs
@@ -1,5 +1,5 @@
 /*
-* Adyen Recurring API (deprecated)
+* Adyen Recurring API
 *
 *
 * The version of the OpenAPI document: 68

--- a/Adyen/Model/Recurring/ScheduleAccountUpdaterResult.cs
+++ b/Adyen/Model/Recurring/ScheduleAccountUpdaterResult.cs
@@ -1,5 +1,5 @@
 /*
-* Adyen Recurring API (deprecated)
+* Adyen Recurring API
 *
 *
 * The version of the OpenAPI document: 68

--- a/Adyen/Model/Recurring/ServiceError.cs
+++ b/Adyen/Model/Recurring/ServiceError.cs
@@ -1,5 +1,5 @@
 /*
-* Adyen Recurring API (deprecated)
+* Adyen Recurring API
 *
 *
 * The version of the OpenAPI document: 68

--- a/Adyen/Model/Recurring/TokenDetails.cs
+++ b/Adyen/Model/Recurring/TokenDetails.cs
@@ -1,5 +1,5 @@
 /*
-* Adyen Recurring API (deprecated)
+* Adyen Recurring API
 *
 *
 * The version of the OpenAPI document: 68


### PR DESCRIPTION
Adyen Recurring API is still supported, removed the deprecation mark on the Adyen Recurring API
