### PR TITLE
No longer run build.yaml on-push for sdk-automation/models and promote/main branches

### DIFF
--- a/.github/workflows/build-net6.0.yml
+++ b/.github/workflows/build-net6.0.yml
@@ -1,11 +1,9 @@
-name: .NET Core
+name: .NET Core 6.0
 
 on:
   push:
     branches:
       - main
-      - sdk-automation/models
-      - promote/main
   pull_request:
     branches:
       - main
@@ -17,7 +15,7 @@ jobs:
   dotnet6-build-and-unit-test:
     name: Build and Test on .NET 6.0
     runs-on: ${{ matrix.os }}
-    
+
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
@@ -31,10 +29,12 @@ jobs:
           dotnet-version: | 
             6.0.x
             8.0.x
-      
-        
+
+      - name: Restore dependencies
+        run: dotnet restore
+
       - name: Build (debug) in .NET 6.0
-        run: dotnet build -c Debug -f net6.0
+        run: dotnet build --configuration Debug --framework net6.0 --no-restore
 
       - name: Run unit tests on .NET 6.0
-        run: dotnet test --no-build -c Debug -f net6.0 Adyen.Test/Adyen.Test.csproj
+        run: dotnet test --no-build --configuration Debug --framework net6.0 --no-restore Adyen.Test/Adyen.Test.csproj

--- a/.github/workflows/build-net8.0.yml
+++ b/.github/workflows/build-net8.0.yml
@@ -1,11 +1,9 @@
-name: .NET Core
+name: .NET Core 8.0
 
 on:
   push:
     branches:
       - main
-      - sdk-automation/models
-      - promote/main
   pull_request:
     branches:
       - main
@@ -17,21 +15,24 @@ jobs:
   dotnet8-build-and-unit-test:
     name: Build and Test on .NET 8.0
     runs-on: ${{ matrix.os }}
-    
+
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
 
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Setup .NET 8.0
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
-        
+
+      - name: Restore dependencies
+        run: dotnet restore
+
       - name: Build (debug) in .NET 8.0
-        run: dotnet build -c Debug -f net8.0
+        run: dotnet build --configuration Debug --framework net8.0 --no-restore
 
       - name: Run unit tests in .NET 8.0
-        run: dotnet test --no-build -c Debug -f net8.0 Adyen.Test/Adyen.Test.csproj
+        run: dotnet test --no-build --configuration Debug --framework net8.0 --no-restore Adyen.Test/Adyen.Test.csproj

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,16 +12,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      
-      # Set up .NET 6.0
-      - name: Setup .NET
+
+      # Setup .NET 6.0
+      - name: Setup .NET 6.0
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 6.0.x
-      
-      # Build in Release configuration and run unit tests in .NET 6.0
+
+      - name: Restore dependencies for .NET 6.0
+        run: dotnet restore
+
       - name: Run unit tests on .NET 6.0
-        run: dotnet test -c Release -f net6.0 Adyen.Test/Adyen.Test.csproj
+        run: dotnet test --configuration Release --framework net6.0 --no-restore Adyen.Test/Adyen.Test.csproj
 
       # Set up .NET 8.0
       - name: Setup .NET
@@ -29,12 +31,15 @@ jobs:
         with:
           dotnet-version: 8.0.x
 
+      - name: Restore dependencies
+        run: dotnet restore
+
       # Build in Release configuration and run unit tests in .NET 8.0
       - name: Build Release
-        run: dotnet build Adyen -c Release
+        run: dotnet build Adyen --configuration Release --no-restore
 
       - name: Run unit tests on .NET 8.0
-        run: dotnet test --no-build -c Release -f net8.0 Adyen.Test/Adyen.Test.csproj
+        run: dotnet test --no-build --configuration Release --f net8.0 --no-restore Adyen.Test/Adyen.Test.csproj
 
       # Pack Release
       - name: Pack


### PR DESCRIPTION
* No longer run build.yaml on-push for sdk-automation/models and promote/main branches

* Write out `--configuration` and `--framework` flags in the workflows
