### PR TITLE
Extend BalancePlatform unit-test coverage to remaining services

### DIFF
--- a/Adyen.Test/BalancePlatform/AuthorizedCardUsers/AuthorizedCardUsersServiceTest.cs
+++ b/Adyen.Test/BalancePlatform/AuthorizedCardUsers/AuthorizedCardUsersServiceTest.cs
@@ -1,0 +1,146 @@
+using System.Net;
+using System.Text;
+using Adyen.BalancePlatform.Extensions;
+using Adyen.BalancePlatform.Models;
+using Adyen.BalancePlatform.Services;
+using Adyen.Core.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Adyen.Test.BalancePlatform.AuthorizedCardUsers
+{
+    [TestClass]
+    public class AuthorizedCardUsersServiceTest
+    {
+        public AuthorizedCardUsersServiceTest() { }
+
+        [TestMethod]
+        public async Task GetAllAuthorisedCardUsersAsync_Returns200Ok_WithCorrectVerbAndPath()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/AuthorisedCardUsers-get-success.json");
+
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddAuthorizedCardUsersService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var authorizedCardUsersService = testHost.Services.GetRequiredService<IAuthorizedCardUsersService>();
+
+            // Act
+            IGetAllAuthorisedCardUsersApiResponse response =
+                await authorizedCardUsersService.GetAllAuthorisedCardUsersAsync("PI3227C223222B5BPCMFXD2XG");
+
+            // Assert - response
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.IsOk);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            AuthorisedCardUsers? result = response.Ok();
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.LegalEntityIds);
+            Assert.AreEqual(1, result.LegalEntityIds.Count);
+            Assert.AreEqual("LE1234567890", result.LegalEntityIds[0]);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Get, capturedRequest.Method);
+            Assert.AreEqual("/bcl/v2/paymentInstruments/PI3227C223222B5BPCMFXD2XG/authorisedCardUsers", capturedRequest.RequestUri?.AbsolutePath);
+        }
+
+        [TestMethod]
+        public async Task CreateAuthorisedCardUsersAsync_Returns204NoContent_WithCorrectVerbAndPath()
+        {
+            // Arrange
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.NoContent);
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddAuthorizedCardUsersService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var authorizedCardUsersService = testHost.Services.GetRequiredService<IAuthorizedCardUsersService>();
+            var users = new AuthorisedCardUsers { LegalEntityIds = new List<string> { "LE1234567890" } };
+
+            // Act
+            ICreateAuthorisedCardUsersApiResponse response =
+                await authorizedCardUsersService.CreateAuthorisedCardUsersAsync("PI3227C223222B5BPCMFXD2XG", users);
+
+            // Assert - response
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.IsNoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Post, capturedRequest.Method);
+            Assert.AreEqual("/bcl/v2/paymentInstruments/PI3227C223222B5BPCMFXD2XG/authorisedCardUsers", capturedRequest.RequestUri?.AbsolutePath);
+        }
+
+        [TestMethod]
+        public async Task DeleteAuthorisedCardUsersAsync_Returns204NoContent_WithCorrectVerbAndPath()
+        {
+            // Arrange
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.NoContent);
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddAuthorizedCardUsersService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var authorizedCardUsersService = testHost.Services.GetRequiredService<IAuthorizedCardUsersService>();
+
+            // Act
+            IDeleteAuthorisedCardUsersApiResponse response =
+                await authorizedCardUsersService.DeleteAuthorisedCardUsersAsync("PI3227C223222B5BPCMFXD2XG");
+
+            // Assert - response
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.IsNoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Delete, capturedRequest.Method);
+            Assert.AreEqual("/bcl/v2/paymentInstruments/PI3227C223222B5BPCMFXD2XG/authorisedCardUsers", capturedRequest.RequestUri?.AbsolutePath);
+        }
+    }
+}

--- a/Adyen.Test/BalancePlatform/AuthorizedCardUsers/AuthorizedCardUsersTest.cs
+++ b/Adyen.Test/BalancePlatform/AuthorizedCardUsers/AuthorizedCardUsersTest.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+using Adyen.BalancePlatform.Client;
+using Adyen.BalancePlatform.Extensions;
+using Adyen.BalancePlatform.Models;
+using Adyen.Core.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Adyen.Test.BalancePlatform.AuthorizedCardUsers
+{
+    [TestClass]
+    public class AuthorizedCardUsersTest
+    {
+        private readonly JsonSerializerOptionsProvider _jsonSerializerOptionsProvider;
+
+        public AuthorizedCardUsersTest()
+        {
+            IHost host = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options =>
+                    {
+                        options.Environment = AdyenEnvironment.Test;
+                    });
+                })
+                .Build();
+
+            _jsonSerializerOptionsProvider = host.Services.GetRequiredService<JsonSerializerOptionsProvider>();
+        }
+
+        [TestMethod]
+        public void Given_AuthorisedCardUsers_Get_When_Deserialized_Then_Result_Is_Not_Null()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/AuthorisedCardUsers-get-success.json");
+
+            // Act
+            AuthorisedCardUsers result = JsonSerializer.Deserialize<AuthorisedCardUsers>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.LegalEntityIds);
+            Assert.AreEqual(1, result.LegalEntityIds.Count);
+            Assert.AreEqual("LE1234567890", result.LegalEntityIds[0]);
+        }
+
+        [TestMethod]
+        public void Given_AuthorisedCardUsers_Create_When_Deserialized_Then_Result_Is_Not_Null()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/AuthorisedCardUsers-create-success.json");
+
+            // Act
+            AuthorisedCardUsers result = JsonSerializer.Deserialize<AuthorisedCardUsers>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.LegalEntityIds);
+            Assert.AreEqual(1, result.LegalEntityIds.Count);
+            Assert.AreEqual("LE1234567890", result.LegalEntityIds[0]);
+        }
+    }
+}

--- a/Adyen.Test/BalancePlatform/Balances/BalancesServiceTest.cs
+++ b/Adyen.Test/BalancePlatform/Balances/BalancesServiceTest.cs
@@ -1,0 +1,190 @@
+using System.Net;
+using System.Text;
+using Adyen.BalancePlatform.Extensions;
+using Adyen.BalancePlatform.Models;
+using Adyen.BalancePlatform.Services;
+using Adyen.Core.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Adyen.Test.BalancePlatform.Balances
+{
+    [TestClass]
+    public class BalancesServiceTest
+    {
+        public BalancesServiceTest() { }
+
+        [TestMethod]
+        public async Task GetAllWebhookSettingsAsync_Returns200Ok_WithCorrectVerbAndPath()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/WebhookSettings.json");
+
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddBalancesService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var balancesService = testHost.Services.GetRequiredService<IBalancesService>();
+
+            // Act
+            IGetAllWebhookSettingsApiResponse response = await balancesService.GetAllWebhookSettingsAsync(
+                "YOUR_BALANCE_PLATFORM", "UNIQUE_WEBHOOK_ID");
+
+            // Assert - response
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.IsOk);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Get, capturedRequest.Method);
+            Assert.AreEqual("/bcl/v2/balancePlatforms/YOUR_BALANCE_PLATFORM/webhooks/UNIQUE_WEBHOOK_ID/settings", capturedRequest.RequestUri?.AbsolutePath);
+        }
+
+        [TestMethod]
+        public async Task GetWebhookSettingAsync_Returns200Ok_WithCorrectVerbAndPath()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/WebhookSetting.json");
+
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddBalancesService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var balancesService = testHost.Services.GetRequiredService<IBalancesService>();
+
+            // Act
+            IGetWebhookSettingApiResponse response = await balancesService.GetWebhookSettingAsync(
+                "YOUR_BALANCE_PLATFORM", "UNIQUE_WEBHOOK_ID", "UNIQUE_WEBHOOK_SETTING_ID");
+
+            // Assert - response
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.IsOk);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Get, capturedRequest.Method);
+            Assert.AreEqual("/bcl/v2/balancePlatforms/YOUR_BALANCE_PLATFORM/webhooks/UNIQUE_WEBHOOK_ID/settings/UNIQUE_WEBHOOK_SETTING_ID", capturedRequest.RequestUri?.AbsolutePath);
+        }
+
+        [TestMethod]
+        public async Task CreateWebhookSettingAsync_Returns200Ok_WithCorrectVerbAndPath()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/WebhookSetting.json");
+
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddBalancesService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var balancesService = testHost.Services.GetRequiredService<IBalancesService>();
+            var settingInfo = new BalanceWebhookSettingInfo { Currency = "EUR" };
+
+            // Act
+            ICreateWebhookSettingApiResponse response = await balancesService.CreateWebhookSettingAsync(
+                "YOUR_BALANCE_PLATFORM", "UNIQUE_WEBHOOK_ID", settingInfo);
+
+            // Assert - response
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.IsOk);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Post, capturedRequest.Method);
+            Assert.AreEqual("/bcl/v2/balancePlatforms/YOUR_BALANCE_PLATFORM/webhooks/UNIQUE_WEBHOOK_ID/settings", capturedRequest.RequestUri?.AbsolutePath);
+        }
+
+        [TestMethod]
+        public async Task DeleteWebhookSettingAsync_Returns204NoContent_WithCorrectVerbAndPath()
+        {
+            // Arrange
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.NoContent);
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddBalancesService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var balancesService = testHost.Services.GetRequiredService<IBalancesService>();
+
+            // Act
+            IDeleteWebhookSettingApiResponse response = await balancesService.DeleteWebhookSettingAsync(
+                "YOUR_BALANCE_PLATFORM", "UNIQUE_WEBHOOK_ID", "UNIQUE_WEBHOOK_SETTING_ID");
+
+            // Assert - response
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.IsNoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Delete, capturedRequest.Method);
+            Assert.AreEqual("/bcl/v2/balancePlatforms/YOUR_BALANCE_PLATFORM/webhooks/UNIQUE_WEBHOOK_ID/settings/UNIQUE_WEBHOOK_SETTING_ID", capturedRequest.RequestUri?.AbsolutePath);
+        }
+    }
+}

--- a/Adyen.Test/BalancePlatform/Balances/BalancesTest.cs
+++ b/Adyen.Test/BalancePlatform/Balances/BalancesTest.cs
@@ -1,0 +1,47 @@
+using System.Text.Json;
+using Adyen.BalancePlatform.Client;
+using Adyen.BalancePlatform.Extensions;
+using Adyen.BalancePlatform.Models;
+using Adyen.Core.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Adyen.Test.BalancePlatform.Balances
+{
+    [TestClass]
+    public class BalancesTest
+    {
+        private readonly JsonSerializerOptionsProvider _jsonSerializerOptionsProvider;
+
+        public BalancesTest()
+        {
+            IHost host = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options =>
+                    {
+                        options.Environment = AdyenEnvironment.Test;
+                    });
+                })
+                .Build();
+
+            _jsonSerializerOptionsProvider = host.Services.GetRequiredService<JsonSerializerOptionsProvider>();
+        }
+
+        [TestMethod]
+        public void Given_BalanceWebhookSettingInfoUpdate_When_Serialized_Then_PaymentInstrumentId_Is_Present()
+        {
+            // Arrange
+            var update = new BalanceWebhookSettingInfoUpdate { Status = BalanceWebhookSettingInfoUpdate.StatusEnum.Active };
+
+            // Act
+            string result = JsonSerializer.Serialize(update, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            using JsonDocument json = JsonDocument.Parse(result);
+            Assert.IsTrue(json.RootElement.TryGetProperty("status", out _),
+                "status must be present in the serialized output when set");
+        }
+    }
+}

--- a/Adyen.Test/BalancePlatform/GrantAccounts/GrantAccountsServiceTest.cs
+++ b/Adyen.Test/BalancePlatform/GrantAccounts/GrantAccountsServiceTest.cs
@@ -1,0 +1,65 @@
+using System.Net;
+using System.Text;
+using Adyen.BalancePlatform.Extensions;
+using Adyen.BalancePlatform.Models;
+using Adyen.BalancePlatform.Services;
+using Adyen.Core.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Adyen.Test.BalancePlatform.GrantAccounts
+{
+    [TestClass]
+    public class GrantAccountsServiceTest
+    {
+        public GrantAccountsServiceTest() { }
+
+        [TestMethod]
+        public async Task GetGrantAccountAsync_Returns200Ok_WithCorrectVerbAndPath()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/GrantAccount.json");
+
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddGrantAccountsService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var grantAccountsService = testHost.Services.GetRequiredService<IGrantAccountsService>();
+
+            // Act
+            IGetGrantAccountApiResponse response = await grantAccountsService.GetGrantAccountAsync("UNIQUE_GRANT_ACCOUNT_ID");
+
+            // Assert - response
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.IsOk);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            CapitalGrantAccount? result = response.Ok();
+            Assert.IsNotNull(result);
+            Assert.AreEqual("UNIQUE_GRANT_ACCOUNT_ID", result.Id);
+            Assert.AreEqual("BA3227C223222B5CMD3FJFKGZ", result.FundingBalanceAccountId);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Get, capturedRequest.Method);
+            Assert.AreEqual("/bcl/v2/grantAccounts/UNIQUE_GRANT_ACCOUNT_ID", capturedRequest.RequestUri?.AbsolutePath);
+        }
+    }
+}

--- a/Adyen.Test/BalancePlatform/GrantAccounts/GrantAccountsTest.cs
+++ b/Adyen.Test/BalancePlatform/GrantAccounts/GrantAccountsTest.cs
@@ -1,0 +1,47 @@
+using System.Text.Json;
+using Adyen.BalancePlatform.Client;
+using Adyen.BalancePlatform.Extensions;
+using Adyen.BalancePlatform.Models;
+using Adyen.Core.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Adyen.Test.BalancePlatform.GrantAccounts
+{
+    [TestClass]
+    public class GrantAccountsTest
+    {
+        private readonly JsonSerializerOptionsProvider _jsonSerializerOptionsProvider;
+
+        public GrantAccountsTest()
+        {
+            IHost host = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options =>
+                    {
+                        options.Environment = AdyenEnvironment.Test;
+                    });
+                })
+                .Build();
+
+            _jsonSerializerOptionsProvider = host.Services.GetRequiredService<JsonSerializerOptionsProvider>();
+        }
+
+        [TestMethod]
+        public void Given_GrantAccount_When_Deserialized_Then_Result_Is_Not_Null()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/GrantAccount.json");
+
+            // Act
+            CapitalGrantAccount result = JsonSerializer.Deserialize<CapitalGrantAccount>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual("UNIQUE_GRANT_ACCOUNT_ID", result.Id);
+            Assert.AreEqual("BA3227C223222B5CMD3FJFKGZ", result.FundingBalanceAccountId);
+        }
+    }
+}

--- a/Adyen.Test/BalancePlatform/GrantOffers/GrantOffersServiceTest.cs
+++ b/Adyen.Test/BalancePlatform/GrantOffers/GrantOffersServiceTest.cs
@@ -1,0 +1,117 @@
+using System.Net;
+using System.Text;
+using Adyen.BalancePlatform.Extensions;
+using Adyen.BalancePlatform.Models;
+using Adyen.BalancePlatform.Services;
+using Adyen.Core.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Adyen.Test.BalancePlatform.GrantOffers
+{
+    [TestClass]
+    public class GrantOffersServiceTest
+    {
+        public GrantOffersServiceTest() { }
+
+        [TestMethod]
+        public async Task GetAllAvailableGrantOffersAsync_Returns200Ok_WithCorrectVerbAndPath()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/GrantOffers.json");
+
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddGrantOffersService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var grantOffersService = testHost.Services.GetRequiredService<IGrantOffersService>();
+
+            // Act
+            IGetAllAvailableGrantOffersApiResponse response =
+                await grantOffersService.GetAllAvailableGrantOffersAsync("AH3227C223222B5CMD3FJFKGZ");
+
+            // Assert - response
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.IsOk);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Adyen.BalancePlatform.Models.GrantOffers? result = response.Ok();
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.VarGrantOffers);
+            Assert.AreEqual(1, result.VarGrantOffers.Count);
+            Assert.AreEqual("UNIQUE_GRANT_OFFER_ID", result.VarGrantOffers[0].Id);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Get, capturedRequest.Method);
+            Assert.AreEqual("/bcl/v2/grantOffers", capturedRequest.RequestUri?.AbsolutePath);
+            string query = capturedRequest.RequestUri!.Query;
+            Assert.IsTrue(query.Contains("accountHolderId=AH3227C223222B5CMD3FJFKGZ"),
+                $"Expected 'accountHolderId=AH3227C223222B5CMD3FJFKGZ' in query, but was: {query}");
+        }
+
+        [TestMethod]
+        public async Task GetGrantOfferAsync_Returns200Ok_WithCorrectVerbAndPath()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/GrantOffer.json");
+
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddGrantOffersService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var grantOffersService = testHost.Services.GetRequiredService<IGrantOffersService>();
+
+            // Act
+            IGetGrantOfferApiResponse response = await grantOffersService.GetGrantOfferAsync("UNIQUE_GRANT_OFFER_ID");
+
+            // Assert - response
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.IsOk);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            GrantOffer? result = response.Ok();
+            Assert.IsNotNull(result);
+            Assert.AreEqual("UNIQUE_GRANT_OFFER_ID", result.Id);
+            Assert.AreEqual("AH3227C223222B5CMD3FJFKGZ", result.AccountHolderId);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Get, capturedRequest.Method);
+            Assert.AreEqual("/bcl/v2/grantOffers/UNIQUE_GRANT_OFFER_ID", capturedRequest.RequestUri?.AbsolutePath);
+        }
+    }
+}

--- a/Adyen.Test/BalancePlatform/GrantOffers/GrantOffersTest.cs
+++ b/Adyen.Test/BalancePlatform/GrantOffers/GrantOffersTest.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+using Adyen.BalancePlatform.Client;
+using Adyen.BalancePlatform.Extensions;
+using Adyen.BalancePlatform.Models;
+using Adyen.Core.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Adyen.Test.BalancePlatform.GrantOffers
+{
+    [TestClass]
+    public class GrantOffersTest
+    {
+        private readonly JsonSerializerOptionsProvider _jsonSerializerOptionsProvider;
+
+        public GrantOffersTest()
+        {
+            IHost host = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options =>
+                    {
+                        options.Environment = AdyenEnvironment.Test;
+                    });
+                })
+                .Build();
+
+            _jsonSerializerOptionsProvider = host.Services.GetRequiredService<JsonSerializerOptionsProvider>();
+        }
+
+        [TestMethod]
+        public void Given_GrantOffer_When_Deserialized_Then_Result_Is_Not_Null()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/GrantOffer.json");
+
+            // Act
+            GrantOffer result = JsonSerializer.Deserialize<GrantOffer>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual("UNIQUE_GRANT_OFFER_ID", result.Id);
+            Assert.AreEqual("AH3227C223222B5CMD3FJFKGZ", result.AccountHolderId);
+            Assert.AreEqual(GrantOffer.ContractTypeEnum.Loan, result.ContractType);
+        }
+
+        [TestMethod]
+        public void Given_GrantOffers_When_Deserialized_Then_Result_Is_Not_Null()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/GrantOffers.json");
+
+            // Act
+            Adyen.BalancePlatform.Models.GrantOffers result = JsonSerializer.Deserialize<Adyen.BalancePlatform.Models.GrantOffers>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.VarGrantOffers);
+            Assert.AreEqual(1, result.VarGrantOffers.Count);
+            Assert.AreEqual("UNIQUE_GRANT_OFFER_ID", result.VarGrantOffers[0].Id);
+        }
+    }
+}

--- a/Adyen.Test/BalancePlatform/ManageSCADevices/ManageSCADevicesServiceTest.cs
+++ b/Adyen.Test/BalancePlatform/ManageSCADevices/ManageSCADevicesServiceTest.cs
@@ -1,0 +1,158 @@
+using System.Net;
+using System.Text;
+using Adyen.BalancePlatform.Extensions;
+using Adyen.BalancePlatform.Models;
+using Adyen.BalancePlatform.Services;
+using Adyen.Core.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Adyen.Test.BalancePlatform.ManageSCADevices
+{
+    [TestClass]
+    public class ManageSCADevicesServiceTest
+    {
+        public ManageSCADevicesServiceTest() { }
+
+        [TestMethod]
+        public async Task InitiateRegistrationOfScaDeviceAsync_Returns200Ok_WithCorrectVerbAndPath()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/RegisterSCAResponse.json");
+
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddManageSCADevicesService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var manageSCADevicesService = testHost.Services.GetRequiredService<IManageSCADevicesService>();
+            var request = new RegisterSCARequest
+            {
+                PaymentInstrumentId = "PI3227C223222B5BPCMFXD2XG",
+                StrongCustomerAuthentication = new DelegatedAuthenticationData { SdkOutput = "UNIQUE_SDK_OUTPUT_DATA" }
+            };
+
+            // Act
+            IInitiateRegistrationOfScaDeviceApiResponse response =
+                await manageSCADevicesService.InitiateRegistrationOfScaDeviceAsync(request);
+
+            // Assert - response
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.IsOk);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            RegisterSCAResponse? result = response.Ok();
+            Assert.IsNotNull(result);
+            Assert.AreEqual("UNIQUE_SCA_DEVICE_ID", result.Id);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Post, capturedRequest.Method);
+            Assert.AreEqual("/bcl/v2/registeredDevices", capturedRequest.RequestUri?.AbsolutePath);
+        }
+
+        [TestMethod]
+        public async Task ListRegisteredScaDevicesAsync_Returns200Ok_WithCorrectVerbAndPath()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/SearchRegisteredDevicesResponse.json");
+
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddManageSCADevicesService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var manageSCADevicesService = testHost.Services.GetRequiredService<IManageSCADevicesService>();
+
+            // Act
+            IListRegisteredScaDevicesApiResponse response =
+                await manageSCADevicesService.ListRegisteredScaDevicesAsync("PI3227C223222B5BPCMFXD2XG");
+
+            // Assert - response
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.IsOk);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            SearchRegisteredDevicesResponse? result = response.Ok();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, result.ItemsTotal);
+            Assert.IsNotNull(result.Data);
+            Assert.AreEqual(1, result.Data.Count);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Get, capturedRequest.Method);
+            Assert.AreEqual("/bcl/v2/registeredDevices", capturedRequest.RequestUri?.AbsolutePath);
+        }
+
+        [TestMethod]
+        public async Task DeleteRegistrationOfScaDeviceAsync_Returns204NoContent_WithCorrectVerbAndPath()
+        {
+            // Arrange
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.NoContent);
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddManageSCADevicesService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var manageSCADevicesService = testHost.Services.GetRequiredService<IManageSCADevicesService>();
+
+            // Act
+            IDeleteRegistrationOfScaDeviceApiResponse response =
+                await manageSCADevicesService.DeleteRegistrationOfScaDeviceAsync("BSDR42XV3223223S5N6CDQDGH53M8H", "PI3227C223222B5BPCMFXD2XG");
+
+            // Assert - response
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.IsNoContent);
+            Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Delete, capturedRequest.Method);
+            Assert.AreEqual("/bcl/v2/registeredDevices/BSDR42XV3223223S5N6CDQDGH53M8H", capturedRequest.RequestUri?.AbsolutePath);
+        }
+    }
+}

--- a/Adyen.Test/BalancePlatform/ManageSCADevices/ManageSCADevicesTest.cs
+++ b/Adyen.Test/BalancePlatform/ManageSCADevices/ManageSCADevicesTest.cs
@@ -1,0 +1,65 @@
+using System.Text.Json;
+using Adyen.BalancePlatform.Client;
+using Adyen.BalancePlatform.Extensions;
+using Adyen.BalancePlatform.Models;
+using Adyen.Core.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Adyen.Test.BalancePlatform.ManageSCADevices
+{
+    [TestClass]
+    public class ManageSCADevicesTest
+    {
+        private readonly JsonSerializerOptionsProvider _jsonSerializerOptionsProvider;
+
+        public ManageSCADevicesTest()
+        {
+            IHost host = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options =>
+                    {
+                        options.Environment = AdyenEnvironment.Test;
+                    });
+                })
+                .Build();
+
+            _jsonSerializerOptionsProvider = host.Services.GetRequiredService<JsonSerializerOptionsProvider>();
+        }
+
+        [TestMethod]
+        public void Given_RegisterSCAResponse_When_Deserialized_Then_Result_Is_Not_Null()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/RegisterSCAResponse.json");
+
+            // Act
+            RegisterSCAResponse result = JsonSerializer.Deserialize<RegisterSCAResponse>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual("UNIQUE_SCA_DEVICE_ID", result.Id);
+            Assert.AreEqual("PI3227C223222B5BPCMFXD2XG", result.PaymentInstrumentId);
+            Assert.AreEqual(true, result.Success);
+        }
+
+        [TestMethod]
+        public void Given_SearchRegisteredDevicesResponse_When_Deserialized_Then_Result_Is_Not_Null()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/SearchRegisteredDevicesResponse.json");
+
+            // Act
+            SearchRegisteredDevicesResponse result = JsonSerializer.Deserialize<SearchRegisteredDevicesResponse>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, result.ItemsTotal);
+            Assert.AreEqual(1, result.PagesTotal);
+            Assert.IsNotNull(result.Data);
+            Assert.AreEqual(1, result.Data.Count);
+        }
+    }
+}

--- a/Adyen.Test/BalancePlatform/NetworkTokens/NetworkTokensServiceTest.cs
+++ b/Adyen.Test/BalancePlatform/NetworkTokens/NetworkTokensServiceTest.cs
@@ -1,0 +1,105 @@
+using System.Net;
+using System.Text;
+using Adyen.BalancePlatform.Extensions;
+using Adyen.BalancePlatform.Models;
+using Adyen.BalancePlatform.Services;
+using Adyen.Core.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Adyen.Test.BalancePlatform.NetworkTokens
+{
+    [TestClass]
+    public class NetworkTokensServiceTest
+    {
+        public NetworkTokensServiceTest() { }
+
+        [TestMethod]
+        public async Task GetNetworkTokenAsync_Returns200Ok_WithCorrectVerbAndPath()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/GetNetworkTokenResponse.json");
+
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddNetworkTokensService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var networkTokensService = testHost.Services.GetRequiredService<INetworkTokensService>();
+
+            // Act
+            IGetNetworkTokenApiResponse response = await networkTokensService.GetNetworkTokenAsync("NT1234567890");
+
+            // Assert - response
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.IsOk);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            GetNetworkTokenResponse? result = response.Ok();
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.Token);
+            Assert.AreEqual("NT1234567890", result.Token.Id);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Get, capturedRequest.Method);
+            Assert.AreEqual("/bcl/v2/networkTokens/NT1234567890", capturedRequest.RequestUri?.AbsolutePath);
+        }
+
+        [TestMethod]
+        public async Task UpdateNetworkTokenAsync_Returns202Accepted_WithCorrectVerbAndPath()
+        {
+            // Arrange
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.Accepted);
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddNetworkTokensService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var networkTokensService = testHost.Services.GetRequiredService<INetworkTokensService>();
+            var updateRequest = new UpdateNetworkTokenRequest { Status = UpdateNetworkTokenRequest.StatusEnum.Active };
+
+            // Act
+            IUpdateNetworkTokenApiResponse response =
+                await networkTokensService.UpdateNetworkTokenAsync("NT1234567890", updateRequest);
+
+            // Assert - response
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.IsAccepted);
+            Assert.AreEqual(HttpStatusCode.Accepted, response.StatusCode);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Patch, capturedRequest.Method);
+            Assert.AreEqual("/bcl/v2/networkTokens/NT1234567890", capturedRequest.RequestUri?.AbsolutePath);
+        }
+    }
+}

--- a/Adyen.Test/BalancePlatform/NetworkTokens/NetworkTokensTest.cs
+++ b/Adyen.Test/BalancePlatform/NetworkTokens/NetworkTokensTest.cs
@@ -1,0 +1,49 @@
+using System.Text.Json;
+using Adyen.BalancePlatform.Client;
+using Adyen.BalancePlatform.Extensions;
+using Adyen.BalancePlatform.Models;
+using Adyen.Core.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Adyen.Test.BalancePlatform.NetworkTokens
+{
+    [TestClass]
+    public class NetworkTokensTest
+    {
+        private readonly JsonSerializerOptionsProvider _jsonSerializerOptionsProvider;
+
+        public NetworkTokensTest()
+        {
+            IHost host = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options =>
+                    {
+                        options.Environment = AdyenEnvironment.Test;
+                    });
+                })
+                .Build();
+
+            _jsonSerializerOptionsProvider = host.Services.GetRequiredService<JsonSerializerOptionsProvider>();
+        }
+
+        [TestMethod]
+        public void Given_GetNetworkTokenResponse_When_Deserialized_Then_Result_Is_Not_Null()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/GetNetworkTokenResponse.json");
+
+            // Act
+            GetNetworkTokenResponse result = JsonSerializer.Deserialize<GetNetworkTokenResponse>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.Token);
+            Assert.AreEqual("NT1234567890", result.Token.Id);
+            Assert.AreEqual("PI3227C223222B5BPCMFXD2XG", result.Token.PaymentInstrumentId);
+            Assert.AreEqual(NetworkToken.StatusEnum.Active, result.Token.Status);
+        }
+    }
+}

--- a/Adyen.Test/BalancePlatform/Platform/PlatformServiceTest.cs
+++ b/Adyen.Test/BalancePlatform/Platform/PlatformServiceTest.cs
@@ -1,0 +1,160 @@
+using System.Net;
+using System.Text;
+using Adyen.BalancePlatform.Extensions;
+using Adyen.BalancePlatform.Models;
+using Adyen.BalancePlatform.Services;
+using Adyen.Core.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Adyen.Test.BalancePlatform.Platform
+{
+    [TestClass]
+    public class PlatformServiceTest
+    {
+        public PlatformServiceTest() { }
+
+        [TestMethod]
+        public async Task GetBalancePlatformAsync_Returns200Ok_WithCorrectVerbAndPath()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/BalancePlatform.json");
+
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddPlatformService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var platformService = testHost.Services.GetRequiredService<IPlatformService>();
+
+            // Act
+            IGetBalancePlatformApiResponse response = await platformService.GetBalancePlatformAsync("YOUR_BALANCE_PLATFORM");
+
+            // Assert - response
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.IsOk);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Adyen.BalancePlatform.Models.BalancePlatform? result = response.Ok();
+            Assert.IsNotNull(result);
+            Assert.AreEqual("YOUR_BALANCE_PLATFORM", result.Id);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Get, capturedRequest.Method);
+            Assert.AreEqual("/bcl/v2/balancePlatforms/YOUR_BALANCE_PLATFORM", capturedRequest.RequestUri?.AbsolutePath);
+        }
+
+        [TestMethod]
+        public async Task GetAllAccountHoldersUnderBalancePlatformAsync_Returns200Ok_WithCorrectVerbAndPath()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/PaginatedAccountHoldersResponse.json");
+
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddPlatformService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var platformService = testHost.Services.GetRequiredService<IPlatformService>();
+
+            // Act
+            IGetAllAccountHoldersUnderBalancePlatformApiResponse response =
+                await platformService.GetAllAccountHoldersUnderBalancePlatformAsync("YOUR_BALANCE_PLATFORM");
+
+            // Assert - response
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.IsOk);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            PaginatedAccountHoldersResponse? result = response.Ok();
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.AccountHolders);
+            Assert.AreEqual(3, result.AccountHolders.Count);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Get, capturedRequest.Method);
+            Assert.AreEqual("/bcl/v2/balancePlatforms/YOUR_BALANCE_PLATFORM/accountHolders", capturedRequest.RequestUri?.AbsolutePath);
+        }
+
+        [TestMethod]
+        public async Task GetAllTransactionRulesForBalancePlatformAsync_Returns200Ok_WithCorrectVerbAndPath()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/TransactionRulesResponse.json");
+
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddPlatformService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var platformService = testHost.Services.GetRequiredService<IPlatformService>();
+
+            // Act
+            IGetAllTransactionRulesForBalancePlatformApiResponse response =
+                await platformService.GetAllTransactionRulesForBalancePlatformAsync("YOUR_BALANCE_PLATFORM");
+
+            // Assert - response
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.IsOk);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            TransactionRulesResponse? result = response.Ok();
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.TransactionRules);
+            Assert.AreEqual(2, result.TransactionRules.Count);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Get, capturedRequest.Method);
+            Assert.AreEqual("/bcl/v2/balancePlatforms/YOUR_BALANCE_PLATFORM/transactionRules", capturedRequest.RequestUri?.AbsolutePath);
+        }
+    }
+}

--- a/Adyen.Test/BalancePlatform/Platform/PlatformTest.cs
+++ b/Adyen.Test/BalancePlatform/Platform/PlatformTest.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using Adyen.BalancePlatform.Client;
+using Adyen.BalancePlatform.Extensions;
+using Adyen.BalancePlatform.Models;
+using Adyen.Core.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Adyen.Test.BalancePlatform.Platform
+{
+    [TestClass]
+    public class PlatformTest
+    {
+        private readonly JsonSerializerOptionsProvider _jsonSerializerOptionsProvider;
+
+        public PlatformTest()
+        {
+            IHost host = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options =>
+                    {
+                        options.Environment = AdyenEnvironment.Test;
+                    });
+                })
+                .Build();
+
+            _jsonSerializerOptionsProvider = host.Services.GetRequiredService<JsonSerializerOptionsProvider>();
+        }
+
+        [TestMethod]
+        public void Given_BalancePlatform_When_Deserialized_Then_Result_Is_Not_Null()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/BalancePlatform.json");
+
+            // Act
+            Adyen.BalancePlatform.Models.BalancePlatform result = JsonSerializer.Deserialize<Adyen.BalancePlatform.Models.BalancePlatform>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual("YOUR_BALANCE_PLATFORM", result.Id);
+            Assert.AreEqual("Active", result.Status);
+        }
+
+        [TestMethod]
+        public void Given_PaginatedAccountHoldersResponse_When_Deserialized_Then_Result_Is_Not_Null()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/PaginatedAccountHoldersResponse.json");
+
+            // Act
+            PaginatedAccountHoldersResponse result = JsonSerializer.Deserialize<PaginatedAccountHoldersResponse>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.AccountHolders);
+        }
+    }
+}

--- a/Adyen.Test/BalancePlatform/SCADeviceManagement/SCADeviceManagementServiceTest.cs
+++ b/Adyen.Test/BalancePlatform/SCADeviceManagement/SCADeviceManagementServiceTest.cs
@@ -1,0 +1,175 @@
+using System.Net;
+using System.Text;
+using Adyen.BalancePlatform.Extensions;
+using Adyen.BalancePlatform.Models;
+using Adyen.BalancePlatform.Services;
+using Adyen.Core.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Adyen.Test.BalancePlatform.SCADeviceManagement
+{
+    [TestClass]
+    public class SCADeviceManagementServiceTest
+    {
+        public SCADeviceManagementServiceTest() { }
+
+        [TestMethod]
+        public async Task BeginScaDeviceRegistrationAsync_Returns201Created_WithCorrectVerbAndPath()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/BeginScaDeviceRegistrationResponse.json");
+
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.Created)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddSCADeviceManagementService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var scaDeviceManagementService = testHost.Services.GetRequiredService<ISCADeviceManagementService>();
+            var request = new BeginScaDeviceRegistrationRequest
+            {
+                Name = "My Device",
+                SdkOutput = "UNIQUE_SDK_OUTPUT_DATA"
+            };
+
+            // Act
+            IBeginScaDeviceRegistrationApiResponse response =
+                await scaDeviceManagementService.BeginScaDeviceRegistrationAsync(request);
+
+            // Assert - response
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.IsCreated);
+            Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
+            BeginScaDeviceRegistrationResponse? result = response.Created();
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.ScaDevice);
+            Assert.AreEqual("BSDR42XV3223223S5N6CDQDGH53M8H", result.ScaDevice.Id);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Post, capturedRequest.Method);
+            Assert.AreEqual("/bcl/v2/scaDevices", capturedRequest.RequestUri?.AbsolutePath);
+        }
+
+        [TestMethod]
+        public async Task FinishScaDeviceRegistrationAsync_Returns200Ok_WithCorrectVerbAndPath()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/FinishScaDeviceRegistrationResponse.json");
+
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddSCADeviceManagementService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var scaDeviceManagementService = testHost.Services.GetRequiredService<ISCADeviceManagementService>();
+            var request = new FinishScaDeviceRegistrationRequest { SdkOutput = "UNIQUE_SDK_OUTPUT_DATA" };
+
+            // Act
+            IFinishScaDeviceRegistrationApiResponse response =
+                await scaDeviceManagementService.FinishScaDeviceRegistrationAsync("BSDR42XV3223223S5N6CDQDGH53M8H", request);
+
+            // Assert - response
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.IsOk);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            FinishScaDeviceRegistrationResponse? result = response.Ok();
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.ScaDevice);
+            Assert.AreEqual("BSDR42XV3223223S5N6CDQDGH53M8H", result.ScaDevice.Id);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Patch, capturedRequest.Method);
+            Assert.AreEqual("/bcl/v2/scaDevices/BSDR42XV3223223S5N6CDQDGH53M8H", capturedRequest.RequestUri?.AbsolutePath);
+        }
+
+        [TestMethod]
+        public async Task SubmitScaAssociationAsync_Returns201Created_WithCorrectVerbAndPath()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/SubmitScaAssociationResponse.json");
+
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.Created)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddSCADeviceManagementService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var scaDeviceManagementService = testHost.Services.GetRequiredService<ISCADeviceManagementService>();
+            var request = new SubmitScaAssociationRequest
+            {
+                Entities = new List<ScaEntity>
+                {
+                    new ScaEntity { Type = ScaEntityType.AccountHolder, Id = "AH00000000000000000000001" }
+                }
+            };
+
+            // Act
+            ISubmitScaAssociationApiResponse response =
+                await scaDeviceManagementService.SubmitScaAssociationAsync("BSDR11111111111A1AAA1AAAAA1AA1", request);
+
+            // Assert - response
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.IsCreated);
+            Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
+            SubmitScaAssociationResponse? result = response.Created();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, result.ScaAssociations.Count);
+            Assert.AreEqual("BSDR11111111111A1AAA1AAAAA1AA1", result.ScaAssociations[0].ScaDeviceId);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Post, capturedRequest.Method);
+            Assert.AreEqual("/bcl/v2/scaDevices/BSDR11111111111A1AAA1AAAAA1AA1/scaAssociations", capturedRequest.RequestUri?.AbsolutePath);
+        }
+    }
+}

--- a/Adyen.Test/BalancePlatform/SCADeviceManagement/SCADeviceManagementTest.cs
+++ b/Adyen.Test/BalancePlatform/SCADeviceManagement/SCADeviceManagementTest.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using Adyen.BalancePlatform.Client;
+using Adyen.BalancePlatform.Extensions;
+using Adyen.BalancePlatform.Models;
+using Adyen.Core.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Adyen.Test.BalancePlatform.SCADeviceManagement
+{
+    [TestClass]
+    public class SCADeviceManagementTest
+    {
+        private readonly JsonSerializerOptionsProvider _jsonSerializerOptionsProvider;
+
+        public SCADeviceManagementTest()
+        {
+            IHost host = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options =>
+                    {
+                        options.Environment = AdyenEnvironment.Test;
+                    });
+                })
+                .Build();
+
+            _jsonSerializerOptionsProvider = host.Services.GetRequiredService<JsonSerializerOptionsProvider>();
+        }
+
+        [TestMethod]
+        public void Given_BeginScaDeviceRegistrationResponse_When_Deserialized_Then_Result_Is_Not_Null()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/BeginScaDeviceRegistrationResponse.json");
+
+            // Act
+            BeginScaDeviceRegistrationResponse result = JsonSerializer.Deserialize<BeginScaDeviceRegistrationResponse>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.ScaDevice);
+            Assert.AreEqual("BSDR42XV3223223S5N6CDQDGH53M8H", result.ScaDevice.Id);
+            Assert.AreEqual(ScaDeviceType.Ios, result.ScaDevice.Type);
+            Assert.IsNotNull(result.SdkInput);
+        }
+
+        [TestMethod]
+        public void Given_FinishScaDeviceRegistrationResponse_When_Deserialized_Then_Result_Is_Not_Null()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/FinishScaDeviceRegistrationResponse.json");
+
+            // Act
+            FinishScaDeviceRegistrationResponse result = JsonSerializer.Deserialize<FinishScaDeviceRegistrationResponse>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.ScaDevice);
+            Assert.AreEqual("BSDR42XV3223223S5N6CDQDGH53M8H", result.ScaDevice.Id);
+            Assert.AreEqual(ScaDeviceType.Ios, result.ScaDevice.Type);
+        }
+
+        [TestMethod]
+        public void Given_SubmitScaAssociationResponse_When_Deserialized_Then_Result_Is_Not_Null()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/SubmitScaAssociationResponse.json");
+
+            // Act
+            SubmitScaAssociationResponse result = JsonSerializer.Deserialize<SubmitScaAssociationResponse>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.ScaAssociations);
+            Assert.AreEqual(1, result.ScaAssociations.Count);
+            Assert.AreEqual("BSDR11111111111A1AAA1AAAAA1AA1", result.ScaAssociations[0].ScaDeviceId);
+            Assert.AreEqual("AH00000000000000000000001", result.ScaAssociations[0].EntityId);
+            Assert.AreEqual(ScaEntityType.AccountHolder, result.ScaAssociations[0].EntityType);
+            Assert.AreEqual(AssociationStatus.PendingApproval, result.ScaAssociations[0].Status);
+        }
+    }
+}

--- a/Adyen.Test/BalancePlatform/TransferRoutes/TransferRoutesServiceTest.cs
+++ b/Adyen.Test/BalancePlatform/TransferRoutes/TransferRoutesServiceTest.cs
@@ -1,0 +1,73 @@
+using System.Net;
+using System.Text;
+using Adyen.BalancePlatform.Extensions;
+using Adyen.BalancePlatform.Models;
+using Adyen.BalancePlatform.Services;
+using Adyen.Core.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Adyen.Test.BalancePlatform.TransferRoutes
+{
+    [TestClass]
+    public class TransferRoutesServiceTest
+    {
+        public TransferRoutesServiceTest() { }
+
+        [TestMethod]
+        public async Task CalculateTransferRoutesAsync_Returns200Ok_WithCorrectVerbAndPath()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/TransferRouteResponse.json");
+
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddTransferRoutesService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var transferRoutesService = testHost.Services.GetRequiredService<ITransferRoutesService>();
+            var request = new TransferRouteRequest
+            {
+                BalancePlatform = "YOUR_BALANCE_PLATFORM",
+                Category = TransferRouteRequest.CategoryEnum.Bank,
+                Currency = "USD"
+            };
+
+            // Act
+            ICalculateTransferRoutesApiResponse response = await transferRoutesService.CalculateTransferRoutesAsync(request);
+
+            // Assert - response
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.IsOk);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            TransferRouteResponse? result = response.Ok();
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.TransferRoutes);
+            Assert.AreEqual(2, result.TransferRoutes.Count);
+            Assert.AreEqual("USD", result.TransferRoutes[0].Currency);
+            Assert.AreEqual("NL", result.TransferRoutes[0].Country);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Post, capturedRequest.Method);
+            Assert.AreEqual("/bcl/v2/transferRoutes/calculate", capturedRequest.RequestUri?.AbsolutePath);
+        }
+    }
+}

--- a/Adyen.Test/BalancePlatform/TransferRoutes/TransferRoutesTest.cs
+++ b/Adyen.Test/BalancePlatform/TransferRoutes/TransferRoutesTest.cs
@@ -1,0 +1,49 @@
+using System.Text.Json;
+using Adyen.BalancePlatform.Client;
+using Adyen.BalancePlatform.Extensions;
+using Adyen.BalancePlatform.Models;
+using Adyen.Core.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Adyen.Test.BalancePlatform.TransferRoutes
+{
+    [TestClass]
+    public class TransferRoutesTest
+    {
+        private readonly JsonSerializerOptionsProvider _jsonSerializerOptionsProvider;
+
+        public TransferRoutesTest()
+        {
+            IHost host = Host.CreateDefaultBuilder()
+                .ConfigureBalancePlatform((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options =>
+                    {
+                        options.Environment = AdyenEnvironment.Test;
+                    });
+                })
+                .Build();
+
+            _jsonSerializerOptionsProvider = host.Services.GetRequiredService<JsonSerializerOptionsProvider>();
+        }
+
+        [TestMethod]
+        public void Given_TransferRouteResponse_When_Deserialized_Then_Result_Is_Not_Null()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/balanceplatform/TransferRouteResponse.json");
+
+            // Act
+            TransferRouteResponse result = JsonSerializer.Deserialize<TransferRouteResponse>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.TransferRoutes);
+            Assert.AreEqual(2, result.TransferRoutes.Count);
+            Assert.AreEqual("USD", result.TransferRoutes[0].Currency);
+            Assert.AreEqual("NL", result.TransferRoutes[0].Country);
+        }
+    }
+}

--- a/Adyen.Test/mocks/balanceplatform/AssociationFinaliseResponse.json
+++ b/Adyen.Test/mocks/balanceplatform/AssociationFinaliseResponse.json
@@ -1,0 +1,5 @@
+{
+  "type": "PAYMENT_INSTRUMENT",
+  "deviceId": "UNIQUE_SCA_DEVICE_ID",
+  "ids": ["PI3227C223222B5BPCMFXD2XG"]
+}

--- a/Adyen.Test/mocks/balanceplatform/AssociationInitiateResponse.json
+++ b/Adyen.Test/mocks/balanceplatform/AssociationInitiateResponse.json
@@ -1,0 +1,3 @@
+{
+  "sdkInput": "UNIQUE_SDK_INPUT_DATA"
+}

--- a/Adyen.Test/mocks/balanceplatform/BeginScaDeviceRegistrationResponse.json
+++ b/Adyen.Test/mocks/balanceplatform/BeginScaDeviceRegistrationResponse.json
@@ -1,0 +1,8 @@
+{
+  "scaDevice": {
+    "id": "BSDR42XV3223223S5N6CDQDGH53M8H",
+    "name": "My Device",
+    "type": "ios"
+  },
+  "sdkInput": "eyJjaGFsbGVuZ2UiOiJVWEZaTURONGNXWjZUVFExUlhWV2JuaEJPVzVzTm05cVVEUktUbFZtZGtrPSJ9"
+}

--- a/Adyen.Test/mocks/balanceplatform/FinishScaDeviceRegistrationResponse.json
+++ b/Adyen.Test/mocks/balanceplatform/FinishScaDeviceRegistrationResponse.json
@@ -1,0 +1,7 @@
+{
+  "scaDevice": {
+    "id": "BSDR42XV3223223S5N6CDQDGH53M8H",
+    "name": "Device",
+    "type": "ios"
+  }
+}

--- a/Adyen.Test/mocks/balanceplatform/GetNetworkTokenResponse.json
+++ b/Adyen.Test/mocks/balanceplatform/GetNetworkTokenResponse.json
@@ -1,0 +1,8 @@
+{
+  "token": {
+    "id": "NT1234567890",
+    "paymentInstrumentId": "PI3227C223222B5BPCMFXD2XG",
+    "status": "active",
+    "tokenLastFour": "1234"
+  }
+}

--- a/Adyen.Test/mocks/balanceplatform/GrantAccount.json
+++ b/Adyen.Test/mocks/balanceplatform/GrantAccount.json
@@ -1,0 +1,6 @@
+{
+  "id": "UNIQUE_GRANT_ACCOUNT_ID",
+  "fundingBalanceAccountId": "BA3227C223222B5CMD3FJFKGZ",
+  "balances": [],
+  "limits": []
+}

--- a/Adyen.Test/mocks/balanceplatform/GrantOffer.json
+++ b/Adyen.Test/mocks/balanceplatform/GrantOffer.json
@@ -1,0 +1,20 @@
+{
+  "id": "UNIQUE_GRANT_OFFER_ID",
+  "accountHolderId": "AH3227C223222B5CMD3FJFKGZ",
+  "contractType": "loan",
+  "amount": {
+    "currency": "EUR",
+    "value": 10000
+  },
+  "fee": {
+    "amount": {
+      "currency": "EUR",
+      "value": 500
+    }
+  },
+  "repayment": {
+    "basisPoints": 1000
+  },
+  "startsAt": "2024-01-01T00:00:00.0000000Z",
+  "expiresAt": "2024-12-31T23:59:59.0000000Z"
+}

--- a/Adyen.Test/mocks/balanceplatform/GrantOffers.json
+++ b/Adyen.Test/mocks/balanceplatform/GrantOffers.json
@@ -1,0 +1,24 @@
+{
+  "grantOffers": [
+    {
+      "id": "UNIQUE_GRANT_OFFER_ID",
+      "accountHolderId": "AH3227C223222B5CMD3FJFKGZ",
+      "contractType": "loan",
+      "amount": {
+        "currency": "EUR",
+        "value": 10000
+      },
+      "fee": {
+        "amount": {
+          "currency": "EUR",
+          "value": 500
+        }
+      },
+      "repayment": {
+        "basisPoints": 1000
+      },
+      "startsAt": "2024-01-01T00:00:00.0000000Z",
+      "expiresAt": "2024-12-31T23:59:59.0000000Z"
+    }
+  ]
+}

--- a/Adyen.Test/mocks/balanceplatform/RegisterSCAFinalResponse.json
+++ b/Adyen.Test/mocks/balanceplatform/RegisterSCAFinalResponse.json
@@ -1,0 +1,3 @@
+{
+  "success": true
+}

--- a/Adyen.Test/mocks/balanceplatform/RegisterSCAResponse.json
+++ b/Adyen.Test/mocks/balanceplatform/RegisterSCAResponse.json
@@ -1,0 +1,6 @@
+{
+  "id": "UNIQUE_SCA_DEVICE_ID",
+  "paymentInstrumentId": "PI3227C223222B5BPCMFXD2XG",
+  "sdkInput": "UNIQUE_SDK_INPUT_DATA",
+  "success": true
+}

--- a/Adyen.Test/mocks/balanceplatform/SearchRegisteredDevicesResponse.json
+++ b/Adyen.Test/mocks/balanceplatform/SearchRegisteredDevicesResponse.json
@@ -1,0 +1,11 @@
+{
+  "data": [
+    {
+      "id": "BSDR42XV3223223S5N6CDQDGH53M8H",
+      "name": "My Device",
+      "type": "ios"
+    }
+  ],
+  "itemsTotal": 1,
+  "pagesTotal": 1
+}

--- a/Adyen.Test/mocks/balanceplatform/SubmitScaAssociationResponse.json
+++ b/Adyen.Test/mocks/balanceplatform/SubmitScaAssociationResponse.json
@@ -1,0 +1,10 @@
+{
+  "scaAssociations": [
+    {
+      "scaDeviceId": "BSDR11111111111A1AAA1AAAAA1AA1",
+      "entityType": "accountHolder",
+      "entityId": "AH00000000000000000000001",
+      "status": "pendingApproval"
+    }
+  ]
+}

--- a/Adyen.Test/mocks/balanceplatform/TransferRouteResponse.json
+++ b/Adyen.Test/mocks/balanceplatform/TransferRouteResponse.json
@@ -1,0 +1,35 @@
+{
+  "transferRoutes": [
+    {
+      "country": "NL",
+      "currency": "USD",
+      "priority": "crossBorder",
+      "requirements": [
+        {
+          "description": "Amount of transfer must be at least 100, and no greater than 99999999999",
+          "max": 99999999999,
+          "min": 100,
+          "type": "amountMinMaxRequirement"
+        },
+        {
+          "description": "Bank account identification type must be iban or numberAndBic",
+          "bankAccountIdentificationTypes": ["iban", "numberAndBic"],
+          "type": "bankAccountIdentificationTypeRequirement"
+        }
+      ]
+    },
+    {
+      "country": "NL",
+      "currency": "USD",
+      "priority": "wire",
+      "requirements": [
+        {
+          "description": "Amount of transfer must be at least 100, and no greater than 99999999999",
+          "max": 99999999999,
+          "min": 100,
+          "type": "amountMinMaxRequirement"
+        }
+      ]
+    }
+  ]
+}

--- a/Adyen.Test/mocks/balanceplatform/WebhookSetting.json
+++ b/Adyen.Test/mocks/balanceplatform/WebhookSetting.json
@@ -1,0 +1,10 @@
+{
+  "currency": "EUR",
+  "id": "UNIQUE_WEBHOOK_SETTING_ID",
+  "status": "active",
+  "target": {
+    "type": "balancePlatform",
+    "id": "YOUR_BALANCE_PLATFORM"
+  },
+  "type": "BalanceWebhookSetting"
+}

--- a/Adyen.Test/mocks/balanceplatform/WebhookSettings.json
+++ b/Adyen.Test/mocks/balanceplatform/WebhookSettings.json
@@ -1,0 +1,14 @@
+{
+  "webhookSettings": [
+    {
+      "currency": "EUR",
+      "id": "UNIQUE_WEBHOOK_SETTING_ID",
+      "status": "active",
+      "target": {
+        "type": "balancePlatform",
+        "id": "YOUR_BALANCE_PLATFORM"
+      },
+      "type": "BalanceWebhookSetting"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Adds unit tests for the 9 BalancePlatform services that had no test coverage, as requested in #1589.

For each service, two test files follow the established convention:
- `*Test.cs` — model serialization/deserialization tests
- `*ServiceTest.cs` — HTTP-level tests using `MockDelegatingHandler`, asserting verb, path, query params, and response fields

**Services covered:**
- `PlatformService` (GetBalancePlatform, GetAllAccountHolders, GetAllTransactionRules)
- `BalancesService` (CreateWebhookSetting, GetAllWebhookSettings, GetWebhookSetting, DeleteWebhookSetting)
- `TransferRoutesService` (CalculateTransferRoutes)
- `AuthorizedCardUsersService` (GetAll, Create, Delete)
- `NetworkTokensService` (GetNetworkToken, UpdateNetworkToken)
- `SCADeviceManagementService` (BeginRegistration, FinishRegistration, SubmitAssociation)
- `ManageSCADevicesService` (InitiateRegistration, ListDevices, DeleteRegistration)
- `GrantOffersService` (GetAllAvailableGrantOffers, GetGrantOffer)
- `GrantAccountsService` (GetGrantAccount)

**Mock fixtures:** 15 new JSON files. Where OpenAPI spec examples exist (at commit `7824ebf`), mock data is aligned with those examples (TransferRoutes, ScaDevices, AuthorisedCardUsers, BalancePlatform).

**Note:** `BalancesService` response deserialization tests are omitted because `BalanceWebhookSetting` (a polymorphic type) has a known constructor issue in the generated code — the base class constructor calls `Enum.Parse(typeof(SettingType), this.GetType().Name)` which fails for the subclass name. HTTP-level routing tests are included and pass correctly.

## Tested scenarios

- `dotnet test Adyen.Test --filter "FullyQualifiedName~BalancePlatform"` — 93 tests pass
- Full suite: 540 tests pass

## Fixed issue

Fixes #1589