### PR TITLE
Fix the typo of cref in the XML doc, 

### DIFF
--- a/templates-v7/csharp/libraries/generichost/JsonConverter.mustache
+++ b/templates-v7/csharp/libraries/generichost/JsonConverter.mustache
@@ -427,7 +427,7 @@
         /// <summary>
         /// Serializes the properties of <see cref="{{classname}}"/>.
         /// </summary>
-        /// <param name="writer"><see creft="Utf8JsonWriter"/></param>
+        /// <param name="writer"><see cref="Utf8JsonWriter"/></param>
         /// <param name="{{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}"></param>
         /// <param name="jsonSerializerOptions"><see cref="JsonSerializerOptions"/></param>
         /// <exception cref="NotImplementedException"></exception>


### PR DESCRIPTION
**Description**
The file `templates-v7/csharp/libraries/generichost/JsonConverter.mustache` at line 430, the comment has been corrected with the correct word "cref" instead of "creft".

**Tested scenarios**

**Fixed issue**:  #1256 