### PR TITLE
HmacKeyToken: change AdyenHmacKey property to non-nullable string

### DIFF
--- a/templates-v7/csharp/libraries/generichost/HmacKeyToken.mustache
+++ b/templates-v7/csharp/libraries/generichost/HmacKeyToken.mustache
@@ -21,7 +21,7 @@ namespace {{packageName}}.{{apiName}}.{{clientPackage}}
         /// <summary>
         /// The `ADYEN_HMAC_KEY`, can be configured in <see cref="Adyen.Core.Options.AdyenOptions"/>.
         /// </summary>
-        public string? AdyenHmacKey { get; }
+        public string AdyenHmacKey { get; }
     
         /// <summary>
         /// Constructs the HmacKeyToken object with the ADYEN_HMAC_KEY value provided.


### PR DESCRIPTION
This pull request makes a small but important change to the `HmacKeyToken` class property definition. 
The property `AdyenHmacKey` is now required and no longer nullable, which enforces that a value must always be provided when constructing this object. This is aligned with the constructor that requires a non-nullable string.

See Gemini [feedback](https://github.com/Adyen/adyen-dotnet-api-library/pull/1251#discussion_r2782393351)
