### PR TITLE
V7 generator - Update workflow to address parallelism issues for windows-latest during build

### DIFF
--- a/.github/workflows/build-net8.0.yml
+++ b/.github/workflows/build-net8.0.yml
@@ -31,11 +31,16 @@ jobs:
         with:
           dotnet-version: 8.0.x
 
+      - name: Clean
+        run: dotnet clean
+
       - name: Restore dependencies
-        run: dotnet restore
+        run: dotnet restore -m:1          # -m:1 disables parallelism and ensures only one build touches /obj. 
 
       - name: Build (debug) in .NET 8.0
-        run: dotnet build --configuration Debug --framework net8.0
+        run: dotnet build --no-restore -m:1 --framework net8.0
+        env:
+          UseSharedCompilation: false     # We are dealing with two sources of parallelism (see matrix) - Adyen.GeneratedMSBuildEditorConfig.editorconfig gets a .lock-file, this prevents another parallel process from accessing the build during the .lock. 
 
       - name: Run unit tests in .NET 8.0
-        run: dotnet test --configuration Debug --framework net8.0 --no-restore Adyen.Test/Adyen.Test.csproj
+        run: dotnet test --no-build --framework net8.0 Adyen.Test/Adyen.Test.csproj

--- a/Adyen/Adyen.csproj
+++ b/Adyen/Adyen.csproj
@@ -12,6 +12,7 @@
     <FileVersion>33.0.0</FileVersion>
     <IncludeSymbols>true</IncludeSymbols>
     <IncludeSource>true</IncludeSource>
+    <BuildInParallel>false</BuildInParallel>
     <Description>The Adyen API Library for .NET Core allows developers to interact with the Adyen APIs, including Hosted Payment Pages and the Terminal API.</Description>
     <PackageProjectUrl>https://github.com/Adyen/adyen-dotnet-api-library</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Adyen/adyen-dotnet-api-library</RepositoryUrl>
@@ -42,13 +43,6 @@
     <PackageReference Include="Polly" Version="8.6.4" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.Json" Version="8.0.6" />
-  </ItemGroup>
-  
-  <!-- .NET 4.5 references, compilation flags and build options -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Web" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
We are dealing with two sources of parallelism (see matrix) - Adyen.GeneratedMSBuildEditorConfig.editorconfig gets a .lock-file, this prevents another parallel process from accessing the build during the .lock. 

```txt
...adyen-dotnet-api-library\Adyen\obj\Debug\net8.0\Adyen.dll' for writing -- The process cannot access the file 'D:\a\adyen-dotnet-api-library\adyen-dotnet-api-library\Adyen\obj\Debug\net8.0\Adyen.dll' because it is being used by another process.; file may be locked by 'VBCSCompiler'
```

This PR addresses the following issues:
* Workflow no longer GeneratePackageOnBuild (pkg) when `dotnet build` is called
   * We also set `UseSharedCompilation` to `false`
* `dotnet clean` is called before the build/test steps to ensure a clean run
* `dotnet build` and `dotnet restore` no longer builds in parallel
* Removed .NET 4.5 properties in .csproj

**Note:**
* **[!]** T his is required for https://github.com/Adyen/adyen-dotnet-api-library/pull/1128 

**Tested scenario:**
* I've ran the workflow with models here in this closed-PR: #1227 the pipeline is green ✅ 


