### PR TITLE
Fix incorrect XML docs in generated enum classes

### DIFF
--- a/templates-v7/csharp/libraries/generichost/modelInnerEnum.mustache
+++ b/templates-v7/csharp/libraries/generichost/modelInnerEnum.mustache
@@ -45,7 +45,7 @@
             /// Converts a <see cref="{{datatypeWithEnum}}"/> instance to a string implicitly.
             /// </summary>
             /// <param name="option">The <see cref="{{datatypeWithEnum}}"/> instance. Default to null.</param>
-            /// <returns>String value of the <see cref="{{datatypeWithEnum}}"/> instance./// </returns>
+            /// <returns>String value of the <see cref="{{datatypeWithEnum}}"/> instance.</returns>
             public static implicit operator string?({{datatypeWithEnum}}? option) => option?.Value;
         
             /// <summary>
@@ -92,9 +92,6 @@
             /// </summary>
             /// <param name="value"><see cref="{{datatypeWithEnum}}"/></param>
             /// <returns>String value of the enum.</returns>
-            {{#isString}}
-            /// <exception cref="NotImplementedException"></exception>
-            {{/isString}}
             public static {{>EnumValueDataType}}?{{#lambda.first}}{{#nrt}}{{/nrt}}{{/lambda.first}} ToJsonValue({{datatypeWithEnum}}? value)
             {
                 if (value == null)


### PR DESCRIPTION
## Description
Fixes two recurring issues in generated enum class XML documentation:

1. **Typo in `<returns>` tag**: The implicit `string` operator had `instance./// </returns>` instead of `instance.</returns>` — a stray `/// ` before the closing tag.
2. **False `<exception cref="NotImplementedException">`**: The `ToJsonValue` method was documented with a `NotImplementedException` tag, but the method is fully implemented and never throws.

## Tested scenarios
- Fixed the Mustache template (`modelInnerEnum.mustache`) so future code generation produces correct docs
- Applied the same fixes to all 500+ already-generated `.cs` files
- `dotnet build` passes with 0 errors

## Fixed issue
Fixes #1516