### PR TITLE
Use --skip-duplicate to ignore uploading the .symbols.nupkg package when publishing to NuGet

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,4 +37,4 @@ jobs:
 
       # Publish Package
       - name: Publish Nuget
-        run: dotnet nuget push nuget/*.nupkg --api-key ${{ secrets.ADYEN_NUGET }} --source "nuget.org"
+        run: dotnet nuget push nuget/*.nupkg --api-key ${{ secrets.ADYEN_NUGET }} --source "nuget.org" --skip-duplicate


### PR DESCRIPTION
`dotnet pack` will generate a _second_ symbols package (`.symbols.nupkg`), therefore when publishing it tries to push both ending on `*.nupkg`, see:
```
 dotnet nuget push nuget/*.nupkg --api-key ${{ secrets.ADYEN_NUGET }} --source "nuget.org"
```

Therefore when looking into the github action logs, we get a red-status message as the NuGet server will respond with a 4XX error (duplicate).

```
Pushing Adyen.31.0.0.nupkg to 'https://www.nuget.org/api/v2/package/'...
...
Pushing Adyen.31.0.0.symbols.nupkg to 'https://www.nuget.org/api/v2/package/'...
...
Conflict https://www.nuget.org/api/v2/package/ 
error: Response status code does not indicate success: 409 (A package with ID 'Adyen' and version '31.0.0' already exists and cannot be modified.
```

I've included the `--skip-duplicate` flag to ignore the error messages when pushing `.symbols.nupkg` package.


