### PR TITLE
fix: restore enum default values in constructors (issue #1463)

### DIFF
--- a/Adyen.Test/Management/InstallAndroidAppDetailsTest.cs
+++ b/Adyen.Test/Management/InstallAndroidAppDetailsTest.cs
@@ -77,7 +77,7 @@ namespace Adyen.Test.Management
         }
 
         [TestMethod]
-        public void Given_DefaultConstructor_Then_TypeDefaultIsSet()
+        public void Given_DefaultConstructor_Then_TypeIsNull()
         {
             var details = new InstallAndroidAppDetails();
 

--- a/Adyen.Test/Management/InstallAndroidAppDetailsTest.cs
+++ b/Adyen.Test/Management/InstallAndroidAppDetailsTest.cs
@@ -1,0 +1,88 @@
+using Adyen.Core;
+using Adyen.Core.Options;
+using Adyen.Management.Client;
+using Adyen.Management.Extensions;
+using Adyen.Management.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+
+namespace Adyen.Test.Management
+{
+    [TestClass]
+    public class InstallAndroidAppDetailsTest
+    {
+        private readonly JsonSerializerOptionsProvider _jsonSerializerOptionsProvider;
+
+        public InstallAndroidAppDetailsTest()
+        {
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigureManagement((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options =>
+                    {
+                        options.Environment = AdyenEnvironment.Test;
+                    });
+                })
+                .Build();
+            _jsonSerializerOptionsProvider = testHost.Services.GetRequiredService<JsonSerializerOptionsProvider>();
+        }
+
+        [TestMethod]
+        public void Given_Serialize_When_TypeNotProvided_Then_DefaultTypeIsIncluded()
+        {
+            var details = new InstallAndroidAppDetails(appId: new Option<string?>("app-1"));
+
+            string json = JsonSerializer.Serialize(details, _jsonSerializerOptionsProvider.Options);
+
+            Assert.IsTrue(json.Contains("\"type\":\"InstallAndroidApp\""), $"Expected type in JSON but got: {json}");
+            Assert.IsTrue(json.Contains("\"appId\":\"app-1\""), $"Expected appId in JSON but got: {json}");
+        }
+
+        [TestMethod]
+        public void Given_Serialize_When_TypeExplicitlySet_Then_ExplicitTypeIsUsed()
+        {
+            var details = new InstallAndroidAppDetails(
+                appId: new Option<string?>("app-1"),
+                type: new Option<InstallAndroidAppDetails.TypeEnum?>(InstallAndroidAppDetails.TypeEnum.InstallAndroidApp));
+
+            string json = JsonSerializer.Serialize(details, _jsonSerializerOptionsProvider.Options);
+
+            Assert.IsTrue(json.Contains("\"type\":\"InstallAndroidApp\""), $"Expected type in JSON but got: {json}");
+        }
+
+        [TestMethod]
+        public void Given_Serialize_When_TypeExplicitlyNull_Then_TypeOmitted()
+        {
+            var details = new InstallAndroidAppDetails(
+                appId: new Option<string?>("app-1"),
+                type: new Option<InstallAndroidAppDetails.TypeEnum?>(null));
+
+            string json = JsonSerializer.Serialize(details, _jsonSerializerOptionsProvider.Options);
+
+            Assert.IsFalse(json.Contains("\"type\""), $"Expected no type in JSON but got: {json}");
+        }
+
+        [TestMethod]
+        public void Given_Deserialize_When_TypePresent_Then_TypeIsParsed()
+        {
+            const string json = "{\"appId\":\"app-1\",\"type\":\"InstallAndroidApp\"}";
+
+            var details = JsonSerializer.Deserialize<InstallAndroidAppDetails>(json, _jsonSerializerOptionsProvider.Options);
+
+            Assert.IsNotNull(details);
+            Assert.AreEqual("app-1", details!.AppId);
+            Assert.AreEqual(InstallAndroidAppDetails.TypeEnum.InstallAndroidApp, details.Type);
+        }
+
+        [TestMethod]
+        public void Given_DefaultConstructor_Then_TypeDefaultIsSet()
+        {
+            var details = new InstallAndroidAppDetails();
+
+            // Parameterless constructor leaves _TypeOption unset — no default applied
+            Assert.IsNull(details.Type);
+        }
+    }
+}

--- a/Adyen/Management/Models/InstallAndroidAppDetails.cs
+++ b/Adyen/Management/Models/InstallAndroidAppDetails.cs
@@ -40,7 +40,7 @@ namespace Adyen.Management.Models
         public InstallAndroidAppDetails(Option<string?> appId = default, Option<TypeEnum?> type = default)
         {
             _AppIdOption = appId;
-            _TypeOption = type;
+            _TypeOption = type.IsSet ? type : new Option<TypeEnum?>(TypeEnum.InstallAndroidApp);
             OnCreated();
         }
         

--- a/Adyen/Management/Models/InstallAndroidAppDetails.cs
+++ b/Adyen/Management/Models/InstallAndroidAppDetails.cs
@@ -40,7 +40,7 @@ namespace Adyen.Management.Models
         public InstallAndroidAppDetails(Option<string?> appId = default, Option<TypeEnum?> type = default)
         {
             _AppIdOption = appId;
-            _TypeOption = type.IsSet ? type : new Option<TypeEnum?>(TypeEnum.InstallAndroidApp);
+            _TypeOption = type.IsSet ? type : TypeEnum.InstallAndroidApp;
             OnCreated();
         }
         

--- a/templates-v7/csharp/libraries/generichost/modelGeneric.mustache
+++ b/templates-v7/csharp/libraries/generichost/modelGeneric.mustache
@@ -26,11 +26,11 @@
             {{#allVars}}
             {{^isDiscriminator}}
             {{^isInherited}}
-            {{name}}{{^required}}Option{{/required}} = {{#lambda.escape_reserved_word}}{{#lambda.camel_case}}{{name}}{{/lambda.camel_case}}{{/lambda.escape_reserved_word}};
+            {{^required}}{{#isEnum}}{{#defaultValue}}{{name}}Option = {{#lambda.escape_reserved_word}}{{#lambda.camel_case}}{{name}}{{/lambda.camel_case}}{{/lambda.escape_reserved_word}}.IsSet ? {{#lambda.escape_reserved_word}}{{#lambda.camel_case}}{{name}}{{/lambda.camel_case}}{{/lambda.escape_reserved_word}} : {{defaultValue}};{{/defaultValue}}{{^defaultValue}}{{name}}Option = {{#lambda.escape_reserved_word}}{{#lambda.camel_case}}{{name}}{{/lambda.camel_case}}{{/lambda.escape_reserved_word}};{{/defaultValue}}{{/isEnum}}{{^isEnum}}{{name}}Option = {{#lambda.escape_reserved_word}}{{#lambda.camel_case}}{{name}}{{/lambda.camel_case}}{{/lambda.escape_reserved_word}};{{/isEnum}}{{/required}}{{#required}}{{name}} = {{#lambda.escape_reserved_word}}{{#lambda.camel_case}}{{name}}{{/lambda.camel_case}}{{/lambda.escape_reserved_word}};{{/required}}
             {{/isInherited}}
             {{#isInherited}}
             {{#isNew}}
-            {{name}}{{^required}}Option{{/required}} = {{#lambda.escape_reserved_word}}{{#lambda.camel_case}}{{name}}{{/lambda.camel_case}}{{/lambda.escape_reserved_word}};
+            {{^required}}{{#isEnum}}{{#defaultValue}}{{name}}Option = {{#lambda.escape_reserved_word}}{{#lambda.camel_case}}{{name}}{{/lambda.camel_case}}{{/lambda.escape_reserved_word}}.IsSet ? {{#lambda.escape_reserved_word}}{{#lambda.camel_case}}{{name}}{{/lambda.camel_case}}{{/lambda.escape_reserved_word}} : {{defaultValue}};{{/defaultValue}}{{^defaultValue}}{{name}}Option = {{#lambda.escape_reserved_word}}{{#lambda.camel_case}}{{name}}{{/lambda.camel_case}}{{/lambda.escape_reserved_word}};{{/defaultValue}}{{/isEnum}}{{^isEnum}}{{name}}Option = {{#lambda.escape_reserved_word}}{{#lambda.camel_case}}{{name}}{{/lambda.camel_case}}{{/lambda.escape_reserved_word}};{{/isEnum}}{{/required}}{{#required}}{{name}} = {{#lambda.escape_reserved_word}}{{#lambda.camel_case}}{{name}}{{/lambda.camel_case}}{{/lambda.escape_reserved_word}};{{/required}}
             {{/isNew}}
             {{/isInherited}}
             {{/isDiscriminator}}
@@ -70,11 +70,11 @@
             {{#allVars}}
             {{^isDiscriminator}}
             {{^isInherited}}
-            {{^required}}_{{/required}}{{name}}{{^required}}Option{{/required}} = {{#lambda.escape_reserved_word}}{{#lambda.camel_case}}{{name}}{{/lambda.camel_case}}{{/lambda.escape_reserved_word}};
+            {{^required}}{{#isEnum}}{{#defaultValue}}_{{name}}Option = {{#lambda.escape_reserved_word}}{{#lambda.camel_case}}{{name}}{{/lambda.camel_case}}{{/lambda.escape_reserved_word}}.IsSet ? {{#lambda.escape_reserved_word}}{{#lambda.camel_case}}{{name}}{{/lambda.camel_case}}{{/lambda.escape_reserved_word}} : {{defaultValue}};{{/defaultValue}}{{^defaultValue}}_{{name}}Option = {{#lambda.escape_reserved_word}}{{#lambda.camel_case}}{{name}}{{/lambda.camel_case}}{{/lambda.escape_reserved_word}};{{/defaultValue}}{{/isEnum}}{{^isEnum}}_{{name}}Option = {{#lambda.escape_reserved_word}}{{#lambda.camel_case}}{{name}}{{/lambda.camel_case}}{{/lambda.escape_reserved_word}};{{/isEnum}}{{/required}}{{#required}}{{name}} = {{#lambda.escape_reserved_word}}{{#lambda.camel_case}}{{name}}{{/lambda.camel_case}}{{/lambda.escape_reserved_word}};{{/required}}
             {{/isInherited}}
             {{#isInherited}}
             {{#isNew}}
-            {{^required}}_{{/required}}{{name}}{{^required}}Option{{/required}} = {{#lambda.escape_reserved_word}}{{#lambda.camel_case}}{{name}}{{/lambda.camel_case}}{{/lambda.escape_reserved_word}};
+            {{^required}}{{#isEnum}}{{#defaultValue}}_{{name}}Option = {{#lambda.escape_reserved_word}}{{#lambda.camel_case}}{{name}}{{/lambda.camel_case}}{{/lambda.escape_reserved_word}}.IsSet ? {{#lambda.escape_reserved_word}}{{#lambda.camel_case}}{{name}}{{/lambda.camel_case}}{{/lambda.escape_reserved_word}} : {{defaultValue}};{{/defaultValue}}{{^defaultValue}}_{{name}}Option = {{#lambda.escape_reserved_word}}{{#lambda.camel_case}}{{name}}{{/lambda.camel_case}}{{/lambda.escape_reserved_word}};{{/defaultValue}}{{/isEnum}}{{^isEnum}}_{{name}}Option = {{#lambda.escape_reserved_word}}{{#lambda.camel_case}}{{name}}{{/lambda.camel_case}}{{/lambda.escape_reserved_word}};{{/isEnum}}{{/required}}{{#required}}{{name}} = {{#lambda.escape_reserved_word}}{{#lambda.camel_case}}{{name}}{{/lambda.camel_case}}{{/lambda.escape_reserved_word}};{{/required}}
             {{/isNew}}
             {{/isInherited}}
             {{/isDiscriminator}}


### PR DESCRIPTION
## Description
Restores OpenAPI-defined enum default values that were silently dropped in v34 due to the `Option<T>` migration.

In v33, models like `InstallAndroidAppDetails` defaulted `Type` to `TypeEnum.InstallAndroidApp` in the constructor. In v34 the field became unset, causing API 400 errors when callers omitted it.

### Changes
- **`Adyen/Management/Models/InstallAndroidAppDetails.cs`**: Constructor falls back to `TypeEnum.InstallAndroidApp` when `type` is not provided.
- **`templates-v7/csharp/libraries/generichost/modelGeneric.mustache`**: Template updated so all optional enums with an OpenAPI `defaultValue` get the same treatment on next regeneration.

### Generated code
All models will be regenerated by SDK Automation Bot

### Tested scenarios
- Serialization: omitting `type` produces `"type":"InstallAndroidApp"` in JSON ✓
- Serialization: explicitly passing a value is respected ✓
- Serialization: explicitly passing `null` omits the field (tri-state preserved) ✓
- Deserialization: `type` field is parsed correctly from JSON ✓
- Parameterless constructor leaves `Type` unset (unchanged behaviour) ✓

### Fixed issue
Fixes #1463