### PR TITLE
Add FundingSourceEnum new values

### DIFF
--- a/Adyen/Model/Management/SplitConfigurationRule.cs
+++ b/Adyen/Model/Management/SplitConfigurationRule.cs
@@ -55,8 +55,25 @@ namespace Adyen.Model.Management
             /// Enum ANY for value: ANY
             /// </summary>
             [EnumMember(Value = "ANY")]
-            ANY = 3
+            ANY = 3,
 
+            /// <summary>
+            /// Enum Charged for value: charged
+            /// </summary>
+            [EnumMember(Value = "charged")]
+            Charged = 4,            
+
+            /// <summary>
+            /// Enum DeferredDebit for value: deferred_debit
+            /// </summary>
+            [EnumMember(Value = "deferred_debit")]
+            DeferredDebit = 5,
+
+            /// <summary>
+            /// Enum Prepaid for value: prepaid
+            /// </summary>
+            [EnumMember(Value = "prepaid")]
+            Prepaid = 6
         }
 
 


### PR DESCRIPTION
Add missing values in `SplitConfigurationRule.FundingSourceEnum` 

Fix #1158 