### PR TITLE
Update function docs: fix incorrect throw `NotImplementedException`

### DIFF
--- a/templates-v7/csharp/libraries/generichost/JsonConverter.mustache
+++ b/templates-v7/csharp/libraries/generichost/JsonConverter.mustache
@@ -328,7 +328,6 @@
         /// <param name="writer"><see cref="Utf8JsonWriter"/></param>
         /// <param name="{{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}"></param>
         /// <param name="jsonSerializerOptions"><see cref="JsonSerializerOptions"/></param>
-        /// <exception cref="NotImplementedException"></exception>
         public override void Write(Utf8JsonWriter writer, {{classname}} {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}, JsonSerializerOptions jsonSerializerOptions)
         {
             {{#lambda.trimLineBreaks}}
@@ -430,7 +429,6 @@
         /// <param name="writer"><see cref="Utf8JsonWriter"/></param>
         /// <param name="{{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}"></param>
         /// <param name="jsonSerializerOptions"><see cref="JsonSerializerOptions"/></param>
-        /// <exception cref="NotImplementedException"></exception>
         public void WriteProperties(Utf8JsonWriter writer, {{classname}} {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}, JsonSerializerOptions jsonSerializerOptions)
         {
             {{#lambda.trimTrailingWithNewLine}}


### PR DESCRIPTION
Update templates to remove incorrect comment about throwing `NotImplementedException`

Fix #1255