### PR TITLE
Turn HttpMethod into uppercase

### DIFF
--- a/templates-v7/csharp/libraries/generichost/api.mustache
+++ b/templates-v7/csharp/libraries/generichost/api.mustache
@@ -412,7 +412,7 @@ namespace {{packageName}}.{{apiPackage}}
                     {{/produces}}
                     {{#net60OrLater}}
 #if NET462 || NETSTANDARD2_0
-                    httpRequestMessage.Method = new HttpMethod("{{#lambda.titlecase}}{{#lambda.lowercase}}{{httpMethod}}{{/lambda.lowercase}}{{/lambda.titlecase}}");
+                    httpRequestMessage.Method = new HttpMethod("{{#lambda.titlecase}}{{#lambda.uppercase}}{{httpMethod}}{{/lambda.uppercase}}{{/lambda.titlecase}}");
 #else
                     httpRequestMessage.Method = HttpMethod.{{#lambda.titlecase}}{{#lambda.lowercase}}{{httpMethod}}{{/lambda.lowercase}}{{/lambda.titlecase}};
 #endif


### PR DESCRIPTION
To maintain netstandard2.0 support, which [does **not support** `HttpMethod.Patch`](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpmethod.post?view=netstandard-2.0), we initialize the raw string (new HttpMethod("PATCH")) similar to what we do in our [HttpClientWrapper](https://github.com/Adyen/adyen-dotnet-api-library/blob/v32.2.1/Adyen/HttpClient/HttpClientWrapper.cs#L58). The `mustache`-template doesn't allow us to check for `if == PATCH`, hence the proposed fix uses `new HttpMethod(...)`


**Description**
Capitalize HttpMethod("POST"), idem for GET, PATCH, DELETE etc.



**Fixed issue**:  <!-- #-prefixed issue number -->
Addresses: https://github.com/Adyen/adyen-dotnet-api-library/pull/1322/changes#r2792649021