### PR TITLE
Update publish.yml to use .NET 8.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
         run: dotnet build Adyen --configuration Release --no-restore
 
       - name: Run unit tests on .NET 8.0
-        run: dotnet test --no-build --configuration Release --no-restore Adyen.Test/Adyen.Test.csproj
+        run: dotnet test --no-build --configuration Release --framework net8.0 --no-restore Adyen.Test/Adyen.Test.csproj
 
       # Pack Release
       - name: Pack


### PR DESCRIPTION
Fix the publish.yml file to run tests using the correct .NET 8.0 framework before pushing to NuGet.
