### PR TITLE
Fix: JsonConverters crash on null nullable value-type Option<T?> properties

### DIFF
--- a/Adyen.Test/Checkout/NullableOptionSerializationTest.cs
+++ b/Adyen.Test/Checkout/NullableOptionSerializationTest.cs
@@ -1,0 +1,83 @@
+using System.Text.Json;
+using Adyen.Checkout.Client;
+using Adyen.Checkout.Extensions;
+using Adyen.Checkout.Models;
+using Adyen.Core.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Adyen.Test.Checkout
+{
+    [TestClass]
+    public class NullableOptionSerializationTest
+    {
+        private readonly JsonSerializerOptionsProvider _jsonSerializerOptionsProvider;
+
+        public NullableOptionSerializationTest()
+        {
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigureCheckout((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options =>
+                    {
+                        options.Environment = AdyenEnvironment.Test;
+                    });
+                })
+                .Build();
+
+            _jsonSerializerOptionsProvider = testHost.Services.GetRequiredService<JsonSerializerOptionsProvider>();
+        }
+
+        // Passes: nullable reference-type Option<string?> with null value serializes correctly.
+        [TestMethod]
+        public void Given_PaymentLinkRequest_When_NullableString_IsExplicitlyNull_Then_Serializes_Without_Error()
+        {
+            var request = new PaymentLinkRequest(
+                amount: new Amount("EUR", 1000),
+                merchantAccount: "TestMerchant",
+                reference: "test-ref",
+                countryCode: null
+            );
+
+            string json = JsonSerializer.Serialize(request, _jsonSerializerOptionsProvider.Options);
+
+            Assert.IsNotNull(json);
+            Assert.IsFalse(json.Contains("countryCode"), "Null optional string should be omitted from JSON output.");
+        }
+
+        // Fails: nullable value-type Option<bool?> with null value throws InvalidOperationException.
+        [TestMethod]
+        public void Given_PaymentLinkRequest_When_NullableBool_IsExplicitlyNull_Then_Serializes_Without_Error()
+        {
+            var request = new PaymentLinkRequest(
+                amount: new Amount("EUR", 1000),
+                merchantAccount: "TestMerchant",
+                reference: "test-ref",
+                reusable: null
+            );
+
+            string json = JsonSerializer.Serialize(request, _jsonSerializerOptionsProvider.Options);
+
+            Assert.IsNotNull(json);
+            Assert.IsFalse(json.Contains("reusable"), "Null optional bool should be omitted from JSON output.");
+        }
+
+        // Fails: nullable value-type Option<int?> with null value throws InvalidOperationException.
+        [TestMethod]
+        public void Given_PaymentLinkRequest_When_NullableInt_IsExplicitlyNull_Then_Serializes_Without_Error()
+        {
+            var request = new PaymentLinkRequest(
+                amount: new Amount("EUR", 1000),
+                merchantAccount: "TestMerchant",
+                reference: "test-ref",
+                captureDelayHours: null
+            );
+
+            string json = JsonSerializer.Serialize(request, _jsonSerializerOptionsProvider.Options);
+
+            Assert.IsNotNull(json);
+            Assert.IsFalse(json.Contains("captureDelayHours"), "Null optional int should be omitted from JSON output.");
+        }
+    }
+}

--- a/Adyen.Test/Checkout/NullableOptionSerializationTest.cs
+++ b/Adyen.Test/Checkout/NullableOptionSerializationTest.cs
@@ -46,7 +46,6 @@ namespace Adyen.Test.Checkout
             Assert.IsFalse(json.Contains("countryCode"), "Null optional string should be omitted from JSON output.");
         }
 
-        // Fails: nullable value-type Option<bool?> with null value throws InvalidOperationException.
         [TestMethod]
         public void Given_PaymentLinkRequest_When_NullableBool_IsExplicitlyNull_Then_Serializes_Without_Error()
         {
@@ -63,7 +62,6 @@ namespace Adyen.Test.Checkout
             Assert.IsFalse(json.Contains("reusable"), "Null optional bool should be omitted from JSON output.");
         }
 
-        // Fails: nullable value-type Option<int?> with null value throws InvalidOperationException.
         [TestMethod]
         public void Given_PaymentLinkRequest_When_NullableInt_IsExplicitlyNull_Then_Serializes_Without_Error()
         {
@@ -78,6 +76,40 @@ namespace Adyen.Test.Checkout
 
             Assert.IsNotNull(json);
             Assert.IsFalse(json.Contains("captureDelayHours"), "Null optional int should be omitted from JSON output.");
+        }
+
+        [TestMethod]
+        public void Given_CreateCheckoutSessionRequest_When_NullableDate_IsExplicitlyNull_Then_Serializes_Without_Error()
+        {
+            var request = new CreateCheckoutSessionRequest(
+                amount: new Amount("EUR", 1000),
+                merchantAccount: "TestMerchant",
+                reference: "test-ref",
+                returnUrl: "https://example.com",
+                dateOfBirth: null
+            );
+
+            string json = JsonSerializer.Serialize(request, _jsonSerializerOptionsProvider.Options);
+
+            Assert.IsNotNull(json);
+            Assert.IsFalse(json.Contains("dateOfBirth"), "Null optional DateOnly? should be omitted from JSON output.");
+        }
+
+        [TestMethod]
+        public void Given_CreateCheckoutSessionRequest_When_NullableDateTime_IsExplicitlyNull_Then_Serializes_Without_Error()
+        {
+            var request = new CreateCheckoutSessionRequest(
+                amount: new Amount("EUR", 1000),
+                merchantAccount: "TestMerchant",
+                reference: "test-ref",
+                returnUrl: "https://example.com",
+                expiresAt: null
+            );
+
+            string json = JsonSerializer.Serialize(request, _jsonSerializerOptionsProvider.Options);
+
+            Assert.IsNotNull(json);
+            Assert.IsFalse(json.Contains("expiresAt"), "Null optional DateTimeOffset? should be omitted from JSON output.");
         }
     }
 }

--- a/Adyen.Test/Checkout/NullableOptionSerializationTest.cs
+++ b/Adyen.Test/Checkout/NullableOptionSerializationTest.cs
@@ -111,5 +111,86 @@ namespace Adyen.Test.Checkout
             Assert.IsNotNull(json);
             Assert.IsFalse(json.Contains("expiresAt"), "Null optional DateTimeOffset? should be omitted from JSON output.");
         }
+
+        [TestMethod]
+        public void Given_PaymentLinkRequest_When_NullableBool_HasValue_Then_Serializes_Correctly()
+        {
+            var request = new PaymentLinkRequest(
+                amount: new Amount("EUR", 1000),
+                merchantAccount: "TestMerchant",
+                reference: "test-ref",
+                reusable: true
+            );
+
+            string json = JsonSerializer.Serialize(request, _jsonSerializerOptionsProvider.Options);
+
+            Assert.IsTrue(json.Contains("\"reusable\":true"), "Non-null optional bool should appear in JSON output.");
+        }
+
+        [TestMethod]
+        public void Given_PaymentLinkRequest_When_NullableInt_HasValue_Then_Serializes_Correctly()
+        {
+            var request = new PaymentLinkRequest(
+                amount: new Amount("EUR", 1000),
+                merchantAccount: "TestMerchant",
+                reference: "test-ref",
+                captureDelayHours: 5
+            );
+
+            string json = JsonSerializer.Serialize(request, _jsonSerializerOptionsProvider.Options);
+
+            Assert.IsTrue(json.Contains("\"captureDelayHours\":5"), "Non-null optional int should appear in JSON output.");
+        }
+
+        [TestMethod]
+        public void Given_CreateCheckoutSessionRequest_When_NullableDateTime_HasValue_Then_Serializes_Correctly()
+        {
+            var expiresAt = new DateTimeOffset(2026, 12, 31, 23, 59, 59, TimeSpan.Zero);
+            var request = new CreateCheckoutSessionRequest(
+                amount: new Amount("EUR", 1000),
+                merchantAccount: "TestMerchant",
+                reference: "test-ref",
+                returnUrl: "https://example.com",
+                expiresAt: expiresAt
+            );
+
+            string json = JsonSerializer.Serialize(request, _jsonSerializerOptionsProvider.Options);
+
+            Assert.IsTrue(json.Contains("expiresAt"), "Non-null optional DateTimeOffset? should appear in JSON output.");
+        }
+
+        [TestMethod]
+        public void Given_PaymentLinkRequest_When_NullableBool_IsExplicitlyNull_Then_RoundTrip_Produces_No_Value()
+        {
+            var original = new PaymentLinkRequest(
+                amount: new Amount("EUR", 1000),
+                merchantAccount: "TestMerchant",
+                reference: "test-ref",
+                reusable: null
+            );
+
+            string json = JsonSerializer.Serialize(original, _jsonSerializerOptionsProvider.Options);
+            var deserialized = JsonSerializer.Deserialize<PaymentLinkRequest>(json, _jsonSerializerOptionsProvider.Options);
+
+            Assert.IsNotNull(deserialized);
+            Assert.IsNull(deserialized.Reusable, "Omitted null bool should deserialize back as null.");
+        }
+
+        [TestMethod]
+        public void Given_PaymentLinkRequest_When_NullableBool_HasValue_Then_RoundTrip_Preserves_Value()
+        {
+            var original = new PaymentLinkRequest(
+                amount: new Amount("EUR", 1000),
+                merchantAccount: "TestMerchant",
+                reference: "test-ref",
+                reusable: true
+            );
+
+            string json = JsonSerializer.Serialize(original, _jsonSerializerOptionsProvider.Options);
+            var deserialized = JsonSerializer.Deserialize<PaymentLinkRequest>(json, _jsonSerializerOptionsProvider.Options);
+
+            Assert.IsNotNull(deserialized);
+            Assert.AreEqual(true, deserialized.Reusable);
+        }
     }
 }

--- a/Adyen/Checkout/Models/AccountInfo.cs
+++ b/Adyen/Checkout/Models/AccountInfo.cs
@@ -1320,7 +1320,8 @@ namespace Adyen.Checkout.Models
             }
             
             if (accountInfo._AccountChangeDateOption.IsSet)
-                writer.WriteString("accountChangeDate", accountInfo._AccountChangeDateOption.Value!.Value.ToString(AccountChangeDateFormat));
+                if (accountInfo._AccountChangeDateOption.Value != null)
+                    writer.WriteString("accountChangeDate", accountInfo._AccountChangeDateOption.Value!.Value.ToString(AccountChangeDateFormat));
 
             if (accountInfo._AccountChangeIndicatorOption.IsSet && accountInfo.AccountChangeIndicator != null) 
             {
@@ -1329,7 +1330,8 @@ namespace Adyen.Checkout.Models
             }
             
             if (accountInfo._AccountCreationDateOption.IsSet)
-                writer.WriteString("accountCreationDate", accountInfo._AccountCreationDateOption.Value!.Value.ToString(AccountCreationDateFormat));
+                if (accountInfo._AccountCreationDateOption.Value != null)
+                    writer.WriteString("accountCreationDate", accountInfo._AccountCreationDateOption.Value!.Value.ToString(AccountCreationDateFormat));
 
             if (accountInfo._AccountTypeOption.IsSet && accountInfo.AccountType != null) 
             {
@@ -1342,7 +1344,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteNumber("addCardAttemptsDay", accountInfo._AddCardAttemptsDayOption.Value!.Value);
 
             if (accountInfo._DeliveryAddressUsageDateOption.IsSet)
-                writer.WriteString("deliveryAddressUsageDate", accountInfo._DeliveryAddressUsageDateOption.Value!.Value.ToString(DeliveryAddressUsageDateFormat));
+                if (accountInfo._DeliveryAddressUsageDateOption.Value != null)
+                    writer.WriteString("deliveryAddressUsageDate", accountInfo._DeliveryAddressUsageDateOption.Value!.Value.ToString(DeliveryAddressUsageDateFormat));
 
             if (accountInfo._DeliveryAddressUsageIndicatorOption.IsSet && accountInfo.DeliveryAddressUsageIndicator != null) 
             {
@@ -1359,7 +1362,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("mobilePhone", accountInfo.MobilePhone);
 
             if (accountInfo._PasswordChangeDateOption.IsSet)
-                writer.WriteString("passwordChangeDate", accountInfo._PasswordChangeDateOption.Value!.Value.ToString(PasswordChangeDateFormat));
+                if (accountInfo._PasswordChangeDateOption.Value != null)
+                    writer.WriteString("passwordChangeDate", accountInfo._PasswordChangeDateOption.Value!.Value.ToString(PasswordChangeDateFormat));
 
             if (accountInfo._PasswordChangeIndicatorOption.IsSet && accountInfo.PasswordChangeIndicator != null) 
             {
@@ -1376,7 +1380,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteNumber("pastTransactionsYear", accountInfo._PastTransactionsYearOption.Value!.Value);
 
             if (accountInfo._PaymentAccountAgeOption.IsSet)
-                writer.WriteString("paymentAccountAge", accountInfo._PaymentAccountAgeOption.Value!.Value.ToString(PaymentAccountAgeFormat));
+                if (accountInfo._PaymentAccountAgeOption.Value != null)
+                    writer.WriteString("paymentAccountAge", accountInfo._PaymentAccountAgeOption.Value!.Value.ToString(PaymentAccountAgeFormat));
 
             if (accountInfo._PaymentAccountIndicatorOption.IsSet && accountInfo.PaymentAccountIndicator != null) 
             {

--- a/Adyen/Checkout/Models/AccountInfo.cs
+++ b/Adyen/Checkout/Models/AccountInfo.cs
@@ -1338,7 +1338,8 @@ namespace Adyen.Checkout.Models
             }
             
             if (accountInfo._AddCardAttemptsDayOption.IsSet)
-                writer.WriteNumber("addCardAttemptsDay", accountInfo._AddCardAttemptsDayOption.Value!.Value);
+                if (accountInfo._AddCardAttemptsDayOption.Value != null)
+                    writer.WriteNumber("addCardAttemptsDay", accountInfo._AddCardAttemptsDayOption.Value!.Value);
 
             if (accountInfo._DeliveryAddressUsageDateOption.IsSet)
                 writer.WriteString("deliveryAddressUsageDate", accountInfo._DeliveryAddressUsageDateOption.Value!.Value.ToString(DeliveryAddressUsageDateFormat));
@@ -1367,10 +1368,12 @@ namespace Adyen.Checkout.Models
             }
             
             if (accountInfo._PastTransactionsDayOption.IsSet)
-                writer.WriteNumber("pastTransactionsDay", accountInfo._PastTransactionsDayOption.Value!.Value);
+                if (accountInfo._PastTransactionsDayOption.Value != null)
+                    writer.WriteNumber("pastTransactionsDay", accountInfo._PastTransactionsDayOption.Value!.Value);
 
             if (accountInfo._PastTransactionsYearOption.IsSet)
-                writer.WriteNumber("pastTransactionsYear", accountInfo._PastTransactionsYearOption.Value!.Value);
+                if (accountInfo._PastTransactionsYearOption.Value != null)
+                    writer.WriteNumber("pastTransactionsYear", accountInfo._PastTransactionsYearOption.Value!.Value);
 
             if (accountInfo._PaymentAccountAgeOption.IsSet)
                 writer.WriteString("paymentAccountAge", accountInfo._PaymentAccountAgeOption.Value!.Value.ToString(PaymentAccountAgeFormat));
@@ -1382,10 +1385,12 @@ namespace Adyen.Checkout.Models
             }
             
             if (accountInfo._PurchasesLast6MonthsOption.IsSet)
-                writer.WriteNumber("purchasesLast6Months", accountInfo._PurchasesLast6MonthsOption.Value!.Value);
+                if (accountInfo._PurchasesLast6MonthsOption.Value != null)
+                    writer.WriteNumber("purchasesLast6Months", accountInfo._PurchasesLast6MonthsOption.Value!.Value);
 
             if (accountInfo._SuspiciousActivityOption.IsSet)
-                writer.WriteBoolean("suspiciousActivity", accountInfo._SuspiciousActivityOption.Value!.Value);
+                if (accountInfo._SuspiciousActivityOption.Value != null)
+                    writer.WriteBoolean("suspiciousActivity", accountInfo._SuspiciousActivityOption.Value!.Value);
 
             if (accountInfo._WorkPhoneOption.IsSet)
                 if (accountInfo.WorkPhone != null)

--- a/Adyen/Checkout/Models/Airline.cs
+++ b/Adyen/Checkout/Models/Airline.cs
@@ -437,7 +437,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("documentType", airline.DocumentType);
 
             if (airline._FlightDateOption.IsSet)
-                writer.WriteString("flightDate", airline._FlightDateOption.Value!.Value.ToString(FlightDateFormat));
+                if (airline._FlightDateOption.Value != null)
+                    writer.WriteString("flightDate", airline._FlightDateOption.Value!.Value.ToString(FlightDateFormat));
 
             if (airline._LegsOption.IsSet)
             {

--- a/Adyen/Checkout/Models/Airline.cs
+++ b/Adyen/Checkout/Models/Airline.cs
@@ -413,7 +413,8 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, airline.Agency, jsonSerializerOptions);
             }
             if (airline._BoardingFeeOption.IsSet)
-                writer.WriteNumber("boardingFee", airline._BoardingFeeOption.Value!.Value);
+                if (airline._BoardingFeeOption.Value != null)
+                    writer.WriteNumber("boardingFee", airline._BoardingFeeOption.Value!.Value);
 
             if (airline._CodeOption.IsSet)
                 if (airline.Code != null)

--- a/Adyen/Checkout/Models/AuthenticationData.cs
+++ b/Adyen/Checkout/Models/AuthenticationData.cs
@@ -309,7 +309,8 @@ namespace Adyen.Checkout.Models
             }
             
             if (authenticationData._AuthenticationOnlyOption.IsSet)
-                writer.WriteBoolean("authenticationOnly", authenticationData._AuthenticationOnlyOption.Value!.Value);
+                if (authenticationData._AuthenticationOnlyOption.Value != null)
+                    writer.WriteBoolean("authenticationOnly", authenticationData._AuthenticationOnlyOption.Value!.Value);
 
             if (authenticationData._ThreeDSRequestDataOption.IsSet)
             {

--- a/Adyen/Checkout/Models/BalanceCheckRequest.cs
+++ b/Adyen/Checkout/Models/BalanceCheckRequest.cs
@@ -1322,7 +1322,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteNumber("captureDelayHours", balanceCheckRequest._CaptureDelayHoursOption.Value!.Value);
 
             if (balanceCheckRequest._DateOfBirthOption.IsSet)
-                writer.WriteString("dateOfBirth", balanceCheckRequest._DateOfBirthOption.Value!.Value.ToString(DateOfBirthFormat));
+                if (balanceCheckRequest._DateOfBirthOption.Value != null)
+                    writer.WriteString("dateOfBirth", balanceCheckRequest._DateOfBirthOption.Value!.Value.ToString(DateOfBirthFormat));
 
             if (balanceCheckRequest._DccQuoteOption.IsSet)
             {
@@ -1335,7 +1336,8 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, balanceCheckRequest.DeliveryAddress, jsonSerializerOptions);
             }
             if (balanceCheckRequest._DeliveryDateOption.IsSet)
-                writer.WriteString("deliveryDate", balanceCheckRequest._DeliveryDateOption.Value!.Value.ToString(DeliveryDateFormat));
+                if (balanceCheckRequest._DeliveryDateOption.Value != null)
+                    writer.WriteString("deliveryDate", balanceCheckRequest._DeliveryDateOption.Value!.Value.ToString(DeliveryDateFormat));
 
             if (balanceCheckRequest._DeviceFingerprintOption.IsSet)
                 if (balanceCheckRequest.DeviceFingerprint != null)

--- a/Adyen/Checkout/Models/BalanceCheckRequest.cs
+++ b/Adyen/Checkout/Models/BalanceCheckRequest.cs
@@ -1318,7 +1318,8 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, balanceCheckRequest.BrowserInfo, jsonSerializerOptions);
             }
             if (balanceCheckRequest._CaptureDelayHoursOption.IsSet)
-                writer.WriteNumber("captureDelayHours", balanceCheckRequest._CaptureDelayHoursOption.Value!.Value);
+                if (balanceCheckRequest._CaptureDelayHoursOption.Value != null)
+                    writer.WriteNumber("captureDelayHours", balanceCheckRequest._CaptureDelayHoursOption.Value!.Value);
 
             if (balanceCheckRequest._DateOfBirthOption.IsSet)
                 writer.WriteString("dateOfBirth", balanceCheckRequest._DateOfBirthOption.Value!.Value.ToString(DateOfBirthFormat));
@@ -1341,7 +1342,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("deviceFingerprint", balanceCheckRequest.DeviceFingerprint);
 
             if (balanceCheckRequest._FraudOffsetOption.IsSet)
-                writer.WriteNumber("fraudOffset", balanceCheckRequest._FraudOffsetOption.Value!.Value);
+                if (balanceCheckRequest._FraudOffsetOption.Value != null)
+                    writer.WriteNumber("fraudOffset", balanceCheckRequest._FraudOffsetOption.Value!.Value);
 
             if (balanceCheckRequest._InstallmentsOption.IsSet)
             {
@@ -1456,14 +1458,16 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, balanceCheckRequest.ThreeDS2RequestData, jsonSerializerOptions);
             }
             if (balanceCheckRequest._ThreeDSAuthenticationOnlyOption.IsSet)
-                writer.WriteBoolean("threeDSAuthenticationOnly", balanceCheckRequest._ThreeDSAuthenticationOnlyOption.Value!.Value);
+                if (balanceCheckRequest._ThreeDSAuthenticationOnlyOption.Value != null)
+                    writer.WriteBoolean("threeDSAuthenticationOnly", balanceCheckRequest._ThreeDSAuthenticationOnlyOption.Value!.Value);
 
             if (balanceCheckRequest._TotalsGroupOption.IsSet)
                 if (balanceCheckRequest.TotalsGroup != null)
                     writer.WriteString("totalsGroup", balanceCheckRequest.TotalsGroup);
 
             if (balanceCheckRequest._TrustedShopperOption.IsSet)
-                writer.WriteBoolean("trustedShopper", balanceCheckRequest._TrustedShopperOption.Value!.Value);
+                if (balanceCheckRequest._TrustedShopperOption.Value != null)
+                    writer.WriteBoolean("trustedShopper", balanceCheckRequest._TrustedShopperOption.Value!.Value);
         }
     }
 }

--- a/Adyen/Checkout/Models/BrowserInfo.cs
+++ b/Adyen/Checkout/Models/BrowserInfo.cs
@@ -312,7 +312,8 @@ namespace Adyen.Checkout.Models
                 writer.WriteString("userAgent", browserInfo.UserAgent);
 
             if (browserInfo._JavaScriptEnabledOption.IsSet)
-                writer.WriteBoolean("javaScriptEnabled", browserInfo._JavaScriptEnabledOption.Value!.Value);
+                if (browserInfo._JavaScriptEnabledOption.Value != null)
+                    writer.WriteBoolean("javaScriptEnabled", browserInfo._JavaScriptEnabledOption.Value!.Value);
         }
     }
 }

--- a/Adyen/Checkout/Models/CardBrandDetails.cs
+++ b/Adyen/Checkout/Models/CardBrandDetails.cs
@@ -179,7 +179,8 @@ namespace Adyen.Checkout.Models
         {
             
             if (cardBrandDetails._SupportedOption.IsSet)
-                writer.WriteBoolean("supported", cardBrandDetails._SupportedOption.Value!.Value);
+                if (cardBrandDetails._SupportedOption.Value != null)
+                    writer.WriteBoolean("supported", cardBrandDetails._SupportedOption.Value!.Value);
 
             if (cardBrandDetails._TypeOption.IsSet)
                 if (cardBrandDetails.Type != null)

--- a/Adyen/Checkout/Models/CardDetailsResponse.cs
+++ b/Adyen/Checkout/Models/CardDetailsResponse.cs
@@ -230,7 +230,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("fundingSource", cardDetailsResponse.FundingSource);
 
             if (cardDetailsResponse._IsCardCommercialOption.IsSet)
-                writer.WriteBoolean("isCardCommercial", cardDetailsResponse._IsCardCommercialOption.Value!.Value);
+                if (cardDetailsResponse._IsCardCommercialOption.Value != null)
+                    writer.WriteBoolean("isCardCommercial", cardDetailsResponse._IsCardCommercialOption.Value!.Value);
 
             if (cardDetailsResponse._IssuingCountryCodeOption.IsSet)
                 if (cardDetailsResponse.IssuingCountryCode != null)

--- a/Adyen/Checkout/Models/CheckoutForwardRequestOptions.cs
+++ b/Adyen/Checkout/Models/CheckoutForwardRequestOptions.cs
@@ -241,10 +241,12 @@ namespace Adyen.Checkout.Models
         {
             
             if (checkoutForwardRequestOptions._AccountUpdateOption.IsSet)
-                writer.WriteBoolean("accountUpdate", checkoutForwardRequestOptions._AccountUpdateOption.Value!.Value);
+                if (checkoutForwardRequestOptions._AccountUpdateOption.Value != null)
+                    writer.WriteBoolean("accountUpdate", checkoutForwardRequestOptions._AccountUpdateOption.Value!.Value);
 
             if (checkoutForwardRequestOptions._DryRunOption.IsSet)
-                writer.WriteBoolean("dryRun", checkoutForwardRequestOptions._DryRunOption.Value!.Value);
+                if (checkoutForwardRequestOptions._DryRunOption.Value != null)
+                    writer.WriteBoolean("dryRun", checkoutForwardRequestOptions._DryRunOption.Value!.Value);
 
             if (checkoutForwardRequestOptions._NetworkTokenOption.IsSet)
             {
@@ -257,7 +259,8 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, checkoutForwardRequestOptions.NetworkTxReferencePaths, jsonSerializerOptions);
             }
             if (checkoutForwardRequestOptions._TokenizeOption.IsSet)
-                writer.WriteBoolean("tokenize", checkoutForwardRequestOptions._TokenizeOption.Value!.Value);
+                if (checkoutForwardRequestOptions._TokenizeOption.Value != null)
+                    writer.WriteBoolean("tokenize", checkoutForwardRequestOptions._TokenizeOption.Value!.Value);
         }
     }
 }

--- a/Adyen/Checkout/Models/CheckoutForwardResponseFromUrl.cs
+++ b/Adyen/Checkout/Models/CheckoutForwardResponseFromUrl.cs
@@ -209,7 +209,8 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, checkoutForwardResponseFromUrl.Headers, jsonSerializerOptions);
             }
             if (checkoutForwardResponseFromUrl._StatusOption.IsSet)
-                writer.WriteNumber("status", checkoutForwardResponseFromUrl._StatusOption.Value!.Value);
+                if (checkoutForwardResponseFromUrl._StatusOption.Value != null)
+                    writer.WriteNumber("status", checkoutForwardResponseFromUrl._StatusOption.Value!.Value);
         }
     }
 }

--- a/Adyen/Checkout/Models/CheckoutNetworkTokenOption.cs
+++ b/Adyen/Checkout/Models/CheckoutNetworkTokenOption.cs
@@ -179,10 +179,12 @@ namespace Adyen.Checkout.Models
         {
             
             if (checkoutNetworkTokenOption._IncludeCryptogramOption.IsSet)
-                writer.WriteBoolean("includeCryptogram", checkoutNetworkTokenOption._IncludeCryptogramOption.Value!.Value);
+                if (checkoutNetworkTokenOption._IncludeCryptogramOption.Value != null)
+                    writer.WriteBoolean("includeCryptogram", checkoutNetworkTokenOption._IncludeCryptogramOption.Value!.Value);
 
             if (checkoutNetworkTokenOption._UseNetworkTokenOption.IsSet)
-                writer.WriteBoolean("useNetworkToken", checkoutNetworkTokenOption._UseNetworkTokenOption.Value!.Value);
+                if (checkoutNetworkTokenOption._UseNetworkTokenOption.Value != null)
+                    writer.WriteBoolean("useNetworkToken", checkoutNetworkTokenOption._UseNetworkTokenOption.Value!.Value);
         }
     }
 }

--- a/Adyen/Checkout/Models/CheckoutSessionInstallmentOption.cs
+++ b/Adyen/Checkout/Models/CheckoutSessionInstallmentOption.cs
@@ -379,7 +379,8 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, checkoutSessionInstallmentOption.Plans, jsonSerializerOptions);
             }
             if (checkoutSessionInstallmentOption._PreselectedValueOption.IsSet)
-                writer.WriteNumber("preselectedValue", checkoutSessionInstallmentOption._PreselectedValueOption.Value!.Value);
+                if (checkoutSessionInstallmentOption._PreselectedValueOption.Value != null)
+                    writer.WriteNumber("preselectedValue", checkoutSessionInstallmentOption._PreselectedValueOption.Value!.Value);
 
             if (checkoutSessionInstallmentOption._ValuesOption.IsSet)
             {

--- a/Adyen/Checkout/Models/CreateCheckoutSessionRequest.cs
+++ b/Adyen/Checkout/Models/CreateCheckoutSessionRequest.cs
@@ -2149,10 +2149,12 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("countryCode", createCheckoutSessionRequest.CountryCode);
 
             if (createCheckoutSessionRequest._DateOfBirthOption.IsSet)
-                writer.WriteString("dateOfBirth", createCheckoutSessionRequest._DateOfBirthOption.Value!.Value.ToString(DateOfBirthFormat));
+                if (createCheckoutSessionRequest._DateOfBirthOption.Value != null)
+                    writer.WriteString("dateOfBirth", createCheckoutSessionRequest._DateOfBirthOption.Value!.Value.ToString(DateOfBirthFormat));
 
             if (createCheckoutSessionRequest._DeliverAtOption.IsSet)
-                writer.WriteString("deliverAt", createCheckoutSessionRequest._DeliverAtOption.Value!.Value.ToString(DeliverAtFormat));
+                if (createCheckoutSessionRequest._DeliverAtOption.Value != null)
+                    writer.WriteString("deliverAt", createCheckoutSessionRequest._DeliverAtOption.Value!.Value.ToString(DeliverAtFormat));
 
             if (createCheckoutSessionRequest._DeliveryAddressOption.IsSet)
             {
@@ -2172,7 +2174,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteBoolean("enableRecurring", createCheckoutSessionRequest._EnableRecurringOption.Value!.Value);
 
             if (createCheckoutSessionRequest._ExpiresAtOption.IsSet)
-                writer.WriteString("expiresAt", createCheckoutSessionRequest._ExpiresAtOption.Value!.Value.ToString(ExpiresAtFormat));
+                if (createCheckoutSessionRequest._ExpiresAtOption.Value != null)
+                    writer.WriteString("expiresAt", createCheckoutSessionRequest._ExpiresAtOption.Value!.Value.ToString(ExpiresAtFormat));
 
             if (createCheckoutSessionRequest._FundOriginOption.IsSet)
             {

--- a/Adyen/Checkout/Models/CreateCheckoutSessionRequest.cs
+++ b/Adyen/Checkout/Models/CreateCheckoutSessionRequest.cs
@@ -2130,7 +2130,8 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, createCheckoutSessionRequest.BlockedPaymentMethods, jsonSerializerOptions);
             }
             if (createCheckoutSessionRequest._CaptureDelayHoursOption.IsSet)
-                writer.WriteNumber("captureDelayHours", createCheckoutSessionRequest._CaptureDelayHoursOption.Value!.Value);
+                if (createCheckoutSessionRequest._CaptureDelayHoursOption.Value != null)
+                    writer.WriteNumber("captureDelayHours", createCheckoutSessionRequest._CaptureDelayHoursOption.Value!.Value);
 
             if (createCheckoutSessionRequest._ChannelOption.IsSet && createCheckoutSessionRequest.Channel != null) 
             {
@@ -2159,13 +2160,16 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, createCheckoutSessionRequest.DeliveryAddress, jsonSerializerOptions);
             }
             if (createCheckoutSessionRequest._EnableOneClickOption.IsSet)
-                writer.WriteBoolean("enableOneClick", createCheckoutSessionRequest._EnableOneClickOption.Value!.Value);
+                if (createCheckoutSessionRequest._EnableOneClickOption.Value != null)
+                    writer.WriteBoolean("enableOneClick", createCheckoutSessionRequest._EnableOneClickOption.Value!.Value);
 
             if (createCheckoutSessionRequest._EnablePayOutOption.IsSet)
-                writer.WriteBoolean("enablePayOut", createCheckoutSessionRequest._EnablePayOutOption.Value!.Value);
+                if (createCheckoutSessionRequest._EnablePayOutOption.Value != null)
+                    writer.WriteBoolean("enablePayOut", createCheckoutSessionRequest._EnablePayOutOption.Value!.Value);
 
             if (createCheckoutSessionRequest._EnableRecurringOption.IsSet)
-                writer.WriteBoolean("enableRecurring", createCheckoutSessionRequest._EnableRecurringOption.Value!.Value);
+                if (createCheckoutSessionRequest._EnableRecurringOption.Value != null)
+                    writer.WriteBoolean("enableRecurring", createCheckoutSessionRequest._EnableRecurringOption.Value!.Value);
 
             if (createCheckoutSessionRequest._ExpiresAtOption.IsSet)
                 writer.WriteString("expiresAt", createCheckoutSessionRequest._ExpiresAtOption.Value!.Value.ToString(ExpiresAtFormat));
@@ -2283,17 +2287,20 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("shopperStatement", createCheckoutSessionRequest.ShopperStatement);
 
             if (createCheckoutSessionRequest._ShowInstallmentAmountOption.IsSet)
-                writer.WriteBoolean("showInstallmentAmount", createCheckoutSessionRequest._ShowInstallmentAmountOption.Value!.Value);
+                if (createCheckoutSessionRequest._ShowInstallmentAmountOption.Value != null)
+                    writer.WriteBoolean("showInstallmentAmount", createCheckoutSessionRequest._ShowInstallmentAmountOption.Value!.Value);
 
             if (createCheckoutSessionRequest._ShowRemovePaymentMethodButtonOption.IsSet)
-                writer.WriteBoolean("showRemovePaymentMethodButton", createCheckoutSessionRequest._ShowRemovePaymentMethodButtonOption.Value!.Value);
+                if (createCheckoutSessionRequest._ShowRemovePaymentMethodButtonOption.Value != null)
+                    writer.WriteBoolean("showRemovePaymentMethodButton", createCheckoutSessionRequest._ShowRemovePaymentMethodButtonOption.Value!.Value);
 
             if (createCheckoutSessionRequest._SocialSecurityNumberOption.IsSet)
                 if (createCheckoutSessionRequest.SocialSecurityNumber != null)
                     writer.WriteString("socialSecurityNumber", createCheckoutSessionRequest.SocialSecurityNumber);
 
             if (createCheckoutSessionRequest._SplitCardFundingSourcesOption.IsSet)
-                writer.WriteBoolean("splitCardFundingSources", createCheckoutSessionRequest._SplitCardFundingSourcesOption.Value!.Value);
+                if (createCheckoutSessionRequest._SplitCardFundingSourcesOption.Value != null)
+                    writer.WriteBoolean("splitCardFundingSources", createCheckoutSessionRequest._SplitCardFundingSourcesOption.Value!.Value);
 
             if (createCheckoutSessionRequest._SplitsOption.IsSet)
             {
@@ -2311,7 +2318,8 @@ namespace Adyen.Checkout.Models
             }
             
             if (createCheckoutSessionRequest._StorePaymentMethodOption.IsSet)
-                writer.WriteBoolean("storePaymentMethod", createCheckoutSessionRequest._StorePaymentMethodOption.Value!.Value);
+                if (createCheckoutSessionRequest._StorePaymentMethodOption.Value != null)
+                    writer.WriteBoolean("storePaymentMethod", createCheckoutSessionRequest._StorePaymentMethodOption.Value!.Value);
 
             if (createCheckoutSessionRequest._StorePaymentMethodModeOption.IsSet && createCheckoutSessionRequest.StorePaymentMethodMode != null) 
             {
@@ -2333,10 +2341,12 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, createCheckoutSessionRequest.ThreeDS2RequestData, jsonSerializerOptions);
             }
             if (createCheckoutSessionRequest._ThreeDSAuthenticationOnlyOption.IsSet)
-                writer.WriteBoolean("threeDSAuthenticationOnly", createCheckoutSessionRequest._ThreeDSAuthenticationOnlyOption.Value!.Value);
+                if (createCheckoutSessionRequest._ThreeDSAuthenticationOnlyOption.Value != null)
+                    writer.WriteBoolean("threeDSAuthenticationOnly", createCheckoutSessionRequest._ThreeDSAuthenticationOnlyOption.Value!.Value);
 
             if (createCheckoutSessionRequest._TrustedShopperOption.IsSet)
-                writer.WriteBoolean("trustedShopper", createCheckoutSessionRequest._TrustedShopperOption.Value!.Value);
+                if (createCheckoutSessionRequest._TrustedShopperOption.Value != null)
+                    writer.WriteBoolean("trustedShopper", createCheckoutSessionRequest._TrustedShopperOption.Value!.Value);
         }
     }
 }

--- a/Adyen/Checkout/Models/CreateCheckoutSessionResponse.cs
+++ b/Adyen/Checkout/Models/CreateCheckoutSessionResponse.cs
@@ -2190,7 +2190,8 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, createCheckoutSessionResponse.BlockedPaymentMethods, jsonSerializerOptions);
             }
             if (createCheckoutSessionResponse._CaptureDelayHoursOption.IsSet)
-                writer.WriteNumber("captureDelayHours", createCheckoutSessionResponse._CaptureDelayHoursOption.Value!.Value);
+                if (createCheckoutSessionResponse._CaptureDelayHoursOption.Value != null)
+                    writer.WriteNumber("captureDelayHours", createCheckoutSessionResponse._CaptureDelayHoursOption.Value!.Value);
 
             if (createCheckoutSessionResponse._ChannelOption.IsSet && createCheckoutSessionResponse.Channel != null) 
             {
@@ -2219,13 +2220,16 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, createCheckoutSessionResponse.DeliveryAddress, jsonSerializerOptions);
             }
             if (createCheckoutSessionResponse._EnableOneClickOption.IsSet)
-                writer.WriteBoolean("enableOneClick", createCheckoutSessionResponse._EnableOneClickOption.Value!.Value);
+                if (createCheckoutSessionResponse._EnableOneClickOption.Value != null)
+                    writer.WriteBoolean("enableOneClick", createCheckoutSessionResponse._EnableOneClickOption.Value!.Value);
 
             if (createCheckoutSessionResponse._EnablePayOutOption.IsSet)
-                writer.WriteBoolean("enablePayOut", createCheckoutSessionResponse._EnablePayOutOption.Value!.Value);
+                if (createCheckoutSessionResponse._EnablePayOutOption.Value != null)
+                    writer.WriteBoolean("enablePayOut", createCheckoutSessionResponse._EnablePayOutOption.Value!.Value);
 
             if (createCheckoutSessionResponse._EnableRecurringOption.IsSet)
-                writer.WriteBoolean("enableRecurring", createCheckoutSessionResponse._EnableRecurringOption.Value!.Value);
+                if (createCheckoutSessionResponse._EnableRecurringOption.Value != null)
+                    writer.WriteBoolean("enableRecurring", createCheckoutSessionResponse._EnableRecurringOption.Value!.Value);
 
             if (createCheckoutSessionResponse._FundOriginOption.IsSet)
             {
@@ -2344,17 +2348,20 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("shopperStatement", createCheckoutSessionResponse.ShopperStatement);
 
             if (createCheckoutSessionResponse._ShowInstallmentAmountOption.IsSet)
-                writer.WriteBoolean("showInstallmentAmount", createCheckoutSessionResponse._ShowInstallmentAmountOption.Value!.Value);
+                if (createCheckoutSessionResponse._ShowInstallmentAmountOption.Value != null)
+                    writer.WriteBoolean("showInstallmentAmount", createCheckoutSessionResponse._ShowInstallmentAmountOption.Value!.Value);
 
             if (createCheckoutSessionResponse._ShowRemovePaymentMethodButtonOption.IsSet)
-                writer.WriteBoolean("showRemovePaymentMethodButton", createCheckoutSessionResponse._ShowRemovePaymentMethodButtonOption.Value!.Value);
+                if (createCheckoutSessionResponse._ShowRemovePaymentMethodButtonOption.Value != null)
+                    writer.WriteBoolean("showRemovePaymentMethodButton", createCheckoutSessionResponse._ShowRemovePaymentMethodButtonOption.Value!.Value);
 
             if (createCheckoutSessionResponse._SocialSecurityNumberOption.IsSet)
                 if (createCheckoutSessionResponse.SocialSecurityNumber != null)
                     writer.WriteString("socialSecurityNumber", createCheckoutSessionResponse.SocialSecurityNumber);
 
             if (createCheckoutSessionResponse._SplitCardFundingSourcesOption.IsSet)
-                writer.WriteBoolean("splitCardFundingSources", createCheckoutSessionResponse._SplitCardFundingSourcesOption.Value!.Value);
+                if (createCheckoutSessionResponse._SplitCardFundingSourcesOption.Value != null)
+                    writer.WriteBoolean("splitCardFundingSources", createCheckoutSessionResponse._SplitCardFundingSourcesOption.Value!.Value);
 
             if (createCheckoutSessionResponse._SplitsOption.IsSet)
             {
@@ -2372,7 +2379,8 @@ namespace Adyen.Checkout.Models
             }
             
             if (createCheckoutSessionResponse._StorePaymentMethodOption.IsSet)
-                writer.WriteBoolean("storePaymentMethod", createCheckoutSessionResponse._StorePaymentMethodOption.Value!.Value);
+                if (createCheckoutSessionResponse._StorePaymentMethodOption.Value != null)
+                    writer.WriteBoolean("storePaymentMethod", createCheckoutSessionResponse._StorePaymentMethodOption.Value!.Value);
 
             if (createCheckoutSessionResponse._StorePaymentMethodModeOption.IsSet && createCheckoutSessionResponse.StorePaymentMethodMode != null) 
             {
@@ -2394,10 +2402,12 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, createCheckoutSessionResponse.ThreeDS2RequestData, jsonSerializerOptions);
             }
             if (createCheckoutSessionResponse._ThreeDSAuthenticationOnlyOption.IsSet)
-                writer.WriteBoolean("threeDSAuthenticationOnly", createCheckoutSessionResponse._ThreeDSAuthenticationOnlyOption.Value!.Value);
+                if (createCheckoutSessionResponse._ThreeDSAuthenticationOnlyOption.Value != null)
+                    writer.WriteBoolean("threeDSAuthenticationOnly", createCheckoutSessionResponse._ThreeDSAuthenticationOnlyOption.Value!.Value);
 
             if (createCheckoutSessionResponse._TrustedShopperOption.IsSet)
-                writer.WriteBoolean("trustedShopper", createCheckoutSessionResponse._TrustedShopperOption.Value!.Value);
+                if (createCheckoutSessionResponse._TrustedShopperOption.Value != null)
+                    writer.WriteBoolean("trustedShopper", createCheckoutSessionResponse._TrustedShopperOption.Value!.Value);
 
             if (createCheckoutSessionResponse._UrlOption.IsSet)
                 if (createCheckoutSessionResponse.Url != null)

--- a/Adyen/Checkout/Models/CreateCheckoutSessionResponse.cs
+++ b/Adyen/Checkout/Models/CreateCheckoutSessionResponse.cs
@@ -2209,10 +2209,12 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("countryCode", createCheckoutSessionResponse.CountryCode);
 
             if (createCheckoutSessionResponse._DateOfBirthOption.IsSet)
-                writer.WriteString("dateOfBirth", createCheckoutSessionResponse._DateOfBirthOption.Value!.Value.ToString(DateOfBirthFormat));
+                if (createCheckoutSessionResponse._DateOfBirthOption.Value != null)
+                    writer.WriteString("dateOfBirth", createCheckoutSessionResponse._DateOfBirthOption.Value!.Value.ToString(DateOfBirthFormat));
 
             if (createCheckoutSessionResponse._DeliverAtOption.IsSet)
-                writer.WriteString("deliverAt", createCheckoutSessionResponse._DeliverAtOption.Value!.Value.ToString(DeliverAtFormat));
+                if (createCheckoutSessionResponse._DeliverAtOption.Value != null)
+                    writer.WriteString("deliverAt", createCheckoutSessionResponse._DeliverAtOption.Value!.Value.ToString(DeliverAtFormat));
 
             if (createCheckoutSessionResponse._DeliveryAddressOption.IsSet)
             {

--- a/Adyen/Checkout/Models/DefaultErrorResponseEntity.cs
+++ b/Adyen/Checkout/Models/DefaultErrorResponseEntity.cs
@@ -326,7 +326,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("requestId", defaultErrorResponseEntity.RequestId);
 
             if (defaultErrorResponseEntity._StatusOption.IsSet)
-                writer.WriteNumber("status", defaultErrorResponseEntity._StatusOption.Value!.Value);
+                if (defaultErrorResponseEntity._StatusOption.Value != null)
+                    writer.WriteNumber("status", defaultErrorResponseEntity._StatusOption.Value!.Value);
 
             if (defaultErrorResponseEntity._TitleOption.IsSet)
                 if (defaultErrorResponseEntity.Title != null)

--- a/Adyen/Checkout/Models/DeliveryMethod.cs
+++ b/Adyen/Checkout/Models/DeliveryMethod.cs
@@ -349,7 +349,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("reference", deliveryMethod.Reference);
 
             if (deliveryMethod._SelectedOption.IsSet)
-                writer.WriteBoolean("selected", deliveryMethod._SelectedOption.Value!.Value);
+                if (deliveryMethod._SelectedOption.Value != null)
+                    writer.WriteBoolean("selected", deliveryMethod._SelectedOption.Value!.Value);
 
             if (deliveryMethod._TypeOption.IsSet && deliveryMethod.Type != null) 
             {

--- a/Adyen/Checkout/Models/DetailsRequestAuthenticationData.cs
+++ b/Adyen/Checkout/Models/DetailsRequestAuthenticationData.cs
@@ -158,7 +158,8 @@ namespace Adyen.Checkout.Models
         {
             
             if (detailsRequestAuthenticationData._AuthenticationOnlyOption.IsSet)
-                writer.WriteBoolean("authenticationOnly", detailsRequestAuthenticationData._AuthenticationOnlyOption.Value!.Value);
+                if (detailsRequestAuthenticationData._AuthenticationOnlyOption.Value != null)
+                    writer.WriteBoolean("authenticationOnly", detailsRequestAuthenticationData._AuthenticationOnlyOption.Value!.Value);
         }
     }
 }

--- a/Adyen/Checkout/Models/Donation.cs
+++ b/Adyen/Checkout/Models/Donation.cs
@@ -238,7 +238,8 @@ namespace Adyen.Checkout.Models
                 writer.WriteString("type", donation.Type);
 
             if (donation._MaxRoundupAmountOption.IsSet)
-                writer.WriteNumber("maxRoundupAmount", donation._MaxRoundupAmountOption.Value!.Value);
+                if (donation._MaxRoundupAmountOption.Value != null)
+                    writer.WriteNumber("maxRoundupAmount", donation._MaxRoundupAmountOption.Value!.Value);
 
             if (donation._ValuesOption.IsSet)
             {

--- a/Adyen/Checkout/Models/DonationPaymentRequest.cs
+++ b/Adyen/Checkout/Models/DonationPaymentRequest.cs
@@ -1527,7 +1527,8 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, donationPaymentRequest.ThreeDS2RequestData, jsonSerializerOptions);
             }
             if (donationPaymentRequest._ThreeDSAuthenticationOnlyOption.IsSet)
-                writer.WriteBoolean("threeDSAuthenticationOnly", donationPaymentRequest._ThreeDSAuthenticationOnlyOption.Value!.Value);
+                if (donationPaymentRequest._ThreeDSAuthenticationOnlyOption.Value != null)
+                    writer.WriteBoolean("threeDSAuthenticationOnly", donationPaymentRequest._ThreeDSAuthenticationOnlyOption.Value!.Value);
         }
     }
 }

--- a/Adyen/Checkout/Models/DonationPaymentRequest.cs
+++ b/Adyen/Checkout/Models/DonationPaymentRequest.cs
@@ -1409,10 +1409,12 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("countryCode", donationPaymentRequest.CountryCode);
 
             if (donationPaymentRequest._DateOfBirthOption.IsSet)
-                writer.WriteString("dateOfBirth", donationPaymentRequest._DateOfBirthOption.Value!.Value.ToString(DateOfBirthFormat));
+                if (donationPaymentRequest._DateOfBirthOption.Value != null)
+                    writer.WriteString("dateOfBirth", donationPaymentRequest._DateOfBirthOption.Value!.Value.ToString(DateOfBirthFormat));
 
             if (donationPaymentRequest._DeliverAtOption.IsSet)
-                writer.WriteString("deliverAt", donationPaymentRequest._DeliverAtOption.Value!.Value.ToString(DeliverAtFormat));
+                if (donationPaymentRequest._DeliverAtOption.Value != null)
+                    writer.WriteString("deliverAt", donationPaymentRequest._DeliverAtOption.Value!.Value.ToString(DeliverAtFormat));
 
             if (donationPaymentRequest._DeliveryAddressOption.IsSet)
             {

--- a/Adyen/Checkout/Models/InputDetail.cs
+++ b/Adyen/Checkout/Models/InputDetail.cs
@@ -355,7 +355,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("key", inputDetail.Key);
 
             if (inputDetail._OptionalOption.IsSet)
-                writer.WriteBoolean("optional", inputDetail._OptionalOption.Value!.Value);
+                if (inputDetail._OptionalOption.Value != null)
+                    writer.WriteBoolean("optional", inputDetail._OptionalOption.Value!.Value);
 
             if (inputDetail._TypeOption.IsSet)
                 if (inputDetail.Type != null)

--- a/Adyen/Checkout/Models/InstallmentOption.cs
+++ b/Adyen/Checkout/Models/InstallmentOption.cs
@@ -395,7 +395,8 @@ namespace Adyen.Checkout.Models
         {
             
             if (installmentOption._MaxValueOption.IsSet)
-                writer.WriteNumber("maxValue", installmentOption._MaxValueOption.Value!.Value);
+                if (installmentOption._MaxValueOption.Value != null)
+                    writer.WriteNumber("maxValue", installmentOption._MaxValueOption.Value!.Value);
 
             if (installmentOption._PlansOption.IsSet)
             {
@@ -403,7 +404,8 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, installmentOption.Plans, jsonSerializerOptions);
             }
             if (installmentOption._PreselectedValueOption.IsSet)
-                writer.WriteNumber("preselectedValue", installmentOption._PreselectedValueOption.Value!.Value);
+                if (installmentOption._PreselectedValueOption.Value != null)
+                    writer.WriteNumber("preselectedValue", installmentOption._PreselectedValueOption.Value!.Value);
 
             if (installmentOption._ValuesOption.IsSet)
             {

--- a/Adyen/Checkout/Models/Installments.cs
+++ b/Adyen/Checkout/Models/Installments.cs
@@ -373,7 +373,8 @@ namespace Adyen.Checkout.Models
             writer.WriteNumber("value", installments.Value);
 
             if (installments._ExtraOption.IsSet)
-                writer.WriteNumber("extra", installments._ExtraOption.Value!.Value);
+                if (installments._ExtraOption.Value != null)
+                    writer.WriteNumber("extra", installments._ExtraOption.Value!.Value);
 
             if (installments._PlanOption.IsSet && installments.Plan != null) 
             {

--- a/Adyen/Checkout/Models/ItemDetailLine.cs
+++ b/Adyen/Checkout/Models/ItemDetailLine.cs
@@ -313,24 +313,28 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("description", itemDetailLine.Description);
 
             if (itemDetailLine._DiscountAmountOption.IsSet)
-                writer.WriteNumber("discountAmount", itemDetailLine._DiscountAmountOption.Value!.Value);
+                if (itemDetailLine._DiscountAmountOption.Value != null)
+                    writer.WriteNumber("discountAmount", itemDetailLine._DiscountAmountOption.Value!.Value);
 
             if (itemDetailLine._ProductCodeOption.IsSet)
                 if (itemDetailLine.ProductCode != null)
                     writer.WriteString("productCode", itemDetailLine.ProductCode);
 
             if (itemDetailLine._QuantityOption.IsSet)
-                writer.WriteNumber("quantity", itemDetailLine._QuantityOption.Value!.Value);
+                if (itemDetailLine._QuantityOption.Value != null)
+                    writer.WriteNumber("quantity", itemDetailLine._QuantityOption.Value!.Value);
 
             if (itemDetailLine._TotalAmountOption.IsSet)
-                writer.WriteNumber("totalAmount", itemDetailLine._TotalAmountOption.Value!.Value);
+                if (itemDetailLine._TotalAmountOption.Value != null)
+                    writer.WriteNumber("totalAmount", itemDetailLine._TotalAmountOption.Value!.Value);
 
             if (itemDetailLine._UnitOfMeasureOption.IsSet)
                 if (itemDetailLine.UnitOfMeasure != null)
                     writer.WriteString("unitOfMeasure", itemDetailLine.UnitOfMeasure);
 
             if (itemDetailLine._UnitPriceOption.IsSet)
-                writer.WriteNumber("unitPrice", itemDetailLine._UnitPriceOption.Value!.Value);
+                if (itemDetailLine._UnitPriceOption.Value != null)
+                    writer.WriteNumber("unitPrice", itemDetailLine._UnitPriceOption.Value!.Value);
         }
     }
 }

--- a/Adyen/Checkout/Models/Leg.cs
+++ b/Adyen/Checkout/Models/Leg.cs
@@ -339,7 +339,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("classOfTravel", leg.ClassOfTravel);
 
             if (leg._DateOfTravelOption.IsSet)
-                writer.WriteString("dateOfTravel", leg._DateOfTravelOption.Value!.Value.ToString(DateOfTravelFormat));
+                if (leg._DateOfTravelOption.Value != null)
+                    writer.WriteString("dateOfTravel", leg._DateOfTravelOption.Value!.Value.ToString(DateOfTravelFormat));
 
             if (leg._DepartureAirportCodeOption.IsSet)
                 if (leg.DepartureAirportCode != null)

--- a/Adyen/Checkout/Models/Leg.cs
+++ b/Adyen/Checkout/Models/Leg.cs
@@ -346,7 +346,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("departureAirportCode", leg.DepartureAirportCode);
 
             if (leg._DepartureTaxOption.IsSet)
-                writer.WriteNumber("departureTax", leg._DepartureTaxOption.Value!.Value);
+                if (leg._DepartureTaxOption.Value != null)
+                    writer.WriteNumber("departureTax", leg._DepartureTaxOption.Value!.Value);
 
             if (leg._DestinationAirportCodeOption.IsSet)
                 if (leg.DestinationAirportCode != null)

--- a/Adyen/Checkout/Models/LevelTwoThree.cs
+++ b/Adyen/Checkout/Models/LevelTwoThree.cs
@@ -318,10 +318,12 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, levelTwoThree.Destination, jsonSerializerOptions);
             }
             if (levelTwoThree._DutyAmountOption.IsSet)
-                writer.WriteNumber("dutyAmount", levelTwoThree._DutyAmountOption.Value!.Value);
+                if (levelTwoThree._DutyAmountOption.Value != null)
+                    writer.WriteNumber("dutyAmount", levelTwoThree._DutyAmountOption.Value!.Value);
 
             if (levelTwoThree._FreightAmountOption.IsSet)
-                writer.WriteNumber("freightAmount", levelTwoThree._FreightAmountOption.Value!.Value);
+                if (levelTwoThree._FreightAmountOption.Value != null)
+                    writer.WriteNumber("freightAmount", levelTwoThree._FreightAmountOption.Value!.Value);
 
             if (levelTwoThree._ItemDetailLinesOption.IsSet)
             {
@@ -336,7 +338,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("shipFromPostalCode", levelTwoThree.ShipFromPostalCode);
 
             if (levelTwoThree._TotalTaxAmountOption.IsSet)
-                writer.WriteNumber("totalTaxAmount", levelTwoThree._TotalTaxAmountOption.Value!.Value);
+                if (levelTwoThree._TotalTaxAmountOption.Value != null)
+                    writer.WriteNumber("totalTaxAmount", levelTwoThree._TotalTaxAmountOption.Value!.Value);
         }
     }
 }

--- a/Adyen/Checkout/Models/LevelTwoThree.cs
+++ b/Adyen/Checkout/Models/LevelTwoThree.cs
@@ -331,7 +331,8 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, levelTwoThree.ItemDetailLines, jsonSerializerOptions);
             }
             if (levelTwoThree._OrderDateOption.IsSet)
-                writer.WriteString("orderDate", levelTwoThree._OrderDateOption.Value!.Value.ToString(OrderDateFormat));
+                if (levelTwoThree._OrderDateOption.Value != null)
+                    writer.WriteString("orderDate", levelTwoThree._OrderDateOption.Value!.Value.ToString(OrderDateFormat));
 
             if (levelTwoThree._ShipFromPostalCodeOption.IsSet)
                 if (levelTwoThree.ShipFromPostalCode != null)

--- a/Adyen/Checkout/Models/LineItem.cs
+++ b/Adyen/Checkout/Models/LineItem.cs
@@ -515,10 +515,12 @@ namespace Adyen.Checkout.Models
         {
             
             if (lineItem._AmountExcludingTaxOption.IsSet)
-                writer.WriteNumber("amountExcludingTax", lineItem._AmountExcludingTaxOption.Value!.Value);
+                if (lineItem._AmountExcludingTaxOption.Value != null)
+                    writer.WriteNumber("amountExcludingTax", lineItem._AmountExcludingTaxOption.Value!.Value);
 
             if (lineItem._AmountIncludingTaxOption.IsSet)
-                writer.WriteNumber("amountIncludingTax", lineItem._AmountIncludingTaxOption.Value!.Value);
+                if (lineItem._AmountIncludingTaxOption.Value != null)
+                    writer.WriteNumber("amountIncludingTax", lineItem._AmountIncludingTaxOption.Value!.Value);
 
             if (lineItem._BrandOption.IsSet)
                 if (lineItem.Brand != null)
@@ -557,7 +559,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("productUrl", lineItem.ProductUrl);
 
             if (lineItem._QuantityOption.IsSet)
-                writer.WriteNumber("quantity", lineItem._QuantityOption.Value!.Value);
+                if (lineItem._QuantityOption.Value != null)
+                    writer.WriteNumber("quantity", lineItem._QuantityOption.Value!.Value);
 
             if (lineItem._ReceiverEmailOption.IsSet)
                 if (lineItem.ReceiverEmail != null)
@@ -572,10 +575,12 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("sku", lineItem.Sku);
 
             if (lineItem._TaxAmountOption.IsSet)
-                writer.WriteNumber("taxAmount", lineItem._TaxAmountOption.Value!.Value);
+                if (lineItem._TaxAmountOption.Value != null)
+                    writer.WriteNumber("taxAmount", lineItem._TaxAmountOption.Value!.Value);
 
             if (lineItem._TaxPercentageOption.IsSet)
-                writer.WriteNumber("taxPercentage", lineItem._TaxPercentageOption.Value!.Value);
+                if (lineItem._TaxPercentageOption.Value != null)
+                    writer.WriteNumber("taxPercentage", lineItem._TaxPercentageOption.Value!.Value);
 
             if (lineItem._UpcOption.IsSet)
                 if (lineItem.Upc != null)

--- a/Adyen/Checkout/Models/MerchantRiskIndicator.cs
+++ b/Adyen/Checkout/Models/MerchantRiskIndicator.cs
@@ -707,7 +707,8 @@ namespace Adyen.Checkout.Models
         {
             
             if (merchantRiskIndicator._AddressMatchOption.IsSet)
-                writer.WriteBoolean("addressMatch", merchantRiskIndicator._AddressMatchOption.Value!.Value);
+                if (merchantRiskIndicator._AddressMatchOption.Value != null)
+                    writer.WriteBoolean("addressMatch", merchantRiskIndicator._AddressMatchOption.Value!.Value);
 
             if (merchantRiskIndicator._DeliveryAddressIndicatorOption.IsSet && merchantRiskIndicator.DeliveryAddressIndicator != null) 
             {
@@ -735,7 +736,8 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, merchantRiskIndicator.GiftCardAmount, jsonSerializerOptions);
             }
             if (merchantRiskIndicator._GiftCardCountOption.IsSet)
-                writer.WriteNumber("giftCardCount", merchantRiskIndicator._GiftCardCountOption.Value!.Value);
+                if (merchantRiskIndicator._GiftCardCountOption.Value != null)
+                    writer.WriteNumber("giftCardCount", merchantRiskIndicator._GiftCardCountOption.Value!.Value);
 
             if (merchantRiskIndicator._GiftCardCurrOption.IsSet)
                 if (merchantRiskIndicator.GiftCardCurr != null)
@@ -745,14 +747,16 @@ namespace Adyen.Checkout.Models
                 writer.WriteString("preOrderDate", merchantRiskIndicator._PreOrderDateOption.Value!.Value.ToString(PreOrderDateFormat));
 
             if (merchantRiskIndicator._PreOrderPurchaseOption.IsSet)
-                writer.WriteBoolean("preOrderPurchase", merchantRiskIndicator._PreOrderPurchaseOption.Value!.Value);
+                if (merchantRiskIndicator._PreOrderPurchaseOption.Value != null)
+                    writer.WriteBoolean("preOrderPurchase", merchantRiskIndicator._PreOrderPurchaseOption.Value!.Value);
 
             if (merchantRiskIndicator._PreOrderPurchaseIndOption.IsSet)
                 if (merchantRiskIndicator.PreOrderPurchaseInd != null)
                     writer.WriteString("preOrderPurchaseInd", merchantRiskIndicator.PreOrderPurchaseInd);
 
             if (merchantRiskIndicator._ReorderItemsOption.IsSet)
-                writer.WriteBoolean("reorderItems", merchantRiskIndicator._ReorderItemsOption.Value!.Value);
+                if (merchantRiskIndicator._ReorderItemsOption.Value != null)
+                    writer.WriteBoolean("reorderItems", merchantRiskIndicator._ReorderItemsOption.Value!.Value);
 
             if (merchantRiskIndicator._ReorderItemsIndOption.IsSet)
                 if (merchantRiskIndicator.ReorderItemsInd != null)

--- a/Adyen/Checkout/Models/MerchantRiskIndicator.cs
+++ b/Adyen/Checkout/Models/MerchantRiskIndicator.cs
@@ -744,7 +744,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("giftCardCurr", merchantRiskIndicator.GiftCardCurr);
 
             if (merchantRiskIndicator._PreOrderDateOption.IsSet)
-                writer.WriteString("preOrderDate", merchantRiskIndicator._PreOrderDateOption.Value!.Value.ToString(PreOrderDateFormat));
+                if (merchantRiskIndicator._PreOrderDateOption.Value != null)
+                    writer.WriteString("preOrderDate", merchantRiskIndicator._PreOrderDateOption.Value!.Value.ToString(PreOrderDateFormat));
 
             if (merchantRiskIndicator._PreOrderPurchaseOption.IsSet)
                 if (merchantRiskIndicator._PreOrderPurchaseOption.Value != null)

--- a/Adyen/Checkout/Models/Passenger.cs
+++ b/Adyen/Checkout/Models/Passenger.cs
@@ -247,7 +247,8 @@ namespace Adyen.Checkout.Models
         {
             
             if (passenger._DateOfBirthOption.IsSet)
-                writer.WriteString("dateOfBirth", passenger._DateOfBirthOption.Value!.Value.ToString(DateOfBirthFormat));
+                if (passenger._DateOfBirthOption.Value != null)
+                    writer.WriteString("dateOfBirth", passenger._DateOfBirthOption.Value!.Value.ToString(DateOfBirthFormat));
 
             if (passenger._FirstNameOption.IsSet)
                 if (passenger.FirstName != null)

--- a/Adyen/Checkout/Models/PaymentDetailsRequest.cs
+++ b/Adyen/Checkout/Models/PaymentDetailsRequest.cs
@@ -226,7 +226,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("paymentData", paymentDetailsRequest.PaymentData);
 
             if (paymentDetailsRequest._ThreeDSAuthenticationOnlyOption.IsSet)
-                writer.WriteBoolean("threeDSAuthenticationOnly", paymentDetailsRequest._ThreeDSAuthenticationOnlyOption.Value!.Value);
+                if (paymentDetailsRequest._ThreeDSAuthenticationOnlyOption.Value != null)
+                    writer.WriteBoolean("threeDSAuthenticationOnly", paymentDetailsRequest._ThreeDSAuthenticationOnlyOption.Value!.Value);
         }
     }
 }

--- a/Adyen/Checkout/Models/PaymentLinkRequest.cs
+++ b/Adyen/Checkout/Models/PaymentLinkRequest.cs
@@ -1402,10 +1402,12 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("countryCode", paymentLinkRequest.CountryCode);
 
             if (paymentLinkRequest._DateOfBirthOption.IsSet)
-                writer.WriteString("dateOfBirth", paymentLinkRequest._DateOfBirthOption.Value!.Value.ToString(DateOfBirthFormat));
+                if (paymentLinkRequest._DateOfBirthOption.Value != null)
+                    writer.WriteString("dateOfBirth", paymentLinkRequest._DateOfBirthOption.Value!.Value.ToString(DateOfBirthFormat));
 
             if (paymentLinkRequest._DeliverAtOption.IsSet)
-                writer.WriteString("deliverAt", paymentLinkRequest._DeliverAtOption.Value!.Value.ToString(DeliverAtFormat));
+                if (paymentLinkRequest._DeliverAtOption.Value != null)
+                    writer.WriteString("deliverAt", paymentLinkRequest._DeliverAtOption.Value!.Value.ToString(DeliverAtFormat));
 
             if (paymentLinkRequest._DeliveryAddressOption.IsSet)
             {
@@ -1417,7 +1419,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("description", paymentLinkRequest.Description);
 
             if (paymentLinkRequest._ExpiresAtOption.IsSet)
-                writer.WriteString("expiresAt", paymentLinkRequest._ExpiresAtOption.Value!.Value.ToString(ExpiresAtFormat));
+                if (paymentLinkRequest._ExpiresAtOption.Value != null)
+                    writer.WriteString("expiresAt", paymentLinkRequest._ExpiresAtOption.Value!.Value.ToString(ExpiresAtFormat));
 
             if (paymentLinkRequest._FundOriginOption.IsSet)
             {

--- a/Adyen/Checkout/Models/PaymentLinkRequest.cs
+++ b/Adyen/Checkout/Models/PaymentLinkRequest.cs
@@ -1394,7 +1394,8 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, paymentLinkRequest.BlockedPaymentMethods, jsonSerializerOptions);
             }
             if (paymentLinkRequest._CaptureDelayHoursOption.IsSet)
-                writer.WriteNumber("captureDelayHours", paymentLinkRequest._CaptureDelayHoursOption.Value!.Value);
+                if (paymentLinkRequest._CaptureDelayHoursOption.Value != null)
+                    writer.WriteNumber("captureDelayHours", paymentLinkRequest._CaptureDelayHoursOption.Value!.Value);
 
             if (paymentLinkRequest._CountryCodeOption.IsSet)
                 if (paymentLinkRequest.CountryCode != null)
@@ -1439,7 +1440,8 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, paymentLinkRequest.LineItems, jsonSerializerOptions);
             }
             if (paymentLinkRequest._ManualCaptureOption.IsSet)
-                writer.WriteBoolean("manualCapture", paymentLinkRequest._ManualCaptureOption.Value!.Value);
+                if (paymentLinkRequest._ManualCaptureOption.Value != null)
+                    writer.WriteBoolean("manualCapture", paymentLinkRequest._ManualCaptureOption.Value!.Value);
 
             if (paymentLinkRequest._MccOption.IsSet)
                 if (paymentLinkRequest.Mcc != null)
@@ -1475,7 +1477,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("returnUrl", paymentLinkRequest.ReturnUrl);
 
             if (paymentLinkRequest._ReusableOption.IsSet)
-                writer.WriteBoolean("reusable", paymentLinkRequest._ReusableOption.Value!.Value);
+                if (paymentLinkRequest._ReusableOption.Value != null)
+                    writer.WriteBoolean("reusable", paymentLinkRequest._ReusableOption.Value!.Value);
 
             if (paymentLinkRequest._RiskDataOption.IsSet)
             {
@@ -1504,14 +1507,16 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("shopperStatement", paymentLinkRequest.ShopperStatement);
 
             if (paymentLinkRequest._ShowRemovePaymentMethodButtonOption.IsSet)
-                writer.WriteBoolean("showRemovePaymentMethodButton", paymentLinkRequest._ShowRemovePaymentMethodButtonOption.Value!.Value);
+                if (paymentLinkRequest._ShowRemovePaymentMethodButtonOption.Value != null)
+                    writer.WriteBoolean("showRemovePaymentMethodButton", paymentLinkRequest._ShowRemovePaymentMethodButtonOption.Value!.Value);
 
             if (paymentLinkRequest._SocialSecurityNumberOption.IsSet)
                 if (paymentLinkRequest.SocialSecurityNumber != null)
                     writer.WriteString("socialSecurityNumber", paymentLinkRequest.SocialSecurityNumber);
 
             if (paymentLinkRequest._SplitCardFundingSourcesOption.IsSet)
-                writer.WriteBoolean("splitCardFundingSources", paymentLinkRequest._SplitCardFundingSourcesOption.Value!.Value);
+                if (paymentLinkRequest._SplitCardFundingSourcesOption.Value != null)
+                    writer.WriteBoolean("splitCardFundingSources", paymentLinkRequest._SplitCardFundingSourcesOption.Value!.Value);
 
             if (paymentLinkRequest._SplitsOption.IsSet)
             {

--- a/Adyen/Checkout/Models/PaymentLinkResponse.cs
+++ b/Adyen/Checkout/Models/PaymentLinkResponse.cs
@@ -1614,7 +1614,8 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, paymentLinkResponse.BlockedPaymentMethods, jsonSerializerOptions);
             }
             if (paymentLinkResponse._CaptureDelayHoursOption.IsSet)
-                writer.WriteNumber("captureDelayHours", paymentLinkResponse._CaptureDelayHoursOption.Value!.Value);
+                if (paymentLinkResponse._CaptureDelayHoursOption.Value != null)
+                    writer.WriteNumber("captureDelayHours", paymentLinkResponse._CaptureDelayHoursOption.Value!.Value);
 
             if (paymentLinkResponse._CountryCodeOption.IsSet)
                 if (paymentLinkResponse.CountryCode != null)
@@ -1659,7 +1660,8 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, paymentLinkResponse.LineItems, jsonSerializerOptions);
             }
             if (paymentLinkResponse._ManualCaptureOption.IsSet)
-                writer.WriteBoolean("manualCapture", paymentLinkResponse._ManualCaptureOption.Value!.Value);
+                if (paymentLinkResponse._ManualCaptureOption.Value != null)
+                    writer.WriteBoolean("manualCapture", paymentLinkResponse._ManualCaptureOption.Value!.Value);
 
             if (paymentLinkResponse._MccOption.IsSet)
                 if (paymentLinkResponse.Mcc != null)
@@ -1695,7 +1697,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("returnUrl", paymentLinkResponse.ReturnUrl);
 
             if (paymentLinkResponse._ReusableOption.IsSet)
-                writer.WriteBoolean("reusable", paymentLinkResponse._ReusableOption.Value!.Value);
+                if (paymentLinkResponse._ReusableOption.Value != null)
+                    writer.WriteBoolean("reusable", paymentLinkResponse._ReusableOption.Value!.Value);
 
             if (paymentLinkResponse._RiskDataOption.IsSet)
             {
@@ -1724,14 +1727,16 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("shopperStatement", paymentLinkResponse.ShopperStatement);
 
             if (paymentLinkResponse._ShowRemovePaymentMethodButtonOption.IsSet)
-                writer.WriteBoolean("showRemovePaymentMethodButton", paymentLinkResponse._ShowRemovePaymentMethodButtonOption.Value!.Value);
+                if (paymentLinkResponse._ShowRemovePaymentMethodButtonOption.Value != null)
+                    writer.WriteBoolean("showRemovePaymentMethodButton", paymentLinkResponse._ShowRemovePaymentMethodButtonOption.Value!.Value);
 
             if (paymentLinkResponse._SocialSecurityNumberOption.IsSet)
                 if (paymentLinkResponse.SocialSecurityNumber != null)
                     writer.WriteString("socialSecurityNumber", paymentLinkResponse.SocialSecurityNumber);
 
             if (paymentLinkResponse._SplitCardFundingSourcesOption.IsSet)
-                writer.WriteBoolean("splitCardFundingSources", paymentLinkResponse._SplitCardFundingSourcesOption.Value!.Value);
+                if (paymentLinkResponse._SplitCardFundingSourcesOption.Value != null)
+                    writer.WriteBoolean("splitCardFundingSources", paymentLinkResponse._SplitCardFundingSourcesOption.Value!.Value);
 
             if (paymentLinkResponse._SplitsOption.IsSet)
             {

--- a/Adyen/Checkout/Models/PaymentLinkResponse.cs
+++ b/Adyen/Checkout/Models/PaymentLinkResponse.cs
@@ -1622,10 +1622,12 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("countryCode", paymentLinkResponse.CountryCode);
 
             if (paymentLinkResponse._DateOfBirthOption.IsSet)
-                writer.WriteString("dateOfBirth", paymentLinkResponse._DateOfBirthOption.Value!.Value.ToString(DateOfBirthFormat));
+                if (paymentLinkResponse._DateOfBirthOption.Value != null)
+                    writer.WriteString("dateOfBirth", paymentLinkResponse._DateOfBirthOption.Value!.Value.ToString(DateOfBirthFormat));
 
             if (paymentLinkResponse._DeliverAtOption.IsSet)
-                writer.WriteString("deliverAt", paymentLinkResponse._DeliverAtOption.Value!.Value.ToString(DeliverAtFormat));
+                if (paymentLinkResponse._DeliverAtOption.Value != null)
+                    writer.WriteString("deliverAt", paymentLinkResponse._DeliverAtOption.Value!.Value.ToString(DeliverAtFormat));
 
             if (paymentLinkResponse._DeliveryAddressOption.IsSet)
             {
@@ -1637,7 +1639,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("description", paymentLinkResponse.Description);
 
             if (paymentLinkResponse._ExpiresAtOption.IsSet)
-                writer.WriteString("expiresAt", paymentLinkResponse._ExpiresAtOption.Value!.Value.ToString(ExpiresAtFormat));
+                if (paymentLinkResponse._ExpiresAtOption.Value != null)
+                    writer.WriteString("expiresAt", paymentLinkResponse._ExpiresAtOption.Value!.Value.ToString(ExpiresAtFormat));
 
             if (paymentLinkResponse._FundOriginOption.IsSet)
             {
@@ -1767,7 +1770,8 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, paymentLinkResponse.ThreeDS2RequestData, jsonSerializerOptions);
             }
             if (paymentLinkResponse._UpdatedAtOption.IsSet)
-                writer.WriteString("updatedAt", paymentLinkResponse._UpdatedAtOption.Value!.Value.ToString(UpdatedAtFormat));
+                if (paymentLinkResponse._UpdatedAtOption.Value != null)
+                    writer.WriteString("updatedAt", paymentLinkResponse._UpdatedAtOption.Value!.Value.ToString(UpdatedAtFormat));
         }
     }
 }

--- a/Adyen/Checkout/Models/PaymentMethod.cs
+++ b/Adyen/Checkout/Models/PaymentMethod.cs
@@ -525,7 +525,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("name", paymentMethod.Name);
 
             if (paymentMethod._PromotedOption.IsSet)
-                writer.WriteBoolean("promoted", paymentMethod._PromotedOption.Value!.Value);
+                if (paymentMethod._PromotedOption.Value != null)
+                    writer.WriteBoolean("promoted", paymentMethod._PromotedOption.Value!.Value);
 
             if (paymentMethod._TypeOption.IsSet)
                 if (paymentMethod.Type != null)

--- a/Adyen/Checkout/Models/PaymentMethodIssuer.cs
+++ b/Adyen/Checkout/Models/PaymentMethodIssuer.cs
@@ -197,7 +197,8 @@ namespace Adyen.Checkout.Models
                 writer.WriteString("name", paymentMethodIssuer.Name);
 
             if (paymentMethodIssuer._DisabledOption.IsSet)
-                writer.WriteBoolean("disabled", paymentMethodIssuer._DisabledOption.Value!.Value);
+                if (paymentMethodIssuer._DisabledOption.Value != null)
+                    writer.WriteBoolean("disabled", paymentMethodIssuer._DisabledOption.Value!.Value);
         }
     }
 }

--- a/Adyen/Checkout/Models/PaymentMethodsRequest.cs
+++ b/Adyen/Checkout/Models/PaymentMethodsRequest.cs
@@ -796,7 +796,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("shopperReference", paymentMethodsRequest.ShopperReference);
 
             if (paymentMethodsRequest._SplitCardFundingSourcesOption.IsSet)
-                writer.WriteBoolean("splitCardFundingSources", paymentMethodsRequest._SplitCardFundingSourcesOption.Value!.Value);
+                if (paymentMethodsRequest._SplitCardFundingSourcesOption.Value != null)
+                    writer.WriteBoolean("splitCardFundingSources", paymentMethodsRequest._SplitCardFundingSourcesOption.Value!.Value);
 
             if (paymentMethodsRequest._StoreOption.IsSet)
                 if (paymentMethodsRequest.Store != null)

--- a/Adyen/Checkout/Models/PaymentRequest.cs
+++ b/Adyen/Checkout/Models/PaymentRequest.cs
@@ -2279,7 +2279,8 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, paymentRequest.BrowserInfo, jsonSerializerOptions);
             }
             if (paymentRequest._CaptureDelayHoursOption.IsSet)
-                writer.WriteNumber("captureDelayHours", paymentRequest._CaptureDelayHoursOption.Value!.Value);
+                if (paymentRequest._CaptureDelayHoursOption.Value != null)
+                    writer.WriteNumber("captureDelayHours", paymentRequest._CaptureDelayHoursOption.Value!.Value);
 
             if (paymentRequest._ChannelOption.IsSet && paymentRequest.Channel != null) 
             {
@@ -2328,13 +2329,16 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("deviceFingerprint", paymentRequest.DeviceFingerprint);
 
             if (paymentRequest._EnableOneClickOption.IsSet)
-                writer.WriteBoolean("enableOneClick", paymentRequest._EnableOneClickOption.Value!.Value);
+                if (paymentRequest._EnableOneClickOption.Value != null)
+                    writer.WriteBoolean("enableOneClick", paymentRequest._EnableOneClickOption.Value!.Value);
 
             if (paymentRequest._EnablePayOutOption.IsSet)
-                writer.WriteBoolean("enablePayOut", paymentRequest._EnablePayOutOption.Value!.Value);
+                if (paymentRequest._EnablePayOutOption.Value != null)
+                    writer.WriteBoolean("enablePayOut", paymentRequest._EnablePayOutOption.Value!.Value);
 
             if (paymentRequest._EnableRecurringOption.IsSet)
-                writer.WriteBoolean("enableRecurring", paymentRequest._EnableRecurringOption.Value!.Value);
+                if (paymentRequest._EnableRecurringOption.Value != null)
+                    writer.WriteBoolean("enableRecurring", paymentRequest._EnableRecurringOption.Value!.Value);
 
             if (paymentRequest._EnhancedSchemeDataOption.IsSet)
             {
@@ -2348,7 +2352,8 @@ namespace Adyen.Checkout.Models
             }
             
             if (paymentRequest._FraudOffsetOption.IsSet)
-                writer.WriteNumber("fraudOffset", paymentRequest._FraudOffsetOption.Value!.Value);
+                if (paymentRequest._FraudOffsetOption.Value != null)
+                    writer.WriteNumber("fraudOffset", paymentRequest._FraudOffsetOption.Value!.Value);
 
             if (paymentRequest._FundOriginOption.IsSet)
             {
@@ -2517,7 +2522,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("store", paymentRequest.Store);
 
             if (paymentRequest._StorePaymentMethodOption.IsSet)
-                writer.WriteBoolean("storePaymentMethod", paymentRequest._StorePaymentMethodOption.Value!.Value);
+                if (paymentRequest._StorePaymentMethodOption.Value != null)
+                    writer.WriteBoolean("storePaymentMethod", paymentRequest._StorePaymentMethodOption.Value!.Value);
 
             if (paymentRequest._SubMerchantsOption.IsSet)
             {
@@ -2539,10 +2545,12 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, paymentRequest.ThreeDS2RequestData, jsonSerializerOptions);
             }
             if (paymentRequest._ThreeDSAuthenticationOnlyOption.IsSet)
-                writer.WriteBoolean("threeDSAuthenticationOnly", paymentRequest._ThreeDSAuthenticationOnlyOption.Value!.Value);
+                if (paymentRequest._ThreeDSAuthenticationOnlyOption.Value != null)
+                    writer.WriteBoolean("threeDSAuthenticationOnly", paymentRequest._ThreeDSAuthenticationOnlyOption.Value!.Value);
 
             if (paymentRequest._TrustedShopperOption.IsSet)
-                writer.WriteBoolean("trustedShopper", paymentRequest._TrustedShopperOption.Value!.Value);
+                if (paymentRequest._TrustedShopperOption.Value != null)
+                    writer.WriteBoolean("trustedShopper", paymentRequest._TrustedShopperOption.Value!.Value);
         }
     }
 }

--- a/Adyen/Checkout/Models/PaymentRequest.cs
+++ b/Adyen/Checkout/Models/PaymentRequest.cs
@@ -2306,7 +2306,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("countryCode", paymentRequest.CountryCode);
 
             if (paymentRequest._DateOfBirthOption.IsSet)
-                writer.WriteString("dateOfBirth", paymentRequest._DateOfBirthOption.Value!.Value.ToString(DateOfBirthFormat));
+                if (paymentRequest._DateOfBirthOption.Value != null)
+                    writer.WriteString("dateOfBirth", paymentRequest._DateOfBirthOption.Value!.Value.ToString(DateOfBirthFormat));
 
             if (paymentRequest._DccQuoteOption.IsSet)
             {
@@ -2314,7 +2315,8 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, paymentRequest.DccQuote, jsonSerializerOptions);
             }
             if (paymentRequest._DeliverAtOption.IsSet)
-                writer.WriteString("deliverAt", paymentRequest._DeliverAtOption.Value!.Value.ToString(DeliverAtFormat));
+                if (paymentRequest._DeliverAtOption.Value != null)
+                    writer.WriteString("deliverAt", paymentRequest._DeliverAtOption.Value!.Value.ToString(DeliverAtFormat));
 
             if (paymentRequest._DeliveryAddressOption.IsSet)
             {
@@ -2322,7 +2324,8 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, paymentRequest.DeliveryAddress, jsonSerializerOptions);
             }
             if (paymentRequest._DeliveryDateOption.IsSet)
-                writer.WriteString("deliveryDate", paymentRequest._DeliveryDateOption.Value!.Value.ToString(DeliveryDateFormat));
+                if (paymentRequest._DeliveryDateOption.Value != null)
+                    writer.WriteString("deliveryDate", paymentRequest._DeliveryDateOption.Value!.Value.ToString(DeliveryDateFormat));
 
             if (paymentRequest._DeviceFingerprintOption.IsSet)
                 if (paymentRequest.DeviceFingerprint != null)

--- a/Adyen/Checkout/Models/PixRecurring.cs
+++ b/Adyen/Checkout/Models/PixRecurring.cs
@@ -480,7 +480,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("billingDate", pixRecurring.BillingDate);
 
             if (pixRecurring._BusinessDayOnlyOption.IsSet)
-                writer.WriteBoolean("businessDayOnly", pixRecurring._BusinessDayOnlyOption.Value!.Value);
+                if (pixRecurring._BusinessDayOnlyOption.Value != null)
+                    writer.WriteBoolean("businessDayOnly", pixRecurring._BusinessDayOnlyOption.Value!.Value);
 
             if (pixRecurring._EndsAtOption.IsSet)
                 if (pixRecurring.EndsAt != null)
@@ -511,7 +512,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("recurringStatement", pixRecurring.RecurringStatement);
 
             if (pixRecurring._RetryPolicyOption.IsSet)
-                writer.WriteBoolean("retryPolicy", pixRecurring._RetryPolicyOption.Value!.Value);
+                if (pixRecurring._RetryPolicyOption.Value != null)
+                    writer.WriteBoolean("retryPolicy", pixRecurring._RetryPolicyOption.Value!.Value);
 
             if (pixRecurring._StartsAtOption.IsSet)
                 if (pixRecurring.StartsAt != null)

--- a/Adyen/Checkout/Models/Recurring.cs
+++ b/Adyen/Checkout/Models/Recurring.cs
@@ -510,7 +510,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("recurringDetailName", recurring.RecurringDetailName);
 
             if (recurring._RecurringExpiryOption.IsSet)
-                writer.WriteString("recurringExpiry", recurring._RecurringExpiryOption.Value!.Value.ToString(RecurringExpiryFormat));
+                if (recurring._RecurringExpiryOption.Value != null)
+                    writer.WriteString("recurringExpiry", recurring._RecurringExpiryOption.Value!.Value.ToString(RecurringExpiryFormat));
 
             if (recurring._RecurringFrequencyOption.IsSet)
                 if (recurring.RecurringFrequency != null)

--- a/Adyen/Checkout/Models/ResponseAdditionalData3DSecure.cs
+++ b/Adyen/Checkout/Models/ResponseAdditionalData3DSecure.cs
@@ -258,7 +258,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("scaExemptionRequested", responseAdditionalData3DSecure.ScaExemptionRequested);
 
             if (responseAdditionalData3DSecure._Threeds2CardEnrolledOption.IsSet)
-                writer.WriteBoolean("threeds2.cardEnrolled", responseAdditionalData3DSecure._Threeds2CardEnrolledOption.Value!.Value);
+                if (responseAdditionalData3DSecure._Threeds2CardEnrolledOption.Value != null)
+                    writer.WriteBoolean("threeds2.cardEnrolled", responseAdditionalData3DSecure._Threeds2CardEnrolledOption.Value!.Value);
         }
     }
 }

--- a/Adyen/Checkout/Models/RiskData.cs
+++ b/Adyen/Checkout/Models/RiskData.cs
@@ -230,7 +230,8 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, riskData.CustomFields, jsonSerializerOptions);
             }
             if (riskData._FraudOffsetOption.IsSet)
-                writer.WriteNumber("fraudOffset", riskData._FraudOffsetOption.Value!.Value);
+                if (riskData._FraudOffsetOption.Value != null)
+                    writer.WriteNumber("fraudOffset", riskData._FraudOffsetOption.Value!.Value);
 
             if (riskData._ProfileReferenceOption.IsSet)
                 if (riskData.ProfileReference != null)

--- a/Adyen/Checkout/Models/ServiceError.cs
+++ b/Adyen/Checkout/Models/ServiceError.cs
@@ -284,7 +284,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("pspReference", serviceError.PspReference);
 
             if (serviceError._StatusOption.IsSet)
-                writer.WriteNumber("status", serviceError._StatusOption.Value!.Value);
+                if (serviceError._StatusOption.Value != null)
+                    writer.WriteNumber("status", serviceError._StatusOption.Value!.Value);
         }
     }
 }

--- a/Adyen/Checkout/Models/SubInputDetail.cs
+++ b/Adyen/Checkout/Models/SubInputDetail.cs
@@ -277,7 +277,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("key", subInputDetail.Key);
 
             if (subInputDetail._OptionalOption.IsSet)
-                writer.WriteBoolean("optional", subInputDetail._OptionalOption.Value!.Value);
+                if (subInputDetail._OptionalOption.Value != null)
+                    writer.WriteBoolean("optional", subInputDetail._OptionalOption.Value!.Value);
 
             if (subInputDetail._TypeOption.IsSet)
                 if (subInputDetail.Type != null)

--- a/Adyen/Checkout/Models/ThreeDS2RequestData.cs
+++ b/Adyen/Checkout/Models/ThreeDS2RequestData.cs
@@ -1714,7 +1714,8 @@ namespace Adyen.Checkout.Models
             }
             
             if (threeDS2RequestData._AuthenticationOnlyOption.IsSet)
-                writer.WriteBoolean("authenticationOnly", threeDS2RequestData._AuthenticationOnlyOption.Value!.Value);
+                if (threeDS2RequestData._AuthenticationOnlyOption.Value != null)
+                    writer.WriteBoolean("authenticationOnly", threeDS2RequestData._AuthenticationOnlyOption.Value!.Value);
 
             if (threeDS2RequestData._ChallengeIndicatorOption.IsSet && threeDS2RequestData.ChallengeIndicator != null) 
             {
@@ -1754,7 +1755,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("notificationURL", threeDS2RequestData.NotificationURL);
 
             if (threeDS2RequestData._PayTokenIndOption.IsSet)
-                writer.WriteBoolean("payTokenInd", threeDS2RequestData._PayTokenIndOption.Value!.Value);
+                if (threeDS2RequestData._PayTokenIndOption.Value != null)
+                    writer.WriteBoolean("payTokenInd", threeDS2RequestData._PayTokenIndOption.Value!.Value);
 
             if (threeDS2RequestData._PaymentAuthenticationUseCaseOption.IsSet)
                 if (threeDS2RequestData.PaymentAuthenticationUseCase != null)
@@ -1786,7 +1788,8 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, threeDS2RequestData.SdkEphemPubKey, jsonSerializerOptions);
             }
             if (threeDS2RequestData._SdkMaxTimeoutOption.IsSet)
-                writer.WriteNumber("sdkMaxTimeout", threeDS2RequestData._SdkMaxTimeoutOption.Value!.Value);
+                if (threeDS2RequestData._SdkMaxTimeoutOption.Value != null)
+                    writer.WriteNumber("sdkMaxTimeout", threeDS2RequestData._SdkMaxTimeoutOption.Value!.Value);
 
             if (threeDS2RequestData._SdkReferenceNumberOption.IsSet)
                 if (threeDS2RequestData.SdkReferenceNumber != null)

--- a/Adyen/Checkout/Models/ThreeDS2RequestFields.cs
+++ b/Adyen/Checkout/Models/ThreeDS2RequestFields.cs
@@ -1653,7 +1653,8 @@ namespace Adyen.Checkout.Models
             }
             
             if (threeDS2RequestFields._AuthenticationOnlyOption.IsSet)
-                writer.WriteBoolean("authenticationOnly", threeDS2RequestFields._AuthenticationOnlyOption.Value!.Value);
+                if (threeDS2RequestFields._AuthenticationOnlyOption.Value != null)
+                    writer.WriteBoolean("authenticationOnly", threeDS2RequestFields._AuthenticationOnlyOption.Value!.Value);
 
             if (threeDS2RequestFields._ChallengeIndicatorOption.IsSet && threeDS2RequestFields.ChallengeIndicator != null) 
             {
@@ -1693,7 +1694,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("notificationURL", threeDS2RequestFields.NotificationURL);
 
             if (threeDS2RequestFields._PayTokenIndOption.IsSet)
-                writer.WriteBoolean("payTokenInd", threeDS2RequestFields._PayTokenIndOption.Value!.Value);
+                if (threeDS2RequestFields._PayTokenIndOption.Value != null)
+                    writer.WriteBoolean("payTokenInd", threeDS2RequestFields._PayTokenIndOption.Value!.Value);
 
             if (threeDS2RequestFields._PaymentAuthenticationUseCaseOption.IsSet)
                 if (threeDS2RequestFields.PaymentAuthenticationUseCase != null)
@@ -1721,7 +1723,8 @@ namespace Adyen.Checkout.Models
                 JsonSerializer.Serialize(writer, threeDS2RequestFields.SdkEphemPubKey, jsonSerializerOptions);
             }
             if (threeDS2RequestFields._SdkMaxTimeoutOption.IsSet)
-                writer.WriteNumber("sdkMaxTimeout", threeDS2RequestFields._SdkMaxTimeoutOption.Value!.Value);
+                if (threeDS2RequestFields._SdkMaxTimeoutOption.Value != null)
+                    writer.WriteNumber("sdkMaxTimeout", threeDS2RequestFields._SdkMaxTimeoutOption.Value!.Value);
 
             if (threeDS2RequestFields._SdkReferenceNumberOption.IsSet)
                 if (threeDS2RequestFields.SdkReferenceNumber != null)

--- a/Adyen/Checkout/Models/Ticket.cs
+++ b/Adyen/Checkout/Models/Ticket.cs
@@ -209,7 +209,8 @@ namespace Adyen.Checkout.Models
                     writer.WriteString("issueAddress", ticket.IssueAddress);
 
             if (ticket._IssueDateOption.IsSet)
-                writer.WriteString("issueDate", ticket._IssueDateOption.Value!.Value.ToString(IssueDateFormat));
+                if (ticket._IssueDateOption.Value != null)
+                    writer.WriteString("issueDate", ticket._IssueDateOption.Value!.Value.ToString(IssueDateFormat));
 
             if (ticket._NumberOption.IsSet)
                 if (ticket.Number != null)

--- a/templates-v7/csharp/libraries/generichost/JsonConverter.mustache
+++ b/templates-v7/csharp/libraries/generichost/JsonConverter.mustache
@@ -468,7 +468,8 @@
             {{/isString}}
             {{#isBoolean}}
             {{#lambda.copyText}}
-            writer.WriteBoolean("{{baseName}}", {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{^required}}_{{/required}}{{name}}{{^required}}Option.Value{{#vendorExtensions.x-is-value-type}}{{nrt!}}.Value{{/vendorExtensions.x-is-value-type}}{{/required}}{{#required}}{{#isNullable}}.Value{{/isNullable}}{{/required}});
+            {{^required}}{{#vendorExtensions.x-is-value-type}}if ({{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}._{{name}}Option.Value != null)
+    writer.WriteBoolean("{{baseName}}", {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}._{{name}}Option.Value{{nrt!}}.Value);{{/vendorExtensions.x-is-value-type}}{{^vendorExtensions.x-is-value-type}}writer.WriteBoolean("{{baseName}}", {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}._{{name}}Option.Value);{{/vendorExtensions.x-is-value-type}}{{/required}}{{#required}}writer.WriteBoolean("{{baseName}}", {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}{{#isNullable}}.Value{{/isNullable}});{{/required}}
             {{/lambda.copyText}}
             {{#lambda.indent3}}
             {{>WriteProperty}}{{! prevent indent}}
@@ -477,7 +478,8 @@
             {{^isEnum}}
             {{#isNumeric}}
             {{#lambda.copyText}}
-            writer.WriteNumber("{{baseName}}", {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{^required}}_{{/required}}{{name}}{{^required}}Option.Value{{#vendorExtensions.x-is-value-type}}{{nrt!}}.Value{{/vendorExtensions.x-is-value-type}}{{/required}}{{#required}}{{#isNullable}}.Value{{/isNullable}}{{/required}});
+            {{^required}}{{#vendorExtensions.x-is-value-type}}if ({{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}._{{name}}Option.Value != null)
+    writer.WriteNumber("{{baseName}}", {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}._{{name}}Option.Value{{nrt!}}.Value);{{/vendorExtensions.x-is-value-type}}{{^vendorExtensions.x-is-value-type}}writer.WriteNumber("{{baseName}}", {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}._{{name}}Option.Value);{{/vendorExtensions.x-is-value-type}}{{/required}}{{#required}}writer.WriteNumber("{{baseName}}", {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}{{#isNullable}}.Value{{/isNullable}});{{/required}}
             {{/lambda.copyText}}
             {{#lambda.indent3}}
             {{>WriteProperty}}{{! prevent indent}}

--- a/templates-v7/csharp/libraries/generichost/JsonConverter.mustache
+++ b/templates-v7/csharp/libraries/generichost/JsonConverter.mustache
@@ -488,7 +488,8 @@
             {{/isEnum}}
             {{#isDate}}
             {{#lambda.copyText}}
-            writer.WriteString("{{baseName}}", {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{^required}}_{{/required}}{{name}}{{^required}}Option.Value{{#vendorExtensions.x-is-value-type}}{{nrt!}}.Value{{/vendorExtensions.x-is-value-type}}{{/required}}{{#required}}{{#isNullable}}.Value{{/isNullable}}{{/required}}.ToString({{name}}Format));
+            {{^required}}{{#vendorExtensions.x-is-value-type}}if ({{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}._{{name}}Option.Value != null)
+    writer.WriteString("{{baseName}}", {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}._{{name}}Option.Value{{nrt!}}.Value.ToString({{name}}Format));{{/vendorExtensions.x-is-value-type}}{{^vendorExtensions.x-is-value-type}}writer.WriteString("{{baseName}}", {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}._{{name}}Option.Value.ToString({{name}}Format));{{/vendorExtensions.x-is-value-type}}{{/required}}{{#required}}writer.WriteString("{{baseName}}", {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}{{#isNullable}}.Value{{/isNullable}}.ToString({{name}}Format));{{/required}}
             {{/lambda.copyText}}
             {{#lambda.indent3}}
             {{>WriteProperty}}{{! prevent indent}}
@@ -496,7 +497,8 @@
             {{/isDate}}
             {{#isDateTime}}
             {{#lambda.copyText}}
-            writer.WriteString("{{baseName}}", {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{^required}}_{{/required}}{{name}}{{^required}}Option.Value{{#vendorExtensions.x-is-value-type}}{{nrt!}}.Value{{/vendorExtensions.x-is-value-type}}{{/required}}{{#required}}{{#isNullable}}.Value{{/isNullable}}{{/required}}.ToString({{name}}Format));
+            {{^required}}{{#vendorExtensions.x-is-value-type}}if ({{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}._{{name}}Option.Value != null)
+    writer.WriteString("{{baseName}}", {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}._{{name}}Option.Value{{nrt!}}.Value.ToString({{name}}Format));{{/vendorExtensions.x-is-value-type}}{{^vendorExtensions.x-is-value-type}}writer.WriteString("{{baseName}}", {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}._{{name}}Option.Value.ToString({{name}}Format));{{/vendorExtensions.x-is-value-type}}{{/required}}{{#required}}writer.WriteString("{{baseName}}", {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}{{#isNullable}}.Value{{/isNullable}}.ToString({{name}}Format));{{/required}}
             {{/lambda.copyText}}
             {{#lambda.indent3}}
             {{>WriteProperty}}{{! prevent indent}}


### PR DESCRIPTION
## Problem

Serializing any model with a nullable value-type `Option<T?>` property (e.g. `bool?`, `int?`, `DateOnly?`, `DateTimeOffset?`) set explicitly to `null` via the constructor threw `InvalidOperationException: Nullable object must have a value`.

Passing `null` to a constructor parameter typed `Option<T?>` sets `IsSet = true` with `Value = null` via the implicit conversion. The generated `WriteProperties` method then called `.Value!.Value` (or `.Value!.Value.ToString(...)`) without a null guard, causing the crash.

Fixes #1464.

## Root cause

In `templates-v7/csharp/libraries/generichost/JsonConverter.mustache`, the `lambda.copyText` blocks for `isBoolean`, `isNumeric`, `isDate`, and `isDateTime` generated bare write calls for non-required value-type options:

```csharp
// Before — crashes when Value is null
if (request._ReusableOption.IsSet)
    writer.WriteBoolean("reusable", request._ReusableOption.Value!.Value);
```

Reference-type string properties were already safe because their null check was embedded in the paste content.

## Fix

### Template (`JsonConverter.mustache`)
Added a null guard in the `lambda.copyText` paste content for non-required value-type branches of `isBoolean`, `isNumeric`, `isDate`, and `isDateTime`, matching the existing pattern used by string properties:

```csharp
// After — null is safely omitted
if (request._ReusableOption.IsSet)
    if (request._ReusableOption.Value != null)
        writer.WriteBoolean("reusable", request._ReusableOption.Value!.Value);
```

### Generated code
Regenerated Checkout models only. 
All other services will be regenerated by SDK Automation Bot

## Tests

Added `NullableOptionSerializationTest` covering:
- Null `Option<string?>` — was already safe (baseline)
- Null `Option<bool?>` — was crashing, now omitted
- Null `Option<int?>` — was crashing, now omitted
- Null `Option<DateOnly?>` — was crashing, now omitted
- Null `Option<DateTimeOffset?>` — was crashing, now omitted
- Non-null `bool?`, `int?`, `DateTimeOffset?` — regression tests confirming values still serialize correctly
- Round-trip: null bool omitted then deserializes as null; non-null bool round-trips correctly

## Related

- Remaining template readability improvement tracked in #1465