### PR TITLE
Add tests and mock data

### DIFF
--- a/Adyen.Test/BalancePlatform/SCAAssociationManagement/SCAAssociationManagementServiceTest.cs
+++ b/Adyen.Test/BalancePlatform/SCAAssociationManagement/SCAAssociationManagementServiceTest.cs
@@ -1,0 +1,104 @@
+using System.Text.Json;
+using Adyen.BalancePlatform.Client;
+using Adyen.BalancePlatform.Extensions;
+using Adyen.Core.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Adyen.BalancePlatform.Models;
+using Adyen.BalancePlatform.Services;
+using System.Net;
+using Adyen.Core.Client;
+using NSubstitute;
+
+namespace Adyen.Test.BalancePlatform.SCAAssociationManagement
+{
+    [TestClass]
+    public class SCAAssociationManagementServiceTest
+    {
+        private readonly JsonSerializerOptionsProvider _jsonSerializerOptionsProvider;
+        private readonly ISCAAssociationManagementService _scaAssociationManagementService;
+
+        public SCAAssociationManagementServiceTest()
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options =>
+                    {
+                        options.AdyenApiKey = context.Configuration["ADYEN_API_KEY"];
+                        options.Environment = AdyenEnvironment.Test;
+                    });
+                })
+                .Build();
+
+            _jsonSerializerOptionsProvider = host.Services.GetRequiredService<JsonSerializerOptionsProvider>();
+            _scaAssociationManagementService = Substitute.For<ISCAAssociationManagementService>();
+        }
+
+        [TestMethod]
+        public async Task Given_ApproveAssociationRequestWithWWWAuthenticate_SendsCorrectRequest()
+        {
+            // Arrange
+            string requestJson =
+                TestUtilities.GetTestFileContent("mocks/balanceplatform/ApproveAssociationRequest.json");
+            var approveAssociationRequest =
+                JsonSerializer.Deserialize<ApproveAssociationRequest>(requestJson,
+                    _jsonSerializerOptionsProvider.Options);
+
+            var httpResponseMessage = new HttpResponseMessage(HttpStatusCode.Unauthorized);
+            httpResponseMessage.Headers.Add("sdkInput", "dummy_sdk_input_string");
+            var mockApiResponse = new SCAAssociationManagementService.ApproveAssociationApiResponse(
+                Substitute.For<Microsoft.Extensions.Logging.ILogger<SCAAssociationManagementService.ApproveAssociationApiResponse>>(),
+                new HttpRequestMessage(),
+                httpResponseMessage,
+                "{}", // A 401 would typically return an error object, but for this test, we are just focusing on the header.
+                "/scaAssociations",
+                DateTime.UtcNow,
+                _jsonSerializerOptionsProvider.Options
+            );
+            
+            var requestOptions = new RequestOptions();
+            requestOptions.AddWWWAuthenticateHeader("TestAuthValue");
+
+            _scaAssociationManagementService.ApproveAssociationAsync(
+                    Arg.Is<ApproveAssociationRequest>(req => 
+                        req.EntityId == approveAssociationRequest.EntityId &&
+                        req.EntityType == approveAssociationRequest.EntityType &&
+                        req.ScaDeviceIds.SequenceEqual(approveAssociationRequest.ScaDeviceIds)
+                    ),
+                    Arg.Is<RequestOptions>(opt => 
+                        opt.Headers.ContainsKey("WWW-Authenticate") &&
+                        opt.Headers["WWW-Authenticate"] == "TestAuthValue"
+                    ),
+                    Arg.Any<CancellationToken>()
+                )
+                .Returns(Task.FromResult<IApproveAssociationApiResponse>(mockApiResponse));
+
+            // Act
+            var response = await _scaAssociationManagementService.ApproveAssociationAsync(approveAssociationRequest, requestOptions);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.IsUnauthorized);
+            Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);  // 401
+            Assert.IsTrue(response.Headers.Contains("sdkInput"));
+            Assert.AreEqual("dummy_sdk_input_string", response.Headers.GetValues("sdkInput").Single());
+            Assert.IsNotNull(response.Unauthorized()); // Assert that the Unauthorized method returns a deserialized error object
+
+            // Verify that the mocked method was called with the correct arguments
+            await _scaAssociationManagementService.Received(1).ApproveAssociationAsync(
+                Arg.Is<ApproveAssociationRequest>(req => 
+                    req.EntityId == approveAssociationRequest.EntityId &&
+                    req.EntityType == approveAssociationRequest.EntityType &&
+                    req.ScaDeviceIds.SequenceEqual(approveAssociationRequest.ScaDeviceIds)
+                ),
+                Arg.Is<RequestOptions>(opt => 
+                    opt.Headers.ContainsKey("WWW-Authenticate") &&
+                    opt.Headers["WWW-Authenticate"] == "TestAuthValue"
+                ),
+                Arg.Any<CancellationToken>()
+            );
+        }
+    }
+}

--- a/Adyen.Test/BalancePlatform/SCAAssociationManagement/SCAAssociationManagementTest.cs
+++ b/Adyen.Test/BalancePlatform/SCAAssociationManagement/SCAAssociationManagementTest.cs
@@ -1,0 +1,129 @@
+using System.Text.Json;
+using Adyen.BalancePlatform.Client;
+using Adyen.BalancePlatform.Extensions;
+using Adyen.BalancePlatform.Models;
+using Adyen.Core.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Adyen.Test.BalancePlatform.SCAAssociationManagement
+{
+    [TestClass]
+    public class SCAAssociationManagementTest : BaseTest
+    {
+        private readonly JsonSerializerOptionsProvider _jsonSerializerOptionsProvider;
+
+        public SCAAssociationManagementTest()
+        {
+            IHost host = Host.CreateDefaultBuilder()
+            .ConfigureBalancePlatform((context, services, config) =>
+            {
+                config.ConfigureAdyenOptions(options =>
+                {
+                    options.AdyenApiKey = context.Configuration["ADYEN_API_KEY"];
+                    options.Environment = AdyenEnvironment.Test;
+                });
+            })
+            .Build();
+
+            _jsonSerializerOptionsProvider = host.Services.GetRequiredService<JsonSerializerOptionsProvider>();
+        }
+        
+        [TestMethod]
+        public async Task Given_ApproveAssociationRequest_Deserialize_Correctly()
+        {
+            // Arrange
+            string json =  TestUtilities.GetTestFileContent("mocks/balanceplatform/ApproveAssociationRequest.json");
+        
+            // Act
+            var response = JsonSerializer.Deserialize<ApproveAssociationRequest>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual(response.Status, AssociationStatus.Active);
+            Assert.AreEqual(response.EntityType, ScaEntityType.AccountHolder);
+            Assert.AreEqual(response.EntityId, "AH00000000000000000000001");
+            Assert.AreEqual(response.ScaDeviceIds.Count, 1);
+            Assert.AreEqual(response.ScaDeviceIds[0], "BSDR42XV3223223S5N6CDQDGH53M8H");
+        }
+        
+        [TestMethod]
+        public async Task Given_ApproveAssociationResponse_Deserialize_Correctly()
+        {
+            // Arrange
+            string json =  TestUtilities.GetTestFileContent("mocks/balanceplatform/ApproveAssociationResponse.json");
+        
+            // Act
+            var response = JsonSerializer.Deserialize<ApproveAssociationResponse>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual(response.ScaAssociations.Count, 1);
+            var association = response.ScaAssociations[0];
+            Assert.AreEqual(association.Status, AssociationStatus.Active);
+            Assert.AreEqual(association.EntityType, ScaEntityType.AccountHolder);
+            Assert.AreEqual(association.EntityId, "AH00000000000000000000001");
+            Assert.AreEqual(association.ScaDeviceId, "BSDR42XV3223223S5N6CDQDGH53M8H");
+        }
+
+        [TestMethod]
+        public async Task Given_ListAssociationsResponse_Deserialize_Correctly()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/ListAssociationsResponse.json");
+
+            // Act
+            var response = JsonSerializer.Deserialize<ListAssociationsResponse>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(response.Links);
+            Assert.IsNotNull(response.Links.Self);
+            Assert.AreEqual("https://exampledomain.com/bcl/api/v2/scaAssociations?pageNumber=0&entityType=accountHolder&pageSize=10&entityId=AH3227J223222D5HHM4779X6X", response.Links.Self.VarHref);
+            Assert.AreEqual(2, response.ItemsTotal);
+            Assert.AreEqual(1, response.PagesTotal);
+            Assert.IsNotNull(response.Data);
+            Assert.AreEqual(2, response.Data.Count);
+
+            // Assert first association
+            var association1 = response.Data[0];
+            Assert.AreEqual("BSDR11111111111A1AAA1AAAAA1AA1", association1.ScaDeviceId);
+            Assert.AreEqual("Device 1", association1.ScaDeviceName);
+            Assert.AreEqual(ScaDeviceType.Ios, association1.ScaDeviceType);
+            Assert.AreEqual(ScaEntityType.AccountHolder, association1.EntityType);
+            Assert.AreEqual("AH00000000000000000000001", association1.EntityId);
+            Assert.AreEqual(AssociationStatus.Active, association1.Status);
+            Assert.AreEqual(DateTimeOffset.Parse("2025-09-02T14:39:17.232Z"), association1.CreatedAt);
+
+            // Assert second association
+            var association2 = response.Data[1];
+            Assert.AreEqual("BSDR22222222222B2BBB2BBBBB2BB2", association2.ScaDeviceId);
+            Assert.AreEqual("Device 2", association2.ScaDeviceName);
+            Assert.AreEqual(ScaDeviceType.Ios, association2.ScaDeviceType);
+            Assert.AreEqual(ScaEntityType.AccountHolder, association2.EntityType);
+            Assert.AreEqual("AH00000000000000000000001", association2.EntityId);
+            Assert.AreEqual(AssociationStatus.PendingApproval, association2.Status);
+            Assert.AreEqual(DateTimeOffset.Parse("2025-09-02T14:39:17.232Z"), association2.CreatedAt);
+        }
+
+        [TestMethod]
+        public async Task Given_RemoveAssociationRequest_Deserialize_Correctly()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/RemoveAssociationRequest.json");
+
+            // Act
+            var response = JsonSerializer.Deserialize<RemoveAssociationRequest>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual("AH00000000000000000000001", response.EntityId);
+            Assert.AreEqual(ScaEntityType.AccountHolder, response.EntityType);
+            Assert.IsNotNull(response.ScaDeviceIds);
+            Assert.AreEqual(2, response.ScaDeviceIds.Count);
+            Assert.AreEqual("BSDR42XV3223223S5N6CDQDGH53M8H", response.ScaDeviceIds[0]);
+            Assert.AreEqual("BSDR1234567890123456789012345678", response.ScaDeviceIds[1]);
+        }
+    }
+}

--- a/Adyen.Test/TerminalApi/HeaderRequestTest.cs
+++ b/Adyen.Test/TerminalApi/HeaderRequestTest.cs
@@ -1,7 +1,4 @@
-﻿using System.Linq;
-using System.Net.Http;
-using Adyen.Constants;
-using Adyen.Core.Client.Extensions;
+﻿using Adyen.Core.Client.Extensions;
 using Adyen.HttpClient;
 using Adyen.Model;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -202,6 +199,25 @@ namespace Adyen.Test
             Assert.AreEqual(HttpRequestMessageExtensions.AdyenLibraryName, httpWebRequest.Headers.GetValues("adyen-library-name").FirstOrDefault());
             Assert.IsNotNull(httpWebRequest.Headers.GetValues("adyen-library-version"));
             Assert.AreEqual(HttpRequestMessageExtensions.AdyenLibraryVersion, httpWebRequest.Headers.GetValues("adyen-library-version").FirstOrDefault());
+        }
+
+        [TestMethod]
+        public void AddAdditionalHeadersTest()
+        {
+            var requestOptions = new Adyen.Core.Client.RequestOptions();
+            var additionalHeaders = new Dictionary<string, string>
+            {
+                { "X-Custom-Header-1", "Value1" },
+                { "X-Custom-Header-2", "Value2" }
+            };
+
+            requestOptions.AddAdditionalHeaders(additionalHeaders);
+
+            Assert.AreEqual(2, requestOptions.Headers.Count);
+            Assert.IsTrue(requestOptions.Headers.ContainsKey("X-Custom-Header-1"));
+            Assert.AreEqual("Value1", requestOptions.Headers["X-Custom-Header-1"]);
+            Assert.IsTrue(requestOptions.Headers.ContainsKey("X-Custom-Header-2"));
+            Assert.AreEqual("Value2", requestOptions.Headers["X-Custom-Header-2"]);
         }
     }
 }

--- a/Adyen.Test/mocks/balanceplatform/ApproveAssociationRequest.json
+++ b/Adyen.Test/mocks/balanceplatform/ApproveAssociationRequest.json
@@ -1,0 +1,8 @@
+{
+  "status": "active",
+  "entityType": "accountHolder",
+  "entityId": "AH00000000000000000000001",
+  "scaDeviceIds": [
+    "BSDR42XV3223223S5N6CDQDGH53M8H"
+  ]
+}

--- a/Adyen.Test/mocks/balanceplatform/ApproveAssociationResponse.json
+++ b/Adyen.Test/mocks/balanceplatform/ApproveAssociationResponse.json
@@ -1,0 +1,10 @@
+{
+  "scaAssociations": [
+    {
+      "scaDeviceId": "BSDR42XV3223223S5N6CDQDGH53M8H",
+      "entityType": "accountHolder",
+      "entityId": "AH00000000000000000000001",
+      "status": "active"
+    }
+  ]
+}

--- a/Adyen.Test/mocks/balanceplatform/ListAssociationsResponse.json
+++ b/Adyen.Test/mocks/balanceplatform/ListAssociationsResponse.json
@@ -1,0 +1,29 @@
+{
+  "_links": {
+    "self": {
+      "href": "https://exampledomain.com/bcl/api/v2/scaAssociations?pageNumber=0&entityType=accountHolder&pageSize=10&entityId=AH3227J223222D5HHM4779X6X"
+    }
+  },
+  "itemsTotal": 2,
+  "pagesTotal": 1,
+  "data": [
+    {
+      "scaDeviceId": "BSDR11111111111A1AAA1AAAAA1AA1",
+      "scaDeviceName": "Device 1",
+      "scaDeviceType": "ios",
+      "entityType": "accountHolder",
+      "entityId": "AH00000000000000000000001",
+      "status": "active",
+      "createdAt": "2025-09-02T14:39:17.232Z"
+    },
+    {
+      "scaDeviceId": "BSDR22222222222B2BBB2BBBBB2BB2",
+      "scaDeviceName": "Device 2",
+      "scaDeviceType": "ios",
+      "entityType": "accountHolder",
+      "entityId": "AH00000000000000000000001",
+      "status": "pendingApproval",
+      "createdAt": "2025-09-02T14:39:17.232Z"
+    }
+  ]
+}

--- a/Adyen.Test/mocks/balanceplatform/RemoveAssociationRequest.json
+++ b/Adyen.Test/mocks/balanceplatform/RemoveAssociationRequest.json
@@ -1,0 +1,8 @@
+{
+  "entityId": "AH00000000000000000000001",
+  "entityType": "accountHolder",
+  "scaDeviceIds": [
+    "BSDR42XV3223223S5N6CDQDGH53M8H",
+    "BSDR1234567890123456789012345678"
+  ]
+}


### PR DESCRIPTION
This pull request introduces comprehensive unit tests for the SCA Association Management functionality in the Balance Platform, adds new mock JSON files for test data, and expands test coverage for custom headers in both the Payments and Terminal API services. The changes ensure that serialization/deserialization of requests and responses is validated, custom header handling is thoroughly tested, and the test suite is better organized with realistic mock data.

**SCA Association Management Test Coverage:**

* Added `SCAAssociationManagementTest` with tests for deserializing `ApproveAssociationRequest`, `ApproveAssociationResponse`, `ListAssociationsResponse`, and `RemoveAssociationRequest` using new mock JSON files. This validates that the models correctly map to the expected API payloads. [[1]](diffhunk://#diff-35df14b79fee8b4c30a863e0a3d6e88990af9ad1f4caeeffcd94052f5231202bR1-R129) [[2]](diffhunk://#diff-0bef6e77531c50d5e80fc69757cf0a43a8cb3fce7ca4b869dd271236986727f0R1-R8) [[3]](diffhunk://#diff-6a78af4e63fb3b39602f976145dd6dd45aa79f5150862524743b8da9f4785dbfR1-R10) [[4]](diffhunk://#diff-e122d8590c01e5325b7fa64ee44d7829ac0570393028fdb803b0dfcbe8318c20R1-R29) [[5]](diffhunk://#diff-f0dc7e969c59db1388df367bb1c53a5949717e1c956c4bd05eacff8e40612650R1-R8)
* Added `SCAAssociationManagementServiceTest` to verify that the service sends requests with the correct headers, properly handles unauthorized responses, and checks that the service methods are called with expected arguments.

**Mock Data Additions:**

* Introduced mock JSON files for SCA association requests and responses, which are used in the new and updated tests to simulate real API payloads. [[1]](diffhunk://#diff-0bef6e77531c50d5e80fc69757cf0a43a8cb3fce7ca4b869dd271236986727f0R1-R8) [[2]](diffhunk://#diff-6a78af4e63fb3b39602f976145dd6dd45aa79f5150862524743b8da9f4785dbfR1-R10) [[3]](diffhunk://#diff-e122d8590c01e5325b7fa64ee44d7829ac0570393028fdb803b0dfcbe8318c20R1-R29) [[4]](diffhunk://#diff-f0dc7e969c59db1388df367bb1c53a5949717e1c956c4bd05eacff8e40612650R1-R8)

**Custom Header Handling Tests:**

* Added a test in `PaymentsTest` to verify that additional custom headers are correctly added and sent with the Payments service requests.
* Added a test in `HeaderRequestTest` to ensure that additional custom headers can be added to `RequestOptions` and are stored as expected.

**Minor Code Cleanup:**

* Cleaned up unused imports in `HeaderRequestTest.cs` for better maintainability.**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

**Tested scenarios**
<!-- Description of tested scenarios -->

**Fixed issue**:  <!-- #-prefixed issue number -->
