### PR TITLE
Remove unused System.Net.Http import from webhook HostConfiguration classes

### DIFF
--- a/templates-v7/csharp/libraries/generichost/HostConfiguration.mustache
+++ b/templates-v7/csharp/libraries/generichost/HostConfiguration.mustache
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
 using {{packageName}}.{{apiPackage}};
 using {{packageName}}.{{apiName}}.{{clientPackage}};


### PR DESCRIPTION
## Description
Remove `using System.Net.Http;` from `HostConfiguration.mustache` entirely. The namespace is unused in all generated `HostConfiguration.cs` files — the only mention of `HttpClient` in the template is in a plain-text XML doc comment, which does not require a `using` directive.

## Tested scenarios
- Template no longer emits `using System.Net.Http;` in any generated `HostConfiguration.cs` file

## Fixed issue
Fixes #1264