### PR TITLE
Remove unused httpClientOptions and httpClientBuilderOptions from Configure{ApiName} extension methods

### DIFF
--- a/Adyen/AcsWebhooks/Extensions/HostBuilderExtensions.cs
+++ b/Adyen/AcsWebhooks/Extensions/HostBuilderExtensions.cs
@@ -28,9 +28,7 @@ namespace Adyen.AcsWebhooks.Extensions
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureAcsWebhooks(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureAcsWebhooks(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {
@@ -44,14 +42,12 @@ namespace Adyen.AcsWebhooks.Extensions
     
         /// <summary>
         /// Initializes the <see cref="HostConfiguration"/> *and* adds the AcsWebhooks API services defaults to the <see cref="IServiceCollection"/>.
-        /// You can (optionally) configure the <see cref="ServiceLifetime"/>, the <see cref="System.Net.Http.HttpClient"/> (timeouts) and <see cref="IHttpClientBuilder"/>.
+        /// You can (optionally) configure the <see cref="ServiceLifetime"/>.
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
         /// <param name="serviceLifetime"><see cref="ServiceLifetime"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureAcsWebhooksDefaults(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureAcsWebhooksDefaults(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {

--- a/Adyen/BalanceControl/Extensions/HostBuilderExtensions.cs
+++ b/Adyen/BalanceControl/Extensions/HostBuilderExtensions.cs
@@ -28,9 +28,7 @@ namespace Adyen.BalanceControl.Extensions
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureBalanceControl(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureBalanceControl(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {

--- a/Adyen/BalancePlatform/Extensions/HostBuilderExtensions.cs
+++ b/Adyen/BalancePlatform/Extensions/HostBuilderExtensions.cs
@@ -28,9 +28,7 @@ namespace Adyen.BalancePlatform.Extensions
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureBalancePlatform(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureBalancePlatform(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {

--- a/Adyen/BalanceWebhooks/Extensions/HostBuilderExtensions.cs
+++ b/Adyen/BalanceWebhooks/Extensions/HostBuilderExtensions.cs
@@ -28,9 +28,7 @@ namespace Adyen.BalanceWebhooks.Extensions
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureBalanceWebhooks(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureBalanceWebhooks(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {
@@ -44,14 +42,12 @@ namespace Adyen.BalanceWebhooks.Extensions
     
         /// <summary>
         /// Initializes the <see cref="HostConfiguration"/> *and* adds the BalanceWebhooks API services defaults to the <see cref="IServiceCollection"/>.
-        /// You can (optionally) configure the <see cref="ServiceLifetime"/>, the <see cref="System.Net.Http.HttpClient"/> (timeouts) and <see cref="IHttpClientBuilder"/>.
+        /// You can (optionally) configure the <see cref="ServiceLifetime"/>.
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
         /// <param name="serviceLifetime"><see cref="ServiceLifetime"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureBalanceWebhooksDefaults(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureBalanceWebhooksDefaults(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {

--- a/Adyen/BinLookup/Extensions/HostBuilderExtensions.cs
+++ b/Adyen/BinLookup/Extensions/HostBuilderExtensions.cs
@@ -28,9 +28,7 @@ namespace Adyen.BinLookup.Extensions
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureBinLookup(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureBinLookup(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {

--- a/Adyen/Capital/Extensions/HostBuilderExtensions.cs
+++ b/Adyen/Capital/Extensions/HostBuilderExtensions.cs
@@ -28,9 +28,7 @@ namespace Adyen.Capital.Extensions
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureCapital(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureCapital(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {

--- a/Adyen/Checkout/Extensions/HostBuilderExtensions.cs
+++ b/Adyen/Checkout/Extensions/HostBuilderExtensions.cs
@@ -28,9 +28,7 @@ namespace Adyen.Checkout.Extensions
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureCheckout(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureCheckout(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {

--- a/Adyen/ConfigurationWebhooks/Extensions/HostBuilderExtensions.cs
+++ b/Adyen/ConfigurationWebhooks/Extensions/HostBuilderExtensions.cs
@@ -28,9 +28,7 @@ namespace Adyen.ConfigurationWebhooks.Extensions
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureConfigurationWebhooks(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureConfigurationWebhooks(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {
@@ -44,14 +42,12 @@ namespace Adyen.ConfigurationWebhooks.Extensions
     
         /// <summary>
         /// Initializes the <see cref="HostConfiguration"/> *and* adds the ConfigurationWebhooks API services defaults to the <see cref="IServiceCollection"/>.
-        /// You can (optionally) configure the <see cref="ServiceLifetime"/>, the <see cref="System.Net.Http.HttpClient"/> (timeouts) and <see cref="IHttpClientBuilder"/>.
+        /// You can (optionally) configure the <see cref="ServiceLifetime"/>.
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
         /// <param name="serviceLifetime"><see cref="ServiceLifetime"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureConfigurationWebhooksDefaults(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureConfigurationWebhooksDefaults(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {

--- a/Adyen/DataProtection/Extensions/HostBuilderExtensions.cs
+++ b/Adyen/DataProtection/Extensions/HostBuilderExtensions.cs
@@ -28,9 +28,7 @@ namespace Adyen.DataProtection.Extensions
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureDataProtection(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureDataProtection(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {

--- a/Adyen/DisputeWebhooks/Extensions/HostBuilderExtensions.cs
+++ b/Adyen/DisputeWebhooks/Extensions/HostBuilderExtensions.cs
@@ -28,9 +28,7 @@ namespace Adyen.DisputeWebhooks.Extensions
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureDisputeWebhooks(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureDisputeWebhooks(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {
@@ -44,14 +42,12 @@ namespace Adyen.DisputeWebhooks.Extensions
     
         /// <summary>
         /// Initializes the <see cref="HostConfiguration"/> *and* adds the DisputeWebhooks API services defaults to the <see cref="IServiceCollection"/>.
-        /// You can (optionally) configure the <see cref="ServiceLifetime"/>, the <see cref="System.Net.Http.HttpClient"/> (timeouts) and <see cref="IHttpClientBuilder"/>.
+        /// You can (optionally) configure the <see cref="ServiceLifetime"/>.
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
         /// <param name="serviceLifetime"><see cref="ServiceLifetime"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureDisputeWebhooksDefaults(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureDisputeWebhooksDefaults(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {

--- a/Adyen/Disputes/Extensions/HostBuilderExtensions.cs
+++ b/Adyen/Disputes/Extensions/HostBuilderExtensions.cs
@@ -28,9 +28,7 @@ namespace Adyen.Disputes.Extensions
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureDisputes(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureDisputes(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {

--- a/Adyen/LegalEntityManagement/Extensions/HostBuilderExtensions.cs
+++ b/Adyen/LegalEntityManagement/Extensions/HostBuilderExtensions.cs
@@ -28,9 +28,7 @@ namespace Adyen.LegalEntityManagement.Extensions
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureLegalEntityManagement(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureLegalEntityManagement(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {

--- a/Adyen/Management/Extensions/HostBuilderExtensions.cs
+++ b/Adyen/Management/Extensions/HostBuilderExtensions.cs
@@ -28,9 +28,7 @@ namespace Adyen.Management.Extensions
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureManagement(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureManagement(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {

--- a/Adyen/ManagementWebhooks/Extensions/HostBuilderExtensions.cs
+++ b/Adyen/ManagementWebhooks/Extensions/HostBuilderExtensions.cs
@@ -28,9 +28,7 @@ namespace Adyen.ManagementWebhooks.Extensions
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureManagementWebhooks(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureManagementWebhooks(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {
@@ -44,14 +42,12 @@ namespace Adyen.ManagementWebhooks.Extensions
     
         /// <summary>
         /// Initializes the <see cref="HostConfiguration"/> *and* adds the ManagementWebhooks API services defaults to the <see cref="IServiceCollection"/>.
-        /// You can (optionally) configure the <see cref="ServiceLifetime"/>, the <see cref="System.Net.Http.HttpClient"/> (timeouts) and <see cref="IHttpClientBuilder"/>.
+        /// You can (optionally) configure the <see cref="ServiceLifetime"/>.
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
         /// <param name="serviceLifetime"><see cref="ServiceLifetime"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureManagementWebhooksDefaults(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureManagementWebhooksDefaults(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {

--- a/Adyen/NegativeBalanceWarningWebhooks/Extensions/HostBuilderExtensions.cs
+++ b/Adyen/NegativeBalanceWarningWebhooks/Extensions/HostBuilderExtensions.cs
@@ -28,9 +28,7 @@ namespace Adyen.NegativeBalanceWarningWebhooks.Extensions
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureNegativeBalanceWarningWebhooks(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureNegativeBalanceWarningWebhooks(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {
@@ -44,14 +42,12 @@ namespace Adyen.NegativeBalanceWarningWebhooks.Extensions
     
         /// <summary>
         /// Initializes the <see cref="HostConfiguration"/> *and* adds the NegativeBalanceWarningWebhooks API services defaults to the <see cref="IServiceCollection"/>.
-        /// You can (optionally) configure the <see cref="ServiceLifetime"/>, the <see cref="System.Net.Http.HttpClient"/> (timeouts) and <see cref="IHttpClientBuilder"/>.
+        /// You can (optionally) configure the <see cref="ServiceLifetime"/>.
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
         /// <param name="serviceLifetime"><see cref="ServiceLifetime"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureNegativeBalanceWarningWebhooksDefaults(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureNegativeBalanceWarningWebhooksDefaults(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {

--- a/Adyen/Payment/Extensions/HostBuilderExtensions.cs
+++ b/Adyen/Payment/Extensions/HostBuilderExtensions.cs
@@ -28,9 +28,7 @@ namespace Adyen.Payment.Extensions
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigurePayment(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigurePayment(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {

--- a/Adyen/PaymentsApp/Extensions/HostBuilderExtensions.cs
+++ b/Adyen/PaymentsApp/Extensions/HostBuilderExtensions.cs
@@ -28,9 +28,7 @@ namespace Adyen.PaymentsApp.Extensions
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigurePaymentsApp(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigurePaymentsApp(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {

--- a/Adyen/Payout/Extensions/HostBuilderExtensions.cs
+++ b/Adyen/Payout/Extensions/HostBuilderExtensions.cs
@@ -28,9 +28,7 @@ namespace Adyen.Payout.Extensions
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigurePayout(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigurePayout(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {

--- a/Adyen/PosMobile/Extensions/HostBuilderExtensions.cs
+++ b/Adyen/PosMobile/Extensions/HostBuilderExtensions.cs
@@ -28,9 +28,7 @@ namespace Adyen.PosMobile.Extensions
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigurePosMobile(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigurePosMobile(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {

--- a/Adyen/Recurring/Extensions/HostBuilderExtensions.cs
+++ b/Adyen/Recurring/Extensions/HostBuilderExtensions.cs
@@ -28,9 +28,7 @@ namespace Adyen.Recurring.Extensions
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureRecurring(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureRecurring(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {

--- a/Adyen/RelayedAuthorizationWebhooks/Extensions/HostBuilderExtensions.cs
+++ b/Adyen/RelayedAuthorizationWebhooks/Extensions/HostBuilderExtensions.cs
@@ -28,9 +28,7 @@ namespace Adyen.RelayedAuthorizationWebhooks.Extensions
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureRelayedAuthorizationWebhooks(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureRelayedAuthorizationWebhooks(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {
@@ -44,14 +42,12 @@ namespace Adyen.RelayedAuthorizationWebhooks.Extensions
     
         /// <summary>
         /// Initializes the <see cref="HostConfiguration"/> *and* adds the RelayedAuthorizationWebhooks API services defaults to the <see cref="IServiceCollection"/>.
-        /// You can (optionally) configure the <see cref="ServiceLifetime"/>, the <see cref="System.Net.Http.HttpClient"/> (timeouts) and <see cref="IHttpClientBuilder"/>.
+        /// You can (optionally) configure the <see cref="ServiceLifetime"/>.
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
         /// <param name="serviceLifetime"><see cref="ServiceLifetime"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureRelayedAuthorizationWebhooksDefaults(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureRelayedAuthorizationWebhooksDefaults(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {

--- a/Adyen/ReportWebhooks/Extensions/HostBuilderExtensions.cs
+++ b/Adyen/ReportWebhooks/Extensions/HostBuilderExtensions.cs
@@ -28,9 +28,7 @@ namespace Adyen.ReportWebhooks.Extensions
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureReportWebhooks(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureReportWebhooks(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {
@@ -44,14 +42,12 @@ namespace Adyen.ReportWebhooks.Extensions
     
         /// <summary>
         /// Initializes the <see cref="HostConfiguration"/> *and* adds the ReportWebhooks API services defaults to the <see cref="IServiceCollection"/>.
-        /// You can (optionally) configure the <see cref="ServiceLifetime"/>, the <see cref="System.Net.Http.HttpClient"/> (timeouts) and <see cref="IHttpClientBuilder"/>.
+        /// You can (optionally) configure the <see cref="ServiceLifetime"/>.
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
         /// <param name="serviceLifetime"><see cref="ServiceLifetime"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureReportWebhooksDefaults(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureReportWebhooksDefaults(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {

--- a/Adyen/SessionAuthentication/Extensions/HostBuilderExtensions.cs
+++ b/Adyen/SessionAuthentication/Extensions/HostBuilderExtensions.cs
@@ -28,9 +28,7 @@ namespace Adyen.SessionAuthentication.Extensions
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureSessionAuthentication(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureSessionAuthentication(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {

--- a/Adyen/StoredValue/Extensions/HostBuilderExtensions.cs
+++ b/Adyen/StoredValue/Extensions/HostBuilderExtensions.cs
@@ -28,9 +28,7 @@ namespace Adyen.StoredValue.Extensions
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureStoredValue(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureStoredValue(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {

--- a/Adyen/TokenizationWebhooks/Extensions/HostBuilderExtensions.cs
+++ b/Adyen/TokenizationWebhooks/Extensions/HostBuilderExtensions.cs
@@ -28,9 +28,7 @@ namespace Adyen.TokenizationWebhooks.Extensions
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureTokenizationWebhooks(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureTokenizationWebhooks(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {
@@ -44,14 +42,12 @@ namespace Adyen.TokenizationWebhooks.Extensions
     
         /// <summary>
         /// Initializes the <see cref="HostConfiguration"/> *and* adds the TokenizationWebhooks API services defaults to the <see cref="IServiceCollection"/>.
-        /// You can (optionally) configure the <see cref="ServiceLifetime"/>, the <see cref="System.Net.Http.HttpClient"/> (timeouts) and <see cref="IHttpClientBuilder"/>.
+        /// You can (optionally) configure the <see cref="ServiceLifetime"/>.
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
         /// <param name="serviceLifetime"><see cref="ServiceLifetime"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureTokenizationWebhooksDefaults(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureTokenizationWebhooksDefaults(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {

--- a/Adyen/TransactionWebhooks/Extensions/HostBuilderExtensions.cs
+++ b/Adyen/TransactionWebhooks/Extensions/HostBuilderExtensions.cs
@@ -28,9 +28,7 @@ namespace Adyen.TransactionWebhooks.Extensions
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureTransactionWebhooks(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureTransactionWebhooks(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {
@@ -44,14 +42,12 @@ namespace Adyen.TransactionWebhooks.Extensions
     
         /// <summary>
         /// Initializes the <see cref="HostConfiguration"/> *and* adds the TransactionWebhooks API services defaults to the <see cref="IServiceCollection"/>.
-        /// You can (optionally) configure the <see cref="ServiceLifetime"/>, the <see cref="System.Net.Http.HttpClient"/> (timeouts) and <see cref="IHttpClientBuilder"/>.
+        /// You can (optionally) configure the <see cref="ServiceLifetime"/>.
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
         /// <param name="serviceLifetime"><see cref="ServiceLifetime"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureTransactionWebhooksDefaults(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureTransactionWebhooksDefaults(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {

--- a/Adyen/TransferWebhooks/Extensions/HostBuilderExtensions.cs
+++ b/Adyen/TransferWebhooks/Extensions/HostBuilderExtensions.cs
@@ -28,9 +28,7 @@ namespace Adyen.TransferWebhooks.Extensions
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureTransferWebhooks(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureTransferWebhooks(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {
@@ -44,14 +42,12 @@ namespace Adyen.TransferWebhooks.Extensions
     
         /// <summary>
         /// Initializes the <see cref="HostConfiguration"/> *and* adds the TransferWebhooks API services defaults to the <see cref="IServiceCollection"/>.
-        /// You can (optionally) configure the <see cref="ServiceLifetime"/>, the <see cref="System.Net.Http.HttpClient"/> (timeouts) and <see cref="IHttpClientBuilder"/>.
+        /// You can (optionally) configure the <see cref="ServiceLifetime"/>.
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
         /// <param name="serviceLifetime"><see cref="ServiceLifetime"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureTransferWebhooksDefaults(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureTransferWebhooksDefaults(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {

--- a/Adyen/Transfers/Extensions/HostBuilderExtensions.cs
+++ b/Adyen/Transfers/Extensions/HostBuilderExtensions.cs
@@ -28,9 +28,7 @@ namespace Adyen.Transfers.Extensions
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder ConfigureTransfers(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder ConfigureTransfers(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {

--- a/templates-v7/csharp/libraries/generichost/IHostBuilderExtensions.mustache
+++ b/templates-v7/csharp/libraries/generichost/IHostBuilderExtensions.mustache
@@ -22,9 +22,7 @@ namespace {{packageName}}.{{apiName}}.Extensions
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
-        /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder Configure{{apiName}}(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        public static IHostBuilder Configure{{apiName}}(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions)
         {
             hostBuilder.ConfigureServices((context, services) => 
             {
@@ -38,14 +36,14 @@ namespace {{packageName}}.{{apiName}}.Extensions
     
         /// <summary>
         /// Initializes the <see cref="HostConfiguration"/> *and* adds the {{apiName}} API services defaults to the <see cref="IServiceCollection"/>.
-        /// You can (optionally) configure the <see cref="ServiceLifetime"/>, the <see cref="System.Net.Http.HttpClient"/> (timeouts) and <see cref="IHttpClientBuilder"/>.
+        /// You can (optionally) configure the <see cref="ServiceLifetime"/>{{#apiInfo}}{{#apis}}{{#-first}}, the <see cref="System.Net.Http.HttpClient"/> (timeouts) and <see cref="IHttpClientBuilder"/>{{/-first}}{{/apis}}{{/apiInfo}}.
         /// </summary>
         /// <param name="hostBuilder"><see cref="IHostBuilder"/>.</param>
         /// <param name="hostConfigurationOptions">Configures the <see cref="HostBuilderContext"/>, <see cref="IServiceCollection"/>, and <see cref="HostConfiguration"/>.</param>
         /// <param name="serviceLifetime"><see cref="ServiceLifetime"/>.</param>
-        /// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
+        {{#apiInfo}}{{#apis}}{{#-first}}/// <param name="httpClientOptions">Configures the <see cref="System.Net.Http.HttpClient"/>.</param>
         /// <param name="httpClientBuilderOptions">Configures the <see cref="IHttpClientBuilder"/>.</param>
-        public static IHostBuilder Configure{{apiName}}Defaults(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null)
+        {{/-first}}{{/apis}}{{/apiInfo}}public static IHostBuilder Configure{{apiName}}Defaults(this IHostBuilder hostBuilder, Action<HostBuilderContext, IServiceCollection, HostConfiguration> hostConfigurationOptions, ServiceLifetime serviceLifetime = ServiceLifetime.Singleton{{#apiInfo}}{{#apis}}{{#-first}}, Action<System.Net.Http.HttpClient>? httpClientOptions = null, Action<IHttpClientBuilder>? httpClientBuilderOptions = null{{/-first}}{{/apis}}{{/apiInfo}})
         {
             hostBuilder.ConfigureServices((context, services) => 
             {


### PR DESCRIPTION
## Description

The `Configure{ApiName}` IHostBuilder extension methods (e.g. `ConfigureCheckout`, `ConfigureManagement`) accepted `httpClientOptions` and `httpClientBuilderOptions` parameters that were silently ignored — no HTTP client configuration was ever applied. This was misleading and gave users a false sense that their HTTP client customisations were taking effect.

The `Configure{ApiName}Defaults` variants correctly forward these parameters to `AddAll{ApiName}Services` and are unaffected.

**Changes:**
- Removed `Action<HttpClient>? httpClientOptions` and `Action<IHttpClientBuilder>? httpClientBuilderOptions` from all `Configure{ApiName}` method signatures (28 generated files + the mustache template).

## Breaking Changes

> **BREAKING CHANGE:** The `Configure{ApiName}` extension methods (e.g. `ConfigureCheckout`, `ConfigureBalancePlatform`, `ConfigureManagement`, …) no longer accept `httpClientOptions` or `httpClientBuilderOptions` parameters.
>
> **What changed:** The two optional parameters `Action<HttpClient>? httpClientOptions` and `Action<IHttpClientBuilder>? httpClientBuilderOptions` have been removed from the `Configure{ApiName}` overload.
>
> **Why:** These parameters were never wired up — any configuration passed was silently discarded. Keeping them in the signature was deceptive and could give users confidence that HTTP client customisation was applied when it was not.
>
> **Impact:** Code that called `Configure{ApiName}(..., httpClientOptions: ..., httpClientBuilderOptions: ...)` will fail to compile. **Migrate by switching to `Configure{ApiName}Defaults`**, which correctly registers all services and applies `httpClientOptions` / `httpClientBuilderOptions` to the underlying `HttpClient`.
>
> Before:
> ```csharp
> hostBuilder.ConfigureCheckout(
>     (ctx, services, config) => { ... },
>     httpClientOptions: client => client.Timeout = TimeSpan.FromSeconds(30),
>     httpClientBuilderOptions: builder => builder.AddPolicyHandler(retryPolicy));
> ```
>
> After:
> ```csharp
> hostBuilder.ConfigureCheckoutDefaults(
>     (ctx, services, config) => { ... },
>     httpClientOptions: client => client.Timeout = TimeSpan.FromSeconds(30),
>     httpClientBuilderOptions: builder => builder.AddPolicyHandler(retryPolicy));
> ```

## Tested scenarios

- Verified the solution builds with 0 errors (`dotnet build`).

## Fixed issue

Fixes #1469