### PR TITLE
Add XML remarks to readOnly properties

### DIFF
--- a/Adyen/LegalEntityManagement/Models/BankAccountInfo.cs
+++ b/Adyen/LegalEntityManagement/Models/BankAccountInfo.cs
@@ -112,6 +112,7 @@ namespace Adyen.LegalEntityManagement.Models
         /// Identifies if the bank account was created through [instant bank verification](https://docs.adyen.com/release-notes/platforms-and-financial-products#releaseNote&#x3D;2023-05-08-hosted-onboarding).
         /// </summary>
         /// <value>Identifies if the bank account was created through [instant bank verification](https://docs.adyen.com/release-notes/platforms-and-financial-products#releaseNote=2023-05-08-hosted-onboarding).</value>
+        /// <remarks>This property is read-only, set by the Adyen API. The value is ignored in requests.</remarks>
         [JsonPropertyName("trustedSource")]
         public bool? TrustedSource { get { return this._TrustedSourceOption; } set { this._TrustedSourceOption = new(value); } }
 

--- a/templates-v7/csharp/libraries/generichost/modelGeneric.mustache
+++ b/templates-v7/csharp/libraries/generichost/modelGeneric.mustache
@@ -111,6 +111,9 @@
         {{#description}}
         /// <value>{{.}}</value>
         {{/description}}
+        {{#isReadOnly}}
+        /// <remarks>This property is read-only, set by the Adyen API. The value is ignored in requests.</remarks>
+        {{/isReadOnly}}
         {{#example}}
         /* <example>{{.}}</example> */
         {{/example}}
@@ -139,6 +142,9 @@
         /// {{{description}}}{{^description}}<see cref="{{name}}"/>.{{/description}}
         /// </summary>{{#description}}
         /// <value>{{.}}</value>{{/description}}
+        {{#isReadOnly}}
+        /// <remarks>This property is read-only, set by the Adyen API. The value is ignored in requests.</remarks>
+        {{/isReadOnly}}
         {{#example}}
         /* <example>{{.}}</example> */
         {{/example}}
@@ -156,6 +162,9 @@
         /// {{{description}}}{{^description}}<see cref="{{name}}"/>.{{/description}}.
         /// </summary>{{#description}}
         /// <value>{{.}}</value>{{/description}}
+        {{#isReadOnly}}
+        /// <remarks>This property is read-only, set by the Adyen API. The value is ignored in requests.</remarks>
+        {{/isReadOnly}}
         {{#example}}
         /* <example>{{.}}</example> */
         {{/example}}
@@ -198,6 +207,9 @@
         /// {{{description}}}{{^description}}<see cref="{{name}}"/>.{{/description}}
         /// </summary>{{#description}}
         /// <value>{{.}}</value>{{/description}}
+        {{#isReadOnly}}
+        /// <remarks>This property is read-only, set by the Adyen API. The value is ignored in requests.</remarks>
+        {{/isReadOnly}}
         {{#example}}
         /* <example>{{.}}</example> */
         {{/example}}
@@ -224,6 +236,9 @@
         /// {{description}}{{^description}}<see cref="{{name}}"/>.{{/description}}
         /// </summary>{{#description}}
         /// <value>{{{description}}}</value>{{/description}}
+        {{#isReadOnly}}
+        /// <remarks>This property is read-only, set by the Adyen API. The value is ignored in requests.</remarks>
+        {{/isReadOnly}}
         {{#example}}
         /* <example>{{.}}</example> */
         {{/example}}


### PR DESCRIPTION
## Description

Adds `<remarks>` XML documentation to properties generated from OpenAPI `readOnly` fields, indicating they are set by the Adyen API and ignored in requests.

The `BankAccountInfo.cs` model is included as an example of the generated output. All other models will be updated automatically by SDK Automation when they are next regenerated.

## Fixed issue

Closes #1555
