### PR TITLE
Update setters for timers and upgrade dependencies

### DIFF
--- a/.github/workflows/build-net6.0.yml
+++ b/.github/workflows/build-net6.0.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  build-test:
+  dotnet6-build-and-unit-test:
     name: Build and Test on .NET 6.0
     runs-on: ${{ matrix.os }}
     
@@ -38,35 +38,3 @@ jobs:
 
       - name: Run unit tests on .NET 6.0
         run: dotnet test --no-build -c Debug -f net6.0 Adyen.Test/Adyen.Test.csproj
-
-
-  integration-tests:
-    name: Integration Tests
-    runs-on: ${{ matrix.os }}
-    needs: build-test
-    
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, windows-latest ]
-
-    # Check if event is a pull request and has a release tag and is not from a forked repo
-    if: |
-      github.event_name == 'pull_request' &&
-      contains(github.event.pull_request.labels.*.name, 'release') &&
-      github.event.pull_request.head.repo.full_name == github.repository
-
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Setup .NET 6.0 and .NET 8.0
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: | 
-            6.0.x
-            8.0.x
-        
-      - name: Build (debug) in .NET 6.0
-        run: dotnet build -c Debug -f net6.0
-
-      - name: Run integration tests on .NET 6.0
-        run: dotnet test --no-build -c Debug -f net6.0 Adyen.IntegrationTest/Adyen.IntegrationTest.csproj

--- a/.github/workflows/build-net8.0.yml
+++ b/.github/workflows/build-net8.0.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  build-test:
+  dotnet8-build-and-unit-test:
     name: Build and Test on .NET 8.0
     runs-on: ${{ matrix.os }}
     
@@ -35,33 +35,3 @@ jobs:
 
       - name: Run unit tests in .NET 8.0
         run: dotnet test --no-build -c Debug -f net8.0 Adyen.Test/Adyen.Test.csproj
-
-
-  integration-tests:
-    name: Integration Tests
-    runs-on: ${{ matrix.os }}
-    needs: build-test
-    
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, windows-latest ]
-
-    # Check if event is a pull request and has a release tag and is not from a forked repo
-    if: |
-      github.event_name == 'pull_request' &&
-      contains(github.event.pull_request.labels.*.name, 'release') &&
-      github.event.pull_request.head.repo.full_name == github.repository
-
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Setup .NET 8.0
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 8.0.x
-        
-      - name: Build (debug) in .NET 8.0
-        run: dotnet build -c Debug -f net8.0
-
-      - name: Run integration tests in .NET 8.0
-        run: dotnet test --no-build -c Debug -f net8.0 Adyen.IntegrationTest/Adyen.IntegrationTest.csproj

--- a/Adyen.IntegrationTest/Adyen.IntegrationTest.csproj
+++ b/Adyen.IntegrationTest/Adyen.IntegrationTest.csproj
@@ -10,9 +10,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-        <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
-        <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Adyen.Test/Adyen.Test.csproj
+++ b/Adyen.Test/Adyen.Test.csproj
@@ -19,10 +19,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Adyen/Adyen.csproj
+++ b/Adyen/Adyen.csproj
@@ -36,7 +36,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/Adyen/Adyen.csproj
+++ b/Adyen/Adyen.csproj
@@ -36,7 +36,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/Adyen/Client.cs
+++ b/Adyen/Client.cs
@@ -113,9 +113,12 @@ namespace Adyen
         private System.Net.Http.HttpClient GetHttpClient()
         {
             if (_httpClient == null)
-                _httpClient = new System.Net.Http.HttpClient(HttpClientExtensions.ConfigureHttpMessageHandler(Config));
-            // Set Timeout for HttpClient
-            _httpClient.Timeout = TimeSpan.FromMilliseconds(Config.Timeout);
+            {
+                _httpClient = new System.Net.Http.HttpClient(HttpClientExtensions.ConfigureHttpMessageHandler(Config))
+                {
+                    Timeout = TimeSpan.FromMilliseconds(Config.Timeout)
+                };
+            }
             return _httpClient;
         }
 

--- a/Adyen/Config.cs
+++ b/Adyen/Config.cs
@@ -23,28 +23,44 @@ namespace Adyen
         public bool HasApiKey => !string.IsNullOrEmpty(XApiKey);
         
         /// <summary>
-        /// HttpConnection Timeout in milliseconds.
+        /// HttpConnection Timeout in milliseconds (e.g. the time required to send the request and receive the response).
+        /// In > NET6.0, we recommend configuring your own <see cref="HttpClient"/> and pass it in the constructor.
+        /// The values shown here are defaults, if no <see cref="HttpClient"/> is provided.
         /// </summary>
         public int Timeout { get; set; } = 60000;
+
+        /// <summary>
+        /// Only The amount of time it should take to establish the TCP Connection.
+        /// This value is only used in <seealso cref="Adyen.HttpClient.HttpClientExtensions"/> when no default <see cref="HttpClient"/> was passed in the <see cref="Client"/> constructor.
+        /// In > NET6.0, we recommend configuring your own <see cref="HttpClient"/> and pass it in the constructor.
+        /// The values shown here are defaults, if no <see cref="HttpClient"/> is provided.
+        /// </summary>
+        public TimeSpan ConnectTimeout { get; set; } = TimeSpan.FromSeconds(15);
         
         /// <summary>
         /// Force reconnection to refresh DNS and avoid stale connections.
         /// Once a connection exceeds the specified lifetime, it is no longer considered reusable and it is closed and removed from the pool.
         /// This value is only used in <seealso cref="Adyen.HttpClient.HttpClientExtensions"/> when no default <see cref="HttpClient"/> was passed in the <see cref="Client"/> constructor.
+        /// In > NET6.0, we recommend configuring your own <see cref="HttpClient"/> and pass it in the constructor.
+        /// The values shown here are defaults, if no <see cref="HttpClient"/> is provided.
         /// </summary>
-        public TimeSpan PooledConnectionLifetime = TimeSpan.FromMinutes(5);
+        public TimeSpan PooledConnectionLifetime { get; set; } = TimeSpan.FromMinutes(5);
                 
         /// <summary>
         /// Close idle connections after the specified time.
         /// This value is only used in <seealso cref="Adyen.HttpClient.HttpClientExtensions"/> when no default <see cref="HttpClient"/> was passed in the <see cref="Client"/> constructor.
+        /// In > NET6.0, we recommend configuring your own <see cref="HttpClient"/> and pass it in the constructor.
+        /// The values shown here are defaults, if no <see cref="HttpClient"/> is provided.
         /// </summary>
-        public TimeSpan PooledConnectionIdleTimeout = TimeSpan.FromMinutes(2);
+        public TimeSpan PooledConnectionIdleTimeout { get; set; }= TimeSpan.FromMinutes(2);
 
         /// <summary>
         /// Maximum number of concurrent TCP connections per server.
         /// This value is only used in <seealso cref="Adyen.HttpClient.HttpClientExtensions"/> when no default <see cref="HttpClient"/> was passed in the <see cref="Client"/> constructor.
+        /// In > NET6.0, we recommend configuring your own <see cref="HttpClient"/> and pass it in the constructor.
+        /// The values shown here are defaults, if no <see cref="HttpClient"/> is provided.
         /// </summary>
-        public int MaxConnectionsPerServer = 2;
+        public int MaxConnectionsPerServer { get; set; } = 2;
 
         /// <summary>
         /// The url of the Cloud Terminal Api endpoint.

--- a/Adyen/HttpClient/HttpClientExtension.cs
+++ b/Adyen/HttpClient/HttpClientExtension.cs
@@ -40,7 +40,7 @@ namespace Adyen.HttpClient
                 UseProxy = config.Proxy != null,
                 
                 // Sets the TCP connect timeout (max time for creating the TCP connection).
-                ConnectTimeout = TimeSpan.FromMilliseconds(config.Timeout),
+                ConnectTimeout = config.ConnectTimeout,
                 
                 // Force reconnection to refresh DNS and avoid stale connections.
                 PooledConnectionLifetime = config.PooledConnectionLifetime,


### PR DESCRIPTION
* ConnectTimeout (for establishing the HTTP connection) and Timeout (e.g. the time required to send the request and receive the response) are now **separate** configurable values in `Config`
* Upgrade dependencies to latest 
* Integration tests were [enabled in this merge request](https://github.com/Adyen/adyen-dotnet-api-library/commit/6fbfb0845f67186290cdc656ad546234c7ec03e0#diff-ac55abaaeaf67fb06efd5a2233f5a5f9ea20e835e7c502ff05c1bf2b952f1825R51-R83), but the runner, secrets, and related configurations were never properly set up, hence why all tests fail. Additionally, some mocks are based on outdated API versions. I've decided to disable the integrations tests for now.