### PR TITLE
Fix BuildQueryString double-encoding of percent signs

### DIFF
--- a/Adyen.Test/AcsWebhooks/ClientUtilsBuildQueryStringTest.cs
+++ b/Adyen.Test/AcsWebhooks/ClientUtilsBuildQueryStringTest.cs
@@ -8,9 +8,10 @@ namespace Adyen.Test.AcsWebhooks
     /// Tests for the <c>BuildQueryString</c> method in <see cref="Adyen.AcsWebhooks.Client.ClientUtils"/>.
     ///
     /// The method uses minimal percent-encoding: only characters that would break query string
-    /// structure are escaped (&amp;, =, #, space, %). Sub-delimiters (+, /, !) and ASCII
-    /// printable characters are intentionally left unencoded. Non-ASCII characters are encoded
-    /// via <see cref="Uri.EscapeDataString"/>.
+    /// structure are escaped (&amp;, =, #, space). Sub-delimiters (+, /, !) and ASCII
+    /// printable characters are intentionally left unencoded. The <c>%</c> character is also
+    /// left unencoded so that already percent-encoded sequences pass through unchanged.
+    /// Non-ASCII characters are encoded via <see cref="Uri.EscapeDataString"/>.
     ///
     /// Reflection is used because <c>BuildQueryString</c> is <c>internal</c> and the main assembly
     /// is strong-named, which prevents <c>InternalsVisibleTo</c> from granting access to an
@@ -67,17 +68,17 @@ namespace Adyen.Test.AcsWebhooks
         }
 
         [TestMethod]
-        public void Percent_InValue_IsEncoded_PreventingDoubleEncoding()
+        public void Percent_InValue_PassesThrough()
         {
-            // regression: "50%off" must not produce "50%off" (leaving % raw)
-            Assert.AreEqual("foo=50%25off", Invoke(Nvc(("foo", "50%off"))));
+            // raw "%" is not a structural character, so it must not be encoded
+            Assert.AreEqual("foo=50%off", Invoke(Nvc(("foo", "50%off"))));
         }
 
         [TestMethod]
         public void AlreadyEncodedPercent20_IsNotDoubleEncoded()
         {
-            // "%20" in input → "%" becomes "%25", so output is "%2520"
-            Assert.AreEqual("foo=%2520", Invoke(Nvc(("foo", "%20"))));
+            // already-encoded sequences must pass through unchanged — "%" is preserved
+            Assert.AreEqual("foo=%20", Invoke(Nvc(("foo", "%20"))));
         }
 
         [TestMethod]
@@ -132,6 +133,21 @@ namespace Adyen.Test.AcsWebhooks
         {
             // "😊" (U+1F60A) is stored as a surrogate pair in UTF-16; must encode to %F0%9F%98%8A
             Assert.AreEqual("foo=%F0%9F%98%8A", Invoke(Nvc(("foo", "😊"))));
+        }
+
+        [TestMethod]
+        public void AlreadyEncodedToken_PassesThroughUnchanged()
+        {
+            // opaque tokens with pre-encoded sequences must not be double-encoded
+            Assert.AreEqual("token=already%26encoded%20value", Invoke(Nvc(("token", "already%26encoded%20value"))));
+        }
+
+        [TestMethod]
+        public void PercentFollowedByValidHex_PassesThroughUnchanged()
+        {
+            // "100%20rate": the caller is responsible for pre-encoding raw % — this method
+            // treats any % as already encoded and leaves it unchanged
+            Assert.AreEqual("foo=100%20rate", Invoke(Nvc(("foo", "100%20rate"))));
         }
     }
 }

--- a/Adyen.Test/Checkout/PaymentsTest.cs
+++ b/Adyen.Test/Checkout/PaymentsTest.cs
@@ -1230,6 +1230,5 @@ namespace Adyen.Test.Checkout
         }
 
         #endregion
-
     }
 }

--- a/Adyen/AcsWebhooks/Client/ClientUtils.cs
+++ b/Adyen/AcsWebhooks/Client/ClientUtils.cs
@@ -168,6 +168,12 @@ namespace Adyen.AcsWebhooks.Client
         /// query values.
         /// </para>
         /// </summary>
+        /// <remarks>
+        /// The <c>%</c> character is <b>not</b> encoded by this method. If a value contains a
+        /// literal <c>%</c> that is not part of a percent-encoded sequence (e.g. <c>50%off</c>),
+        /// the caller must encode it as <c>%25</c> before passing it to this method. This design
+        /// intentionally preserves already-encoded sequences such as opaque tokens or redirect URLs.
+        /// </remarks>
         /// <param name="parameters">The query string parameters.</param>
         /// <returns>A query string (without leading '?').</returns>
         internal static string BuildQueryString(System.Collections.Specialized.NameValueCollection parameters)
@@ -190,7 +196,6 @@ namespace Adyen.AcsWebhooks.Client
                         case '=': sb.Append("%3D"); break;
                         case '#': sb.Append("%23"); break;
                         case ' ': sb.Append("%20"); break;
-                        case '%': sb.Append("%25"); break;
                         default:
                             if (c > 127)
                             {

--- a/templates-v7/csharp/libraries/generichost/ClientUtils.mustache
+++ b/templates-v7/csharp/libraries/generichost/ClientUtils.mustache
@@ -187,6 +187,12 @@ namespace {{packageName}}.{{apiName}}.{{clientPackage}}
         /// query values.
         /// </para>
         /// </summary>
+        /// <remarks>
+        /// The <c>%</c> character is <b>not</b> encoded by this method. If a value contains a
+        /// literal <c>%</c> that is not part of a percent-encoded sequence (e.g. <c>50%off</c>),
+        /// the caller must encode it as <c>%25</c> before passing it to this method. This design
+        /// intentionally preserves already-encoded sequences such as opaque tokens or redirect URLs.
+        /// </remarks>
         /// <param name="parameters">The query string parameters.</param>
         /// <returns>A query string (without leading '?').</returns>
         internal static string BuildQueryString(System.Collections.Specialized.NameValueCollection parameters)
@@ -209,7 +215,6 @@ namespace {{packageName}}.{{apiName}}.{{clientPackage}}
                         case '=': sb.Append("%3D"); break;
                         case '#': sb.Append("%23"); break;
                         case ' ': sb.Append("%20"); break;
-                        case '%': sb.Append("%25"); break;
                         default:
                             if (c > 127)
                             {


### PR DESCRIPTION
## Description

Removes `case '%': sb.Append("%25"); break;` from the `BuildQueryString` method so that `%` characters pass through unchanged. This prevents double-encoding of query parameter values that already contain percent-encoded sequences (e.g. opaque tokens, redirect URLs, session results).

The `%` character is not a structural query-string character (`&`, `=`, `#`, space are), so encoding it was incorrect when the caller supplies already-encoded values.

A `<remarks>` block has been added to the method's XML doc to make the encoding contract explicit: callers who need to pass a literal `%` that is not part of a percent-encoded sequence must encode it as `%25` before calling this method.

### Files changed

| File | Reason |
|------|--------|
| `templates-v7/csharp/libraries/generichost/ClientUtils.mustache` | Source of truth — fix + `<remarks>` doc added |
| `Adyen/AcsWebhooks/Client/ClientUtils.cs` | Updated manually to back the existing unit tests |
| `Adyen.Test/AcsWebhooks/ClientUtilsBuildQueryStringTest.cs` | Updated two tests that asserted old (buggy) behaviour; added two new regression tests |

> **Note:** The remaining 25 generated `ClientUtils.cs` files are not changed in this PR. They will be automatically regenerated from the updated Mustache template as part of the next OpenAPI spec sync (same process used for all SDK updates).

## Tested scenarios

- All 17 `ClientUtilsBuildQueryStringTest` tests pass
- Existing `Checkout/PaymentsTest` suite unaffected

## Fixed issue

Fixes #1563