### PR TITLE
Fix: add dual Newtonsoft/STJ compatibility to classic webhook models

### DIFF
--- a/Adyen.Test/Webhooks/WebhookHandlerTest.cs
+++ b/Adyen.Test/Webhooks/WebhookHandlerTest.cs
@@ -201,6 +201,50 @@ namespace Adyen.Test.Webhooks
             Assert.AreEqual("HMAC validation failed because the ADYEN_HMAC_KEY is not configured.", exception.Message);
         }
         
+        /// <summary>
+        /// Regression test for GitHub issue #1473.
+        /// Verifies that <see cref="NotificationRequest"/> can be deserialized using Newtonsoft.Json,
+        /// confirming dual STJ/Newtonsoft compatibility on the classic webhook models.
+        /// </summary>
+        [TestMethod]
+        public void Given_WebhookPayload_When_DeserializedWithNewtonsoft_Then_AllPropertiesArePopulated()
+        {
+            var mockPath = GetMockFilePath("mocks/notification/capture-true.json");
+            var jsonRequest = MockFileToString(mockPath);
+
+            var result = Newtonsoft.Json.JsonConvert.DeserializeObject<Adyen.Webhooks.Models.NotificationRequest>(jsonRequest);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual("false", result.Live);
+            Assert.IsNotNull(result.NotificationItemContainers);
+            Assert.AreEqual(1, result.NotificationItemContainers.Count);
+
+            var item = result.NotificationItemContainers[0].NotificationItem;
+            Assert.IsNotNull(item);
+            Assert.AreEqual("CAPTURE", item.EventCode);
+            Assert.AreEqual("PSP_REFERENCE", item.PspReference);
+            Assert.AreEqual(23623, item.Amount.Value);
+            Assert.IsTrue(item.Success);
+        }
+
+        /// <summary>
+        /// Regression test for GitHub issue #1473.
+        /// Verifies that the <c>success</c> field sent as a JSON string ("true"/"false") by Adyen
+        /// is correctly deserialized to <see cref="bool"/> when using Newtonsoft.Json.
+        /// </summary>
+        [TestMethod]
+        public void Given_WebhookPayload_When_SuccessIsStringAndDeserializedWithNewtonsoft_Then_SuccessIsFalse()
+        {
+            var mockPath = GetMockFilePath("mocks/notification/capture-false.json");
+            var jsonRequest = MockFileToString(mockPath);
+
+            var result = Newtonsoft.Json.JsonConvert.DeserializeObject<Adyen.Webhooks.Models.NotificationRequest>(jsonRequest);
+
+            Assert.IsNotNull(result);
+            var item = result.NotificationItemContainers[0].NotificationItem;
+            Assert.IsFalse(item.Success);
+        }
+
         [TestMethod]
         public void TestPOSDisplayNotification()
         {

--- a/Adyen/Webhooks/Models/NotificationRequest.cs
+++ b/Adyen/Webhooks/Models/NotificationRequest.cs
@@ -36,9 +36,11 @@ namespace Adyen.Webhooks.Models
         };
 
         [JsonPropertyName("live")]
+        [Newtonsoft.Json.JsonProperty("live")]
         public string Live { get; set; }
 
         [JsonPropertyName("notificationItems")]
+        [Newtonsoft.Json.JsonProperty("notificationItems")]
         public List<NotificationRequestItemContainer> NotificationItemContainers { get; set; }
 
         /// <summary>

--- a/Adyen/Webhooks/Models/NotificationRequestItem.cs
+++ b/Adyen/Webhooks/Models/NotificationRequestItem.cs
@@ -39,6 +39,7 @@ namespace Adyen.Webhooks.Models
         public string PspReference { get; set; }
         public string Reason { get; set; }
         [JsonConverter(typeof(BooleanFromStringJsonConverter))]
+        [Newtonsoft.Json.JsonConverter(typeof(NewtonsoftBooleanFromStringConverter))]
         public bool Success { get; set; }
         public string PaymentMethod { get; set; }
         public List<string> Operations { get; set; }
@@ -69,5 +70,25 @@ namespace Adyen.Webhooks.Models
         {
             writer.WriteBooleanValue(value);
         }
+    }
+
+    internal class NewtonsoftBooleanFromStringConverter : Newtonsoft.Json.JsonConverter<bool>
+    {
+        public override bool ReadJson(Newtonsoft.Json.JsonReader reader, Type objectType, bool existingValue,
+            bool hasExistingValue, Newtonsoft.Json.JsonSerializer serializer)
+        {
+            if (reader.TokenType == Newtonsoft.Json.JsonToken.Boolean)
+                return (bool)reader.Value;
+
+            if (reader.TokenType == Newtonsoft.Json.JsonToken.String &&
+                bool.TryParse((string)reader.Value, out bool result))
+                return result;
+
+            throw new Newtonsoft.Json.JsonSerializationException(
+                "Unable to convert the webhook success value to boolean.");
+        }
+
+        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, bool value,
+            Newtonsoft.Json.JsonSerializer serializer) => writer.WriteValue(value);
     }
 }

--- a/Adyen/Webhooks/Models/NotificationRequestItem.cs
+++ b/Adyen/Webhooks/Models/NotificationRequestItem.cs
@@ -85,7 +85,7 @@ namespace Adyen.Webhooks.Models
                 return result;
 
             throw new Newtonsoft.Json.JsonSerializationException(
-                "Unable to convert the webhook success value to boolean.");
+                $"Unable to convert the webhook success value '{reader.Value}' to boolean.");
         }
 
         public override void WriteJson(Newtonsoft.Json.JsonWriter writer, bool value,

--- a/Adyen/Webhooks/Models/NotificationRequestItemContainer.cs
+++ b/Adyen/Webhooks/Models/NotificationRequestItemContainer.cs
@@ -29,6 +29,7 @@ namespace Adyen.Webhooks.Models
     public class NotificationRequestItemContainer
     {
         [JsonPropertyName("NotificationRequestItem")]
+        [Newtonsoft.Json.JsonProperty("NotificationRequestItem")]
         public NotificationRequestItem NotificationItem { get; set; }
 
         public override string ToString()


### PR DESCRIPTION
## What problem this solves

Closes #1473.

The classic webhook models in `Adyen/Webhooks/Models` were updated in v34.0.1 to use System.Text.Json attributes (`[JsonPropertyName]`, `[JsonConverter]`). This broke consumers whose ASP.NET pipeline was configured with Newtonsoft.Json, since Newtonsoft ignores STJ attributes — causing `notificationItems` and `NotificationRequestItem` to deserialize as `null`, and the `success` field (sent by Adyen as a JSON string) to throw.

## Root cause

| Property | JSON key | Problem |
|---|---|---|
| `NotificationRequest.NotificationItemContainers` | `notificationItems` | Newtonsoft uses the C# name by default → key mismatch → `null` |
| `NotificationRequestItemContainer.NotificationItem` | `NotificationRequestItem` | Same issue |
| `NotificationRequestItem.Success` | `success` | STJ converter handles string→bool; Newtonsoft has no converter → throws |

## Fix

Both serializers ignore each other's attributes, so dual-annotating is safe and non-breaking:

- Add `[Newtonsoft.Json.JsonProperty("...")]` alongside existing `[JsonPropertyName("...")]` on the two mismatched properties.
- Add a `NewtonsoftBooleanFromStringConverter` (mirrors the existing STJ converter) and annotate `Success` with `[Newtonsoft.Json.JsonConverter(typeof(NewtonsoftBooleanFromStringConverter))]`.

## Backward compatibility

STJ behaviour is completely unchanged. All existing tests pass. No new packages introduced (Newtonsoft.Json is already a dependency).

## Tests

Two regression tests added to `WebhookHandlerTest`:
- **`Given_WebhookPayload_When_DeserializedWithNewtonsoft_Then_AllPropertiesArePopulated`** — deserializes a capture webhook via `JsonConvert.DeserializeObject` and asserts all fields.
- **`Given_WebhookPayload_When_SuccessIsStringAndDeserializedWithNewtonsoft_Then_SuccessIsFalse`** — verifies `success: "false"` (string) is correctly parsed to `bool` by Newtonsoft.