### PR TITLE
Allow workflow_dispatch in publish.yaml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 name: Publish to NuGet
 
 on:
+  workflow_dispatch: {}
   release:
     types: [ published ]
 


### PR DESCRIPTION
Allow publishing to be triggered **manually** from Github actions.