### PR TITLE
Fix incomplete query parameter encoding in BuildQueryString

### DIFF
--- a/Adyen.Test/AcsWebhooks/ClientUtilsBuildQueryStringTest.cs
+++ b/Adyen.Test/AcsWebhooks/ClientUtilsBuildQueryStringTest.cs
@@ -126,5 +126,12 @@ namespace Adyen.Test.AcsWebhooks
         {
             Assert.AreEqual("foo=", Invoke(Nvc(("foo", ""))));
         }
+
+        [TestMethod]
+        public void SurrogatePair_IsPercentEncoded()
+        {
+            // "😊" (U+1F60A) is stored as a surrogate pair in UTF-16; must encode to %F0%9F%98%8A
+            Assert.AreEqual("foo=%F0%9F%98%8A", Invoke(Nvc(("foo", "😊"))));
+        }
     }
 }

--- a/Adyen.Test/AcsWebhooks/ClientUtilsBuildQueryStringTest.cs
+++ b/Adyen.Test/AcsWebhooks/ClientUtilsBuildQueryStringTest.cs
@@ -24,7 +24,8 @@ namespace Adyen.Test.AcsWebhooks
         {
             var method = typeof(Adyen.AcsWebhooks.Client.ClientUtils)
                 .GetMethod("BuildQueryString", BindingFlags.NonPublic | BindingFlags.Static);
-            return (string)method!.Invoke(null, new object[] { parameters });
+            Assert.IsNotNull(method, "BuildQueryString method not found — it may have been renamed or removed.");
+            return (string)method.Invoke(null, new object[] { parameters });
         }
 
         private static NameValueCollection Nvc(params (string key, string value)[] pairs)
@@ -112,6 +113,18 @@ namespace Adyen.Test.AcsWebhooks
         {
             // key contains "&" — must be fully escaped via Uri.EscapeDataString
             Assert.AreEqual("a%26b=1", Invoke(Nvc(("a&b", "1"))));
+        }
+
+        [TestMethod]
+        public void EmptyCollection_ReturnsEmptyString()
+        {
+            Assert.AreEqual("", Invoke(new NameValueCollection()));
+        }
+
+        [TestMethod]
+        public void EmptyValue_RendersKeyWithNoValue()
+        {
+            Assert.AreEqual("foo=", Invoke(Nvc(("foo", ""))));
         }
     }
 }

--- a/Adyen.Test/AcsWebhooks/ClientUtilsBuildQueryStringTest.cs
+++ b/Adyen.Test/AcsWebhooks/ClientUtilsBuildQueryStringTest.cs
@@ -1,0 +1,117 @@
+using System.Collections.Specialized;
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Adyen.Test.AcsWebhooks
+{
+    /// <summary>
+    /// Tests for the <c>BuildQueryString</c> method in <see cref="Adyen.AcsWebhooks.Client.ClientUtils"/>.
+    ///
+    /// The method uses minimal percent-encoding: only characters that would break query string
+    /// structure are escaped (&amp;, =, #, space, %). Sub-delimiters (+, /, !) and ASCII
+    /// printable characters are intentionally left unencoded. Non-ASCII characters are encoded
+    /// via <see cref="Uri.EscapeDataString"/>.
+    ///
+    /// Reflection is used because <c>BuildQueryString</c> is <c>internal</c> and the main assembly
+    /// is strong-named, which prevents <c>InternalsVisibleTo</c> from granting access to an
+    /// unsigned test assembly without embedding the test assembly's public key.
+    ///
+    /// </summary>
+    [TestClass]
+    public class ClientUtilsBuildQueryStringTest
+    {
+        private static string Invoke(NameValueCollection parameters)
+        {
+            var method = typeof(Adyen.AcsWebhooks.Client.ClientUtils)
+                .GetMethod("BuildQueryString", BindingFlags.NonPublic | BindingFlags.Static);
+            return (string)method!.Invoke(null, new object[] { parameters });
+        }
+
+        private static NameValueCollection Nvc(params (string key, string value)[] pairs)
+        {
+            var nvc = new NameValueCollection();
+            foreach (var (k, v) in pairs)
+                nvc.Add(k, v);
+            return nvc;
+        }
+
+        [TestMethod]
+        public void Baseline_NoSpecialChars_ReturnsUnchanged()
+        {
+            Assert.AreEqual("foo=bar", Invoke(Nvc(("foo", "bar"))));
+        }
+
+        [TestMethod]
+        public void Ampersand_InValue_IsEncoded()
+        {
+            Assert.AreEqual("foo=a%26b", Invoke(Nvc(("foo", "a&b"))));
+        }
+
+        [TestMethod]
+        public void Equals_InValue_IsEncoded()
+        {
+            Assert.AreEqual("foo=a%3Db", Invoke(Nvc(("foo", "a=b"))));
+        }
+
+        [TestMethod]
+        public void Hash_InValue_IsEncoded()
+        {
+            Assert.AreEqual("foo=a%23b", Invoke(Nvc(("foo", "a#b"))));
+        }
+
+        [TestMethod]
+        public void Space_InValue_IsEncoded()
+        {
+            Assert.AreEqual("foo=a%20b", Invoke(Nvc(("foo", "a b"))));
+        }
+
+        [TestMethod]
+        public void Percent_InValue_IsEncoded_PreventingDoubleEncoding()
+        {
+            // regression: "50%off" must not produce "50%off" (leaving % raw)
+            Assert.AreEqual("foo=50%25off", Invoke(Nvc(("foo", "50%off"))));
+        }
+
+        [TestMethod]
+        public void AlreadyEncodedPercent20_IsNotDoubleEncoded()
+        {
+            // "%20" in input → "%" becomes "%25", so output is "%2520"
+            Assert.AreEqual("foo=%2520", Invoke(Nvc(("foo", "%20"))));
+        }
+
+        [TestMethod]
+        public void Unicode_IsPercentEncoded()
+        {
+            // "café" → "caf%C3%A9"
+            Assert.AreEqual("foo=caf%C3%A9", Invoke(Nvc(("foo", "café"))));
+        }
+
+        [TestMethod]
+        public void SubDelimiters_ArePreserved()
+        {
+            // +, /, ! must NOT be encoded (minimal encoding contract)
+            Assert.AreEqual("foo=a+b/c!", Invoke(Nvc(("foo", "a+b/c!"))));
+        }
+
+        [TestMethod]
+        public void MultipleParams_AreJoinedWithAmpersand()
+        {
+            Assert.AreEqual("a=1&b=2", Invoke(Nvc(("a", "1"), ("b", "2"))));
+        }
+
+        [TestMethod]
+        public void NullValue_RendersAsEmpty()
+        {
+            var nvc = new NameValueCollection();
+            nvc.Add("foo", null);
+            Assert.AreEqual("foo=", Invoke(nvc));
+        }
+
+        [TestMethod]
+        public void ReservedCharsInKey_AreFullyEncoded()
+        {
+            // key contains "&" — must be fully escaped via Uri.EscapeDataString
+            Assert.AreEqual("a%26b=1", Invoke(Nvc(("a&b", "1"))));
+        }
+    }
+}

--- a/Adyen/AcsWebhooks/Client/ClientUtils.cs
+++ b/Adyen/AcsWebhooks/Client/ClientUtils.cs
@@ -178,8 +178,9 @@ namespace Adyen.AcsWebhooks.Client
                 // only encode characters that would break query string structure,
                 // while preserving sub-delimiters (+, /, !) and non-ASCII via Uri.EscapeDataString
                 var sb = new System.Text.StringBuilder(value.Length);
-                foreach (char c in value)
+                for (int i = 0; i < value.Length; i++)
                 {
+                    char c = value[i];
                     switch (c)
                     {
                         case '&': sb.Append("%26"); break;
@@ -189,9 +190,16 @@ namespace Adyen.AcsWebhooks.Client
                         case '%': sb.Append("%25"); break;
                         default:
                             if (c > 127)
-                                sb.Append(Uri.EscapeDataString(c.ToString()));
+                            {
+                                if (char.IsHighSurrogate(c) && i + 1 < value.Length && char.IsLowSurrogate(value[i + 1]))
+                                    sb.Append(Uri.EscapeDataString(value.Substring(i++, 2)));
+                                else
+                                    sb.Append(Uri.EscapeDataString(c.ToString()));
+                            }
                             else
+                            {
                                 sb.Append(c);
+                            }
                             break;
                     }
                 }

--- a/Adyen/AcsWebhooks/Client/ClientUtils.cs
+++ b/Adyen/AcsWebhooks/Client/ClientUtils.cs
@@ -175,12 +175,27 @@ namespace Adyen.AcsWebhooks.Client
                 var value = parameters[key] ?? string.Empty;
                 // keys are always encoded (must be ASCII identifiers)
                 var encodedKey = Uri.EscapeDataString(key);
-                // only encode selected characters           
-                var encodedValue = value
-                    .Replace("&", "%26")
-                    .Replace("=", "%3D")
-                    .Replace("#", "%23")
-                    .Replace(" ", "%20");
+                // only encode characters that would break query string structure,
+                // while preserving sub-delimiters (+, /, !) and non-ASCII via Uri.EscapeDataString
+                var sb = new System.Text.StringBuilder(value.Length);
+                foreach (char c in value)
+                {
+                    switch (c)
+                    {
+                        case '&': sb.Append("%26"); break;
+                        case '=': sb.Append("%3D"); break;
+                        case '#': sb.Append("%23"); break;
+                        case ' ': sb.Append("%20"); break;
+                        case '%': sb.Append("%25"); break;
+                        default:
+                            if (c > 127)
+                                sb.Append(Uri.EscapeDataString(c.ToString()));
+                            else
+                                sb.Append(c);
+                            break;
+                    }
+                }
+                var encodedValue = sb.ToString();
                 parts.Add(encodedKey + "=" + encodedValue);
             }
             return string.Join("&", parts);

--- a/templates-v7/csharp/libraries/generichost/ClientUtils.mustache
+++ b/templates-v7/csharp/libraries/generichost/ClientUtils.mustache
@@ -197,12 +197,27 @@ namespace {{packageName}}.{{apiName}}.{{clientPackage}}
                 var value = parameters[key] ?? string.Empty;
                 // keys are always encoded (must be ASCII identifiers)
                 var encodedKey = Uri.EscapeDataString(key);
-                // only encode selected characters           
-                var encodedValue = value
-                    .Replace("&", "%26")
-                    .Replace("=", "%3D")
-                    .Replace("#", "%23")
-                    .Replace(" ", "%20");
+                // only encode characters that would break query string structure,
+                // while preserving sub-delimiters (+, /, !) and non-ASCII via Uri.EscapeDataString
+                var sb = new System.Text.StringBuilder(value.Length);
+                foreach (char c in value)
+                {
+                    switch (c)
+                    {
+                        case '&': sb.Append("%26"); break;
+                        case '=': sb.Append("%3D"); break;
+                        case '#': sb.Append("%23"); break;
+                        case ' ': sb.Append("%20"); break;
+                        case '%': sb.Append("%25"); break;
+                        default:
+                            if (c > 127)
+                                sb.Append(Uri.EscapeDataString(c.ToString()));
+                            else
+                                sb.Append(c);
+                            break;
+                    }
+                }
+                var encodedValue = sb.ToString();
                 parts.Add(encodedKey + "=" + encodedValue);
             }
             return string.Join("&", parts);

--- a/templates-v7/csharp/libraries/generichost/ClientUtils.mustache
+++ b/templates-v7/csharp/libraries/generichost/ClientUtils.mustache
@@ -200,8 +200,9 @@ namespace {{packageName}}.{{apiName}}.{{clientPackage}}
                 // only encode characters that would break query string structure,
                 // while preserving sub-delimiters (+, /, !) and non-ASCII via Uri.EscapeDataString
                 var sb = new System.Text.StringBuilder(value.Length);
-                foreach (char c in value)
+                for (int i = 0; i < value.Length; i++)
                 {
+                    char c = value[i];
                     switch (c)
                     {
                         case '&': sb.Append("%26"); break;
@@ -211,9 +212,16 @@ namespace {{packageName}}.{{apiName}}.{{clientPackage}}
                         case '%': sb.Append("%25"); break;
                         default:
                             if (c > 127)
-                                sb.Append(Uri.EscapeDataString(c.ToString()));
+                            {
+                                if (char.IsHighSurrogate(c) && i + 1 < value.Length && char.IsLowSurrogate(value[i + 1]))
+                                    sb.Append(Uri.EscapeDataString(value.Substring(i++, 2)));
+                                else
+                                    sb.Append(Uri.EscapeDataString(c.ToString()));
+                            }
                             else
+                            {
                                 sb.Append(c);
+                            }
                             break;
                     }
                 }


### PR DESCRIPTION
## Description
Fixes the `BuildQueryString` method which had incomplete percent-encoding logic, as reported in #1471.

**Issues with the old implementation:**
- `%` was never encoded, allowing values like `50%off` to produce malformed URLs and already-encoded sequences like `%20` to pass through ambiguously
- Non-ASCII / Unicode characters were emitted raw, violating RFC 3986
- Chained `string.Replace` calls allocated multiple intermediate strings

**New implementation** uses a single-pass `StringBuilder` that:
- Escapes the five structurally significant characters: `&`, `=`, `#`, `space`, `%`
- Delegates non-ASCII characters to `Uri.EscapeDataString` (proper UTF-8 → `%xx` encoding)
- Preserves sub-delimiters (`+`, `/`, `!`) intentionally unencoded per the existing contract

## Scope
- `templates-v7/csharp/libraries/generichost/ClientUtils.mustache` — template updated (source of truth for regeneration)
- `Adyen/AcsWebhooks/Client/ClientUtils.cs` — one generated file updated immediately so tests can run today
- `Adyen.Test/AcsWebhooks/ClientUtilsBuildQueryStringTest.cs` — 14 new tests (reflection-based, since the assembly is strong-named)

> **Note on generated files:** Only `AcsWebhooks/Client/ClientUtils.cs` is patched in this PR. The remaining 25 generated `ClientUtils` files all share the same Mustache template and will be fixed on the next automated SDK regeneration. 

## Tested scenarios
- Baseline (no special chars), `&`, `=`, `#`, space, `%` (regression), already-encoded `%20` (no double-encoding), Unicode (`café`), sub-delimiters preserved, multi-param join, null value, empty value, empty collection, reserved chars in key

## Fixed issue
Fixes #1471