### PR TITLE
Fix bare STJ deserialization by removing [JsonConstructor] from generated models

### DIFF
--- a/templates-v7/csharp/libraries/generichost/modelGeneric.mustache
+++ b/templates-v7/csharp/libraries/generichost/modelGeneric.mustache
@@ -59,8 +59,6 @@
         /// <param name="{{#lambda.camel_case}}{{name}}{{/lambda.camel_case}}">{{description}}{{^description}}{{#lambda.camel_case}}{{name}}{{/lambda.camel_case}}{{/description}}{{#defaultValue}} (default to {{.}}){{/defaultValue}}</param>
         {{/isDiscriminator}}
         {{/allVars}}
-        {{^composedSchemas.anyOf}}
-        {{/composedSchemas.anyOf}}
         {{#model.vendorExtensions.x-model-is-mutable}}{{>visibility}}{{/model.vendorExtensions.x-model-is-mutable}}{{^model.vendorExtensions.x-model-is-mutable}}internal{{/model.vendorExtensions.x-model-is-mutable}} {{classname}}({{#lambda.joinWithComma}}{{#composedSchemas.anyOf}}{{^required}}Option<{{/required}}{{{datatypeWithEnum}}}{{>NullConditionalProperty}}{{^required}}>{{/required}} {{#lambda.escape_reserved_word}}{{#lambda.camel_case}}{{name}}{{/lambda.camel_case}}{{/lambda.escape_reserved_word}}  {{/composedSchemas.anyOf}}{{>ModelSignature}}{{/lambda.joinWithComma}}){{#parent}} : base({{#lambda.joinWithComma}}{{>ModelBaseSignature}}{{/lambda.joinWithComma}}){{/parent}}
         {
             {{#composedSchemas.anyOf}}

--- a/templates-v7/csharp/libraries/generichost/modelGeneric.mustache
+++ b/templates-v7/csharp/libraries/generichost/modelGeneric.mustache
@@ -60,7 +60,6 @@
         {{/isDiscriminator}}
         {{/allVars}}
         {{^composedSchemas.anyOf}}
-        [JsonConstructor]
         {{/composedSchemas.anyOf}}
         {{#model.vendorExtensions.x-model-is-mutable}}{{>visibility}}{{/model.vendorExtensions.x-model-is-mutable}}{{^model.vendorExtensions.x-model-is-mutable}}internal{{/model.vendorExtensions.x-model-is-mutable}} {{classname}}({{#lambda.joinWithComma}}{{#composedSchemas.anyOf}}{{^required}}Option<{{/required}}{{{datatypeWithEnum}}}{{>NullConditionalProperty}}{{^required}}>{{/required}} {{#lambda.escape_reserved_word}}{{#lambda.camel_case}}{{name}}{{/lambda.camel_case}}{{/lambda.escape_reserved_word}}  {{/composedSchemas.anyOf}}{{>ModelSignature}}{{/lambda.joinWithComma}}){{#parent}} : base({{#lambda.joinWithComma}}{{>ModelBaseSignature}}{{/lambda.joinWithComma}}){{/parent}}
         {


### PR DESCRIPTION
## Description

Fixes #1474.

The `[JsonConstructor]` attribute was emitted on the `Option<T>`-parameter constructor of every generated model. When consumers deserialize models **outside** the SDK's pipeline (e.g. unit tests, caching layers, logging, message queues) using plain `JsonSerializer.Deserialize<T>(json)`, `System.Text.Json` tries to use that constructor and fails because it cannot bind `Option<List<T>>` constructor parameters to `List<T>` JSON properties:

```
System.InvalidOperationException: Each parameter in the deserialization constructor on type
'Adyen.Checkout.Models.PaymentMethodsResponse' must bind to an object property or field on deserialization.
```

### Root cause

The SDK registers a custom `JsonConverter<T>` per model (via `HostConfiguration`) whose `Read()` method manually parses the JSON and calls the `Option<T>` constructor directly. **The SDK's own pipeline never relies on `[JsonConstructor]`** — the attribute only affects bare `System.Text.Json` deserialization.

### Fix

Remove `[JsonConstructor]` from the mustache template (`templates-v7/csharp/libraries/generichost/modelGeneric.mustache`). Without the attribute, STJ falls back to the public parameterless constructor + property setters, which works correctly.

### Backward compatibility

- The `Option<T>` constructor remains public and callable as before.
- The SDK pipeline (custom converters) is completely unaffected.
- Bare `JsonSerializer.Deserialize<T>` now works as consumers would expect.

## Tested scenarios

- Verified the template diff targets only the `[JsonConstructor]` line inside the `{{^composedSchemas.anyOf}}` block, leaving models with `anyOf` composition untouched.

## Fixed issue

#1474