### PR TITLE
Add merge_group to build workflow configuration

### DIFF
--- a/.github/workflows/build-net8.0.yml
+++ b/.github/workflows/build-net8.0.yml
@@ -9,6 +9,7 @@ on:
       - main
       - sdk-automation/models
       - promote/main
+  merge_group:    
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
This pull request makes a small update to the workflow triggers in `.github/workflows/javaci.yml`. The change radds a new trigger for `merge_group` events.

This is necessary to trigger the GitHub Actions workflow when a pull request is added to a merge queue.

See GitHub [doc](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions) 

