### PR TITLE
Fix NotificationRequestItem deserialization with default System.Text.Json options

### DIFF
--- a/Adyen.Test/Webhooks/WebhookHandlerTest.cs
+++ b/Adyen.Test/Webhooks/WebhookHandlerTest.cs
@@ -245,6 +245,73 @@ namespace Adyen.Test.Webhooks
             Assert.IsFalse(item.Success);
         }
 
+        /// <summary>
+        /// Regression test for GitHub issue #1514.
+        /// Verifies that <see cref="Adyen.Webhooks.Models.NotificationRequestItem"/> properties are populated
+        /// when deserializing with default <see cref="JsonSerializerOptions"/> (no PropertyNameCaseInsensitive).
+        /// Without [JsonPropertyName] attributes all inner properties silently resolve to null/default.
+        /// </summary>
+        [TestMethod]
+        public void Given_WebhookPayload_When_DeserializedWithDefaultSystemTextJsonOptions_Then_NotificationItemPropertiesArePopulated()
+        {
+            var mockPath = GetMockFilePath("mocks/notification/authorisation-default-stj-options.json");
+            var json = MockFileToString(mockPath);
+
+            var result = JsonSerializer.Deserialize<Adyen.Webhooks.Models.NotificationRequest>(json);
+
+            Assert.IsNotNull(result);
+            var item = result.NotificationItemContainers[0].NotificationItem;
+            Assert.IsNotNull(item);
+            Assert.AreEqual("AUTHORISATION", item.EventCode);
+            Assert.AreEqual("2021-01-01T01:00:00+01:00", item.EventDate);
+            Assert.AreEqual("QFQTPCQ8HXSKGK82", item.PspReference);
+            Assert.AreEqual("YOUR_MERCHANT_REFERENCE", item.MerchantReference);
+            Assert.AreEqual("YOUR_MERCHANT_ACCOUNT", item.MerchantAccountCode);
+            Assert.AreEqual("ach", item.PaymentMethod);
+            Assert.AreEqual("null", item.Reason);
+            Assert.IsTrue(item.Success);
+            Assert.IsNotNull(item.Amount);
+            Assert.AreEqual(1000, item.Amount.Value);
+            Assert.AreEqual("EUR", item.Amount.Currency);
+            CollectionAssert.AreEqual(new[] { "CANCEL", "CAPTURE", "REFUND" }, item.Operations);
+            Assert.AreEqual("YOUR_SHOPPER_REFERENCE", item.AdditionalData["tokenization.shopperReference"]);
+            Assert.AreEqual("M5N7TQ4TG5PFWR50", item.AdditionalData["tokenization.storedPaymentMethodId"]);
+            Assert.AreEqual("created", item.AdditionalData["tokenization.store.operationType"]);
+        }
+
+        /// <summary>
+        /// Regression test for GitHub issue #1514.
+        /// Verifies that <see cref="Adyen.Webhooks.Models.NotificationRequestItem"/> properties are populated
+        /// when deserializing with Newtonsoft.Json, exercising the new [Newtonsoft.Json.JsonProperty] attributes.
+        /// </summary>
+        [TestMethod]
+        public void Given_WebhookPayload_When_DeserializedWithNewtonsoftDefaultOptions_Then_NotificationItemPropertiesArePopulated()
+        {
+            var mockPath = GetMockFilePath("mocks/notification/authorisation-default-stj-options.json");
+            var json = MockFileToString(mockPath);
+
+            var result = Newtonsoft.Json.JsonConvert.DeserializeObject<Adyen.Webhooks.Models.NotificationRequest>(json);
+
+            Assert.IsNotNull(result);
+            var item = result.NotificationItemContainers[0].NotificationItem;
+            Assert.IsNotNull(item);
+            Assert.AreEqual("AUTHORISATION", item.EventCode);
+            Assert.AreEqual("2021-01-01T01:00:00+01:00", item.EventDate);
+            Assert.AreEqual("QFQTPCQ8HXSKGK82", item.PspReference);
+            Assert.AreEqual("YOUR_MERCHANT_REFERENCE", item.MerchantReference);
+            Assert.AreEqual("YOUR_MERCHANT_ACCOUNT", item.MerchantAccountCode);
+            Assert.AreEqual("ach", item.PaymentMethod);
+            Assert.AreEqual("null", item.Reason);
+            Assert.IsTrue(item.Success);
+            Assert.IsNotNull(item.Amount);
+            Assert.AreEqual(1000, item.Amount.Value);
+            Assert.AreEqual("EUR", item.Amount.Currency);
+            CollectionAssert.AreEqual(new[] { "CANCEL", "CAPTURE", "REFUND" }, item.Operations);
+            Assert.AreEqual("YOUR_SHOPPER_REFERENCE", item.AdditionalData["tokenization.shopperReference"]);
+            Assert.AreEqual("M5N7TQ4TG5PFWR50", item.AdditionalData["tokenization.storedPaymentMethodId"]);
+            Assert.AreEqual("created", item.AdditionalData["tokenization.store.operationType"]);
+        }
+
         [TestMethod]
         public void TestPOSDisplayNotification()
         {

--- a/Adyen.Test/mocks/notification/authorisation-default-stj-options.json
+++ b/Adyen.Test/mocks/notification/authorisation-default-stj-options.json
@@ -1,0 +1,31 @@
+{
+  "live": "false",
+  "notificationItems": [
+    {
+      "NotificationRequestItem": {
+        "additionalData": {
+          "tokenization.shopperReference": "YOUR_SHOPPER_REFERENCE",
+          "tokenization.storedPaymentMethodId": "M5N7TQ4TG5PFWR50",
+          "tokenization.store.operationType": "created"
+        },
+        "amount": {
+          "currency": "EUR",
+          "value": 1000
+        },
+        "eventCode": "AUTHORISATION",
+        "eventDate": "2021-01-01T01:00:00+01:00",
+        "merchantAccountCode": "YOUR_MERCHANT_ACCOUNT",
+        "merchantReference": "YOUR_MERCHANT_REFERENCE",
+        "paymentMethod": "ach",
+        "operations": [
+          "CANCEL",
+          "CAPTURE",
+          "REFUND"
+        ],
+        "pspReference": "QFQTPCQ8HXSKGK82",
+        "reason": "null",
+        "success": "true"
+      }
+    }
+  ]
+}

--- a/Adyen/Webhooks/Models/Amount.cs
+++ b/Adyen/Webhooks/Models/Amount.cs
@@ -21,6 +21,8 @@ namespace Adyen.Webhooks.Models
         [Newtonsoft.Json.JsonProperty("value")]
         public long? Value { get; set; }
 
+        public Amount() { }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Amount"/> class for webhooks.
         /// </summary>

--- a/Adyen/Webhooks/Models/Amount.cs
+++ b/Adyen/Webhooks/Models/Amount.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Adyen.Webhooks.Models
 {
     /// <summary>
@@ -8,11 +10,15 @@ namespace Adyen.Webhooks.Models
         /// <summary>
         /// The three-character [ISO currency code](https://docs.adyen.com/development-resources/currency-codes#currency-codes).
         /// </summary>
+        [JsonPropertyName("currency")]
+        [Newtonsoft.Json.JsonProperty("currency")]
         public string Currency { get; set; }
 
         /// <summary>
         /// The amount of the transaction, in [minor units](https://docs.adyen.com/development-resources/currency-codes#minor-units).
         /// </summary>
+        [JsonPropertyName("value")]
+        [Newtonsoft.Json.JsonProperty("value")]
         public long? Value { get; set; }
 
         /// <summary>

--- a/Adyen/Webhooks/Models/NotificationRequestItem.cs
+++ b/Adyen/Webhooks/Models/NotificationRequestItem.cs
@@ -30,19 +30,54 @@ namespace Adyen.Webhooks.Models
 {
     public class NotificationRequestItem
     {
+        [JsonPropertyName("amount")]
+        [Newtonsoft.Json.JsonProperty("amount")]
         public Amount Amount { get; set; }
+
+        [JsonPropertyName("eventCode")]
+        [Newtonsoft.Json.JsonProperty("eventCode")]
         public string EventCode { get; set; }
+
+        [JsonPropertyName("eventDate")]
+        [Newtonsoft.Json.JsonProperty("eventDate")]
         public string EventDate { get; set; }
-        public string MerchantAccountCode  { get; set; }
+
+        [JsonPropertyName("merchantAccountCode")]
+        [Newtonsoft.Json.JsonProperty("merchantAccountCode")]
+        public string MerchantAccountCode { get; set; }
+
+        [JsonPropertyName("merchantReference")]
+        [Newtonsoft.Json.JsonProperty("merchantReference")]
         public string MerchantReference { get; set; }
+
+        [JsonPropertyName("originalReference")]
+        [Newtonsoft.Json.JsonProperty("originalReference")]
         public string OriginalReference { get; set; }
+
+        [JsonPropertyName("pspReference")]
+        [Newtonsoft.Json.JsonProperty("pspReference")]
         public string PspReference { get; set; }
+
+        [JsonPropertyName("reason")]
+        [Newtonsoft.Json.JsonProperty("reason")]
         public string Reason { get; set; }
+
+        [JsonPropertyName("success")]
+        [Newtonsoft.Json.JsonProperty("success")]
         [JsonConverter(typeof(BooleanFromStringJsonConverter))]
         [Newtonsoft.Json.JsonConverter(typeof(NewtonsoftBooleanFromStringConverter))]
         public bool Success { get; set; }
+
+        [JsonPropertyName("paymentMethod")]
+        [Newtonsoft.Json.JsonProperty("paymentMethod")]
         public string PaymentMethod { get; set; }
+
+        [JsonPropertyName("operations")]
+        [Newtonsoft.Json.JsonProperty("operations")]
         public List<string> Operations { get; set; }
+
+        [JsonPropertyName("additionalData")]
+        [Newtonsoft.Json.JsonProperty("additionalData")]
         public Dictionary<string, string> AdditionalData { get; set; }
     }
 


### PR DESCRIPTION
## Description

Extends the dual `[JsonPropertyName]` + `[Newtonsoft.Json.JsonProperty]` annotation pattern (introduced in PR #1479 for the outer classic webhook wrappers) to all properties of `NotificationRequestItem` and `Amount` (in `Adyen.Webhooks.Models`).

Without these attributes, `System.Text.Json` cannot match camelCase JSON keys to PascalCase C# properties when `PropertyNameCaseInsensitive` is not set, causing every inner `NotificationRequestItem` field to silently resolve to `null`/default.

## Tested scenarios

- Added regression test `Given_WebhookPayload_When_DeserializedWithDefaultSystemTextJsonOptions_Then_NotificationItemPropertiesArePopulated` that calls `JsonSerializer.Deserialize<NotificationRequest>` with default options (no `PropertyNameCaseInsensitive`) and asserts all inner properties are populated.
- All 14 existing webhook handler tests continue to pass.

## Fixed issue

Fixes #1514