### PR TITLE
Mustache template with unescaped HTML

### DIFF
--- a/templates/csharp/method_documentation.mustache
+++ b/templates/csharp/method_documentation.mustache
@@ -2,12 +2,12 @@
         /// {{{summary}}}
         /// </summary>
         {{#pathParams}}
-        /// <param name="{{paramName}}"><see cref="{{dataType}}"/> - {{description}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
+        /// <param name="{{paramName}}"><see cref="{{dataType}}"/> - {{{description}}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
         {{/pathParams}}
         {{#bodyParams}}
-        /// <param name="{{paramName}}"><see cref="{{dataType}}"/> - {{description}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
+        /// <param name="{{paramName}}"><see cref="{{dataType}}"/> - {{{description}}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
         {{/bodyParams}}
         {{#queryParams}}
-        /// <param name="{{paramName}}"><see cref="{{dataType}}"/> - {{description}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
+        /// <param name="{{paramName}}"><see cref="{{dataType}}"/> - {{{description}}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
         {{/queryParams}}
         /// <param name="requestOptions"><see cref="RequestOptions"/> - Additional request options.</param>

--- a/templates/csharp/modelGeneric.mustache
+++ b/templates/csharp/modelGeneric.mustache
@@ -1,5 +1,5 @@
     /// <summary>
-    /// {{description}}{{^description}}{{classname}}{{/description}}
+    /// {{{description}}}{{^description}}{{classname}}{{/description}}
     /// </summary>
     {{#vendorExtensions.x-cls-compliant}}
     [CLSCompliant({{{vendorExtensions.x-cls-compliant}}})]
@@ -32,10 +32,10 @@
         {{#isEnum}}
 
         /// <summary>
-        /// {{description}}{{^description}}Gets or Sets {{{name}}}{{/description}}
+        /// {{{description}}}{{^description}}Gets or Sets {{{name}}}{{/description}}
         /// </summary>
         {{#description}}
-        /// <value>{{.}}</value>
+        /// <value>{{{.}}}</value>
         {{/description}}
         {{^conditionalSerialization}}
         [DataMember(Name = "{{baseName}}"{{#required}}, IsRequired = false{{/required}}, EmitDefaultValue = {{#vendorExtensions.x-emit-default-value}}true{{/vendorExtensions.x-emit-default-value}}{{^vendorExtensions.x-emit-default-value}}{{#required}}false{{/required}}{{^required}}{{#isBoolean}}false{{/isBoolean}}{{^isBoolean}}{{#isNullable}}false{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{/isBoolean}}{{/required}}{{/vendorExtensions.x-emit-default-value}})]
@@ -123,7 +123,7 @@
         /// Initializes a new instance of the <see cref="{{classname}}" /> class.
         /// </summary>
         {{#readWriteVars}}
-        /// <param name="{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}">{{description}}{{^description}}{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}{{/description}}{{#required}} (required){{/required}}{{#defaultValue}} (default to {{.}}){{/defaultValue}}.</param>
+        /// <param name="{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}">{{{description}}}{{^description}}{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}{{/description}}{{#required}} (required){{/required}}{{#defaultValue}} (default to {{.}}){{/defaultValue}}.</param>
         {{/readWriteVars}}
     {{#hasOnlyReadOnly}}
         [JsonConstructorAttribute]
@@ -194,9 +194,9 @@
         {{^isInherited}}
         {{^isEnum}}
         /// <summary>
-        /// {{description}}{{^description}}Gets or Sets {{{name}}}{{/description}}
+        /// {{{description}}}{{^description}}Gets or Sets {{{name}}}{{/description}}
         /// </summary>{{#description}}
-        /// <value>{{.}}</value>{{/description}}
+        /// <value>{{{.}}}</value>{{/description}}
         {{^conditionalSerialization}}
         [DataMember(Name = "{{baseName}}"{{#required}}, IsRequired = false{{/required}}, EmitDefaultValue = {{#vendorExtensions.x-emit-default-value}}true{{/vendorExtensions.x-emit-default-value}}{{^vendorExtensions.x-emit-default-value}}{{#required}}false{{/required}}{{^required}}{{#isBoolean}}false{{/isBoolean}}{{^isBoolean}}{{#isNullable}}false{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{/isBoolean}}{{/required}}{{/vendorExtensions.x-emit-default-value}})]
         {{#isDate}}

--- a/templates/csharp/modelOneOf.mustache
+++ b/templates/csharp/modelOneOf.mustache
@@ -1,6 +1,6 @@
 {{#model}}
     /// <summary>
-    /// {{description}}{{^description}}{{classname}}{{/description}}
+    /// {{{description}}}{{^description}}{{classname}}{{/description}}
     /// </summary>
     {{#vendorExtensions.x-cls-compliant}}
     [CLSCompliant({{{.}}})]


### PR DESCRIPTION
`<summary>` and `<value>` are not correctly displayed, special characters are HTML escaped.

This PR updates the templates to render the content of the description without escaping, using `{{{description}}}` 