### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ var config = new Config
     LocalTerminalApiEndpoint = @"https://_terminal_:8443/nexo/" // _terminal_ example: `https://198.51.100.1:8443/nexo` (can be found in the WIFI settings of your terminal)
 };
 var client = new Client(config);
-ITerminalApiLocalService terminalApiLocalService = new TerminalApiLocalService(client);
+ITerminalApiLocalService terminalApiLocalService = new TerminalApiLocalService(client, new SaleToPoiMessageSerializer(), new SaleToPoiMessageSecuredEncryptor(), new SaleToPoiMessageSecuredSerializer());
 // Asynchronous call (preferred)
 var saleToPOIResponse = await terminalApiLocalService.RequestEncryptedAsync(paymentRequest, encryptionCredentialDetails, new CancellationToken()); // Pass cancellation token or create a new one.
 // Synchronous (blocking) call


### PR DESCRIPTION
Update Local Terminal API usage with all the parameters required by the constructor

**Description**
The readme contained outdated examples of usage of the Local Terminal API.
Right now this [class constructor](https://github.com/Adyen/adyen-dotnet-api-library/blob/v32.1.0/Adyen/Service/TerminalApiLocalService.cs#L84) requires 4 parameters

Updated to:
```
ITerminalApiLocalService terminalApiLocalService = new TerminalApiLocalService(
        client,
        new SaleToPoiMessageSerializer(),
        new SaleToPoiMessageSecuredEncryptor(),
        new SaleToPoiMessageSecuredSerializer()
    );

```

**Tested scenarios**
Not applicable

**Fixed issue**:  #1178 
