### PR TITLE
Populate ApplicationName in UserAgent when not null

### DIFF
--- a/Adyen.Test/BaseTest.cs
+++ b/Adyen.Test/BaseTest.cs
@@ -239,7 +239,12 @@ namespace Adyen.Test
             var clientMock = new Client(config)
             {
                 HttpClient = ClientInterfaceSubstitute,
-                Config = MockPaymentData.CreateConfigMock()
+                Config = new Config
+                {
+                    Username = "Username",
+                    Password = "Password",
+                    ApplicationName = "Appname"
+                }
             };
             return clientMock;
         }
@@ -266,7 +271,12 @@ namespace Adyen.Test
             var clientMock = new Client(config)
             {
                 HttpClient = ClientInterfaceSubstitute,
-                Config = MockPaymentData.CreateConfigMock()
+                Config = new Config
+                {
+                    Username = "Username",
+                    Password = "Password",
+                    ApplicationName = "Appname"
+                }
             };
             return clientMock;
         }
@@ -280,8 +290,12 @@ namespace Adyen.Test
         {
             var mockPath = GetMockFilePath(fileName);
             var response = MockFileToString(mockPath);
-            //Create a mock interface
-            var confMock = MockPaymentData.CreateConfigApiKeyBasedMock();
+            
+            var configWithApiKey = new Config
+            {
+                Environment = Model.Environment.Test,
+                XApiKey = "AQEyhmfxK....LAG84XwzP5pSpVd"
+            };
             
             ClientInterfaceSubstitute = Substitute.For<IClient>();
             
@@ -296,7 +310,7 @@ namespace Adyen.Test
             var clientMock = new Client(config)
             {
                 HttpClient = ClientInterfaceSubstitute,
-                Config = confMock
+                Config = configWithApiKey
             };
             return clientMock;
         }

--- a/Adyen.Test/HeaderRequestTest.cs
+++ b/Adyen.Test/HeaderRequestTest.cs
@@ -4,6 +4,7 @@ using Adyen.Constants;
 using Adyen.HttpClient;
 using Adyen.Model;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Environment = Adyen.Model.Environment;
 
 namespace Adyen.Test
 {
@@ -15,8 +16,14 @@ namespace Adyen.Test
         [TestMethod]
         public void BasicAuthenticationHeadersTest()
         {
-            var client = new HttpClientWrapper(MockPaymentData.CreateConfigMock(), new System.Net.Http.HttpClient());
-            var httpRequestMessage = client.GetHttpRequestMessage(_endpoint, "requestBody", null, HttpMethod.Post);
+            var config = new Config
+            {
+                Username = "Username",
+                Password = "Password",
+                ApplicationName = "Appname"
+            };
+            var client = new HttpClientWrapper(config, new System.Net.Http.HttpClient());
+            HttpRequestMessage httpRequestMessage = client.GetHttpRequestMessage(_endpoint, "requestBody", null, HttpMethod.Post);
 
             Assert.IsNotNull(httpRequestMessage.Headers.UserAgent);
             Assert.AreEqual(httpRequestMessage.RequestUri?.ToString(), _endpoint);
@@ -30,8 +37,13 @@ namespace Adyen.Test
         [TestMethod]
         public void ApiKeyBasedHeadersTest()
         {
-            var client = new HttpClientWrapper(MockPaymentData.CreateConfigApiKeyBasedMock(), new System.Net.Http.HttpClient());
-            var httpRequestMessage = client.GetHttpRequestMessage(_endpoint, "requestbody", null, HttpMethod.Get);
+            var configWithApiKey = new Config
+            {
+                Environment = Environment.Test,
+                XApiKey = "AQEyhmfxK....LAG84XwzP5pSpVd"//mock api key
+            };
+            var client = new HttpClientWrapper(configWithApiKey, new System.Net.Http.HttpClient());
+            HttpRequestMessage httpRequestMessage = client.GetHttpRequestMessage(_endpoint, "requestbody", null, HttpMethod.Get);
 
             Assert.IsNotNull(httpRequestMessage.Headers.UserAgent);
             Assert.AreEqual(httpRequestMessage.RequestUri?.ToString(), _endpoint);
@@ -62,7 +74,13 @@ namespace Adyen.Test
         [TestMethod]
         public void IdempotencyKeyTest()
         {
-            var client = new HttpClientWrapper(MockPaymentData.CreateConfigMock(), new System.Net.Http.HttpClient());
+            var config = new Config
+            {
+                Username = "Username",
+                Password = "Password",
+                ApplicationName = "Appname"
+            };
+            var client = new HttpClientWrapper(config, new System.Net.Http.HttpClient());
             var httpWebRequest = client.GetHttpRequestMessage(_endpoint, "requestbody",new RequestOptions
             {
                 IdempotencyKey = "123456789"
@@ -79,7 +97,14 @@ namespace Adyen.Test
                 IdempotencyKey = string.Empty
             };
             
-            var client = new HttpClientWrapper(MockPaymentData.CreateConfigMock(), new System.Net.Http.HttpClient());
+            var config = new Config
+            {
+                Username = "Username",
+                Password = "Password",
+                ApplicationName = "Appname"
+            };
+            
+            var client = new HttpClientWrapper(config, new System.Net.Http.HttpClient());
             var httpWebRequest = client.GetHttpRequestMessage(_endpoint, "requestbody", requestOptions, null);
             Assert.IsFalse(httpWebRequest.Headers.TryGetValues("Idempotency-Key", out var _));
         }
@@ -92,7 +117,14 @@ namespace Adyen.Test
                 IdempotencyKey = " "
             };
             
-            var client = new HttpClientWrapper(MockPaymentData.CreateConfigMock(), new System.Net.Http.HttpClient());
+            var config = new Config
+            {
+                Username = "Username",
+                Password = "Password",
+                ApplicationName = "Appname"
+            };
+            
+            var client = new HttpClientWrapper(config, new System.Net.Http.HttpClient());
             var httpWebRequest = client.GetHttpRequestMessage(_endpoint, "request", requestOptions, null);
 
             Assert.IsFalse(httpWebRequest.Headers.TryGetValues("Idempotency-Key", out var _));
@@ -106,18 +138,64 @@ namespace Adyen.Test
                 IdempotencyKey = "idempotencyKey"
             };
             
-            var client = new HttpClientWrapper(MockPaymentData.CreateConfigMock(), new System.Net.Http.HttpClient());
+            var config = new Config
+            {
+                Username = "Username",
+                Password = "Password",
+                ApplicationName = "Appname"
+            };
+            
+            var client = new HttpClientWrapper(config, new System.Net.Http.HttpClient());
             var httpWebRequest = client.GetHttpRequestMessage(_endpoint,"requestBody", requestOptions, null);
 
             Assert.IsNotNull(httpWebRequest.Headers.GetValues("Idempotency-Key"));
             Assert.AreEqual(requestOptions.IdempotencyKey, httpWebRequest.Headers.GetValues("Idempotency-Key").FirstOrDefault());
         }
+
+        [TestMethod]
+        public void UserAgentPresentWhenApplicationNameIsProvidedTest()
+        {
+            var config = new Config
+            {
+                Username = "Username",
+                Password = "Password",
+                ApplicationName = "YourApplicationName"
+            };
+            
+            var client = new HttpClientWrapper(config, new System.Net.Http.HttpClient());
+            HttpRequestMessage httpWebRequest = client.GetHttpRequestMessage(_endpoint, "requestBody", null, null);
+
+            Assert.AreEqual(httpWebRequest.Headers.GetValues("UserAgent").FirstOrDefault(), $"YourApplicationName {ClientConfig.LibName}/{ClientConfig.LibVersion}");
+        }
         
+        [TestMethod]
+        public void UserAgentPresentWhenApplicationNameIsNotProvidedTest()
+        {
+            var config = new Config
+            {
+                Username = "Username",
+                Password = "Password",
+                ApplicationName = null
+            };
+            
+            var client = new HttpClientWrapper(config, new System.Net.Http.HttpClient());
+            HttpRequestMessage httpWebRequest = client.GetHttpRequestMessage(_endpoint, "requestBody", null, null);
+
+            Assert.AreEqual(httpWebRequest.Headers.GetValues("UserAgent").FirstOrDefault(), $"{ClientConfig.LibName}/{ClientConfig.LibVersion}");
+        }
+
         [TestMethod]
         public void LibraryAnalysisConstantsInHeaderTest()
         {
-            var client = new HttpClientWrapper(MockPaymentData.CreateConfigMock(), new System.Net.Http.HttpClient());
-            var httpWebRequest = client.GetHttpRequestMessage(_endpoint,"requestBody", null, null);
+            var config = new Config
+            {
+                Username = "Username",
+                Password = "Password",
+                ApplicationName = "Appname"
+            };
+            
+            var client = new HttpClientWrapper(config, new System.Net.Http.HttpClient());
+            HttpRequestMessage httpWebRequest = client.GetHttpRequestMessage(_endpoint, "requestBody", null, null);
 
             Assert.IsNotNull(httpWebRequest.Headers.GetValues(ApiConstants.AdyenLibraryName));
             Assert.AreEqual(ClientConfig.LibName, httpWebRequest.Headers.GetValues(ApiConstants.AdyenLibraryName).FirstOrDefault());

--- a/Adyen.Test/HttpClientWrapperTest.cs
+++ b/Adyen.Test/HttpClientWrapperTest.cs
@@ -1,12 +1,5 @@
-using System.Linq;
-using System.Net.Http;
-using System.Threading.Tasks;
 using Adyen.HttpClient;
-using Adyen.Model.Management;
-using Adyen.Model.TerminalApi;
-using Adyen.Service.Management;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSubstitute;
 
 namespace Adyen.Test
 {
@@ -16,9 +9,14 @@ namespace Adyen.Test
         [TestMethod]
         public void EmptyRequestBodyPostTest()
         {
+            var configWithApiKey = new Config
+            {
+                Environment = Model.Environment.Test,
+                XApiKey = "AQEyhmfxK....LAG84XwzP5pSpVd"
+            };
             var mockHttpMessageHandler = new MockHttpMessageHandler("{}", System.Net.HttpStatusCode.OK);
             var httpClient = new System.Net.Http.HttpClient(mockHttpMessageHandler);
-            var httpClientWrapper = new HttpClientWrapper(MockPaymentData.CreateConfigApiKeyBasedMock(), httpClient);
+            var httpClientWrapper = new HttpClientWrapper(configWithApiKey, httpClient);
             var _ = httpClientWrapper.Request("https://test.com/testpath", null, null, HttpMethod.Post);
             Assert.AreEqual("{}", mockHttpMessageHandler.Input);
         }

--- a/Adyen.Test/MockPaymentData.cs
+++ b/Adyen.Test/MockPaymentData.cs
@@ -10,16 +10,6 @@ namespace Adyen.Test
     {
         #region Mock payment data 
 
-        public static Config CreateConfigMock()
-        {
-            return new Config
-            {
-                Username = "Username",
-                Password = "Password",
-                ApplicationName = "Appname"
-            };
-        }
-
         public static Config CreateConfigApiKeyBasedMock()
         {
             return new Config

--- a/Adyen/HttpClient/HttpClientWrapper.cs
+++ b/Adyen/HttpClient/HttpClientWrapper.cs
@@ -65,7 +65,16 @@ namespace Adyen.HttpClient
             httpRequestMessage.Headers.Add("ContentType", "application/json");
             httpRequestMessage.Headers.Add("Accept-Charset", "UTF-8");
             httpRequestMessage.Headers.Add("Cache-Control", "no-cache");
-            httpRequestMessage.Headers.Add("UserAgent", $"{_config.ApplicationName} {ClientConfig.UserAgentSuffix}{ClientConfig.LibVersion}");
+
+            if (!string.IsNullOrWhiteSpace(_config.ApplicationName))
+            {
+                httpRequestMessage.Headers.Add("UserAgent", $"{_config.ApplicationName} {ClientConfig.UserAgentSuffix}{ClientConfig.LibVersion}");
+            }
+            else
+            {
+                httpRequestMessage.Headers.Add("UserAgent", $"{ClientConfig.UserAgentSuffix}{ClientConfig.LibVersion}");
+            }
+
             if (!string.IsNullOrWhiteSpace(requestOptions?.IdempotencyKey))
             {
                 httpRequestMessage.Headers.Add("Idempotency-Key", requestOptions.IdempotencyKey);


### PR DESCRIPTION
Fix: Populates ApplicationName in UserAgent when not null. Previously this value could be `null` if `ApplicationName` was not set in the `Config`.
