### PR TITLE
Revert changes to WebhookHandler to introduce the null-check

### DIFF
--- a/Adyen/Webhooks/BalancePlatformWebhookHandler.cs
+++ b/Adyen/Webhooks/BalancePlatformWebhookHandler.cs
@@ -236,8 +236,21 @@ namespace Adyen.Webhooks
             // Retrieve type from payload
             JToken typeToken = JObject.Parse(jsonPayload).GetValue("type");
             string type = typeToken?.Value<string>();
-            List<MemberInfo> memberInfos = typeof(T).GetTypeInfo().DeclaredMembers.ToList();
-            return memberInfos.Any(memberInfo => memberInfo?.GetCustomAttribute<EnumMemberAttribute>()?.Value == type);
+            
+            // Search for type in <T>.TypeEnum
+            List<string> list = new List<string>();
+            var members = typeof(T)
+                .GetTypeInfo()
+                .DeclaredMembers;
+            
+            foreach (var member in members)
+            {
+                var val = member?.GetCustomAttribute<EnumMemberAttribute>(false)?.Value;
+                if (!string.IsNullOrEmpty(val))
+                    list.Add(val);
+            }
+
+            return list.Contains(type);
         }
     }
 }


### PR DESCRIPTION
**Description**
Unable to parse `TransferNotificationRequest` starting at v30 due to (#1199) due to missing null-check after refactor.

I've reverted the change made in [this commit](https://github.com/Adyen/adyen-dotnet-api-library/commit/5725b745996341ef21a6c7ff7464b6f3ac6b2369#r168560647)

Kudos to [milandhango](https://github.com/milandhango) for reporting the bug and [gmcelhanon](https://github.com/gmcelhanon) for going back-in-time and identifying the root-cause

**Fixed issue**:
#1199