### PR TITLE
fix: add missing XML doc comments in modelInnerEnum template to resolve CS1591 warnings

### DIFF
--- a/templates-v7/csharp/libraries/generichost/modelInnerEnum.mustache
+++ b/templates-v7/csharp/libraries/generichost/modelInnerEnum.mustache
@@ -48,14 +48,29 @@
             /// <returns>String value of the <see cref="{{datatypeWithEnum}}"/> instance./// </returns>
             public static implicit operator string?({{datatypeWithEnum}}? option) => option?.Value;
         
+            /// <summary>
+            /// Compares two <see cref="{{datatypeWithEnum}}"/> instances for equality.
+            /// </summary>
             public static bool operator ==({{datatypeWithEnum}}? left, {{datatypeWithEnum}}? right) => string.Equals(left?.Value, right?.Value, StringComparison.OrdinalIgnoreCase);
-    
+
+            /// <summary>
+            /// Compares two <see cref="{{datatypeWithEnum}}"/> instances for inequality.
+            /// </summary>
             public static bool operator !=({{datatypeWithEnum}}? left, {{datatypeWithEnum}}? right) => !string.Equals(left?.Value, right?.Value, StringComparison.OrdinalIgnoreCase);
 
+            /// <summary>
+            /// Returns true if the given object is equal to this <see cref="{{datatypeWithEnum}}"/> instance.
+            /// </summary>
             public override bool Equals(object? obj) => obj is {{datatypeWithEnum}} other && string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
-    
+
+            /// <summary>
+            /// Returns a hash code for this <see cref="{{datatypeWithEnum}}"/> instance.
+            /// </summary>
             public override int GetHashCode() => Value?.GetHashCode() ?? 0;
-        
+
+            /// <summary>
+            /// Returns the string value of the <see cref="{{datatypeWithEnum}}"/> instance.
+            /// </summary>
             public override string ToString() => Value ?? string.Empty;
         
             {{#useGenericHost}}
@@ -100,12 +115,18 @@
             /// </summary>
             public class {{datatypeWithEnum}}JsonConverter : JsonConverter<{{datatypeWithEnum}}>
             {
+                /// <summary>
+                /// Deserializes a <see cref="{{datatypeWithEnum}}"/> from JSON.
+                /// </summary>
                 public override {{datatypeWithEnum}}? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions jsonOptions)
                 {
                     string value = reader.GetString();
                     return value == null ? null : {{datatypeWithEnum}}.FromStringOrDefault(value) ?? new {{datatypeWithEnum}}(value);
                 }
 
+                /// <summary>
+                /// Serializes a <see cref="{{datatypeWithEnum}}"/> to JSON.
+                /// </summary>
                 public override void Write(Utf8JsonWriter writer, {{datatypeWithEnum}} value, JsonSerializerOptions jsonOptions)
                 {
                     writer.WriteStringValue({{datatypeWithEnum}}.ToJsonValue(value));


### PR DESCRIPTION
## Description
The `modelInnerEnum.mustache` template was missing `/// <summary>` comments on several public members of the generated inner `TypeEnum` classes, causing `CS1591` (Missing XML documentation comment) warnings on every build.

The affected members were:
- `operator ==` and `operator !=`
- `Equals(object?)`
- `GetHashCode()`
- `ToString()`
- `TypeEnumJsonConverter.Read(...)` and `TypeEnumJsonConverter.Write(...)`

## Tested scenarios
- Template change verified locally; fix will take effect on the next code generation run for all services.

## Fixed issue
Resolves CS1591 warnings appearing on all generated models containing inner enum types (e.g. `BalancePlatform`, `ConfigurationWebhooks`, etc.).