### PR TITLE
fix: restrict System.Net.Http NuGet reference to net462 and netstanda…

### DIFF
--- a/Adyen/Adyen.csproj
+++ b/Adyen/Adyen.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 
-  <!-- System.Net.Http is built into the runtime for net8.0+; only reference the NuGet package for older targets -->
+  <!-- System.Net.Http is built into the runtime for net6.0+; only reference the NuGet package for older targets -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>


### PR DESCRIPTION
`System.Net.Http` v4.3.4 was unconditionally referenced across all target frameworks, causing .NET 8 consumers to pull in a vulnerable legacy package (CVE-2019-0981, CVE-2019-0980, CVE-2019-0657) despite `System.Net.Http` being inbox on .NET 8+.

   1. For `.NET 6` and `.NET 8`: `System.Net.Http` is built into the runtime, so they don't need the NuGet package. Excluding it for these targets is actually cleaner and avoids potential version conflicts.

   2. For `.NET Framework 4.6.2` and `.NET Standard 2.0`: The package is still included via the conditional, so these older targets continue to work.

### Test Runs
`v6`: https://github.com/Adyen/adyen-dotnet-api-library/actions/runs/23182595435
`v8`: https://github.com/Adyen/adyen-dotnet-api-library/actions/runs/23182733560
