### PR TITLE
Add oneOf deserialization/serialization tests for Transfers and Checkout

### DIFF
--- a/Adyen.Test/Checkout/PaymentsTest.cs
+++ b/Adyen.Test/Checkout/PaymentsTest.cs
@@ -1095,5 +1095,141 @@ namespace Adyen.Test.Checkout
             Assert.IsFalse(jsonDoc.RootElement.TryGetProperty("merchantReference", out _));
         }
 
+        #region PaymentResponse discriminator
+
+        [TestMethod]
+        public void Given_Deserialize_When_PaymentResponse_WithRedirectAction_Then_CheckoutRedirectAction_IsPopulated()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/checkout/payment-response-redirect-action.json");
+
+            // Act
+            var response = JsonSerializer.Deserialize<PaymentResponse>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual(PaymentResponse.ResultCodeEnum.RedirectShopper, response.ResultCode);
+            Assert.IsNotNull(response.Action);
+            Assert.IsNotNull(response.Action.CheckoutRedirectAction);
+            Assert.IsNull(response.Action.CheckoutThreeDS2Action);
+            Assert.IsNull(response.Action.CheckoutSDKAction);
+            Assert.AreEqual(CheckoutRedirectAction.TypeEnum.Redirect, response.Action.CheckoutRedirectAction.Type);
+            Assert.AreEqual("scheme", response.Action.CheckoutRedirectAction.PaymentMethodType);
+            Assert.AreEqual("GET", response.Action.CheckoutRedirectAction.Method);
+        }
+
+        [TestMethod]
+        public void Given_Deserialize_When_PaymentResponse_WithThreeDS2Action_Then_CheckoutThreeDS2Action_IsPopulated()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/checkout/payment-response-threeDS2-action.json");
+
+            // Act
+            var response = JsonSerializer.Deserialize<PaymentResponse>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual(PaymentResponse.ResultCodeEnum.IdentifyShopper, response.ResultCode);
+            Assert.IsNotNull(response.Action);
+            Assert.IsNotNull(response.Action.CheckoutThreeDS2Action);
+            Assert.IsNull(response.Action.CheckoutRedirectAction);
+            Assert.IsNull(response.Action.CheckoutSDKAction);
+            Assert.AreEqual(CheckoutThreeDS2Action.TypeEnum.ThreeDS2, response.Action.CheckoutThreeDS2Action.Type);
+            Assert.AreEqual("scheme", response.Action.CheckoutThreeDS2Action.PaymentMethodType);
+            Assert.IsNotNull(response.Action.CheckoutThreeDS2Action.Token);
+        }
+
+        [TestMethod]
+        public void Given_Serialize_When_PaymentResponse_WithRedirectAction_Then_TypeIsPreserved()
+        {
+            // Arrange
+            var action = new PaymentResponseAction(new CheckoutRedirectAction
+            {
+                Type = CheckoutRedirectAction.TypeEnum.Redirect,
+                PaymentMethodType = "scheme",
+                Url = "https://checkoutshopper-test.adyen.com/redirect",
+                Method = "GET"
+            });
+            var response = new PaymentResponse
+            {
+                ResultCode = PaymentResponse.ResultCodeEnum.RedirectShopper,
+                Action = action
+            };
+
+            // Act
+            string json = JsonSerializer.Serialize(response, _jsonSerializerOptionsProvider.Options);
+            var jsonDoc = JsonDocument.Parse(json);
+
+            // Assert
+            Assert.AreEqual("RedirectShopper", jsonDoc.RootElement.GetProperty("resultCode").GetString());
+            Assert.AreEqual("redirect", jsonDoc.RootElement.GetProperty("action").GetProperty("type").GetString());
+            Assert.AreEqual("scheme", jsonDoc.RootElement.GetProperty("action").GetProperty("paymentMethodType").GetString());
+            Assert.AreEqual("GET", jsonDoc.RootElement.GetProperty("action").GetProperty("method").GetString());
+        }
+
+        #endregion
+
+        #region PaymentDetailsResponse discriminator
+
+        [TestMethod]
+        public void Given_Deserialize_When_PaymentDetailsResponse_WithoutAction_Then_ResultCode_IsAuthorised()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/checkout/payment-details-response-authorised.json");
+
+            // Act
+            var response = JsonSerializer.Deserialize<PaymentDetailsResponse>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual(PaymentDetailsResponse.ResultCodeEnum.Authorised, response.ResultCode);
+            Assert.IsNull(response.Action);
+        }
+
+        [TestMethod]
+        public void Given_Deserialize_When_PaymentDetailsResponse_WithThreeDS2Action_Then_CheckoutThreeDS2Action_IsPopulated()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/checkout/payment-details-response-threeDS2-action.json");
+
+            // Act
+            var response = JsonSerializer.Deserialize<PaymentDetailsResponse>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual(PaymentDetailsResponse.ResultCodeEnum.ChallengeShopper, response.ResultCode);
+            Assert.IsNotNull(response.Action);
+            Assert.AreEqual(CheckoutThreeDS2Action.TypeEnum.ThreeDS2, response.Action.Type);
+            Assert.AreEqual("scheme", response.Action.PaymentMethodType);
+            Assert.IsNotNull(response.Action.Token);
+        }
+
+        [TestMethod]
+        public void Given_Serialize_When_PaymentDetailsResponse_WithThreeDS2Action_Then_TypeIsPreserved()
+        {
+            // Arrange
+            var response = new PaymentDetailsResponse
+            {
+                ResultCode = PaymentDetailsResponse.ResultCodeEnum.ChallengeShopper,
+                Action = new CheckoutThreeDS2Action
+                {
+                    Type = CheckoutThreeDS2Action.TypeEnum.ThreeDS2,
+                    PaymentMethodType = "scheme",
+                    PaymentData = "test-payment-data"
+                }
+            };
+
+            // Act
+            string json = JsonSerializer.Serialize(response, _jsonSerializerOptionsProvider.Options);
+            var jsonDoc = JsonDocument.Parse(json);
+
+            // Assert
+            Assert.AreEqual("ChallengeShopper", jsonDoc.RootElement.GetProperty("resultCode").GetString());
+            Assert.AreEqual("threeDS2", jsonDoc.RootElement.GetProperty("action").GetProperty("type").GetString());
+            Assert.AreEqual("scheme", jsonDoc.RootElement.GetProperty("action").GetProperty("paymentMethodType").GetString());
+        }
+
+        #endregion
+
     }
 }

--- a/Adyen.Test/Transfers/TransfersTest.cs
+++ b/Adyen.Test/Transfers/TransfersTest.cs
@@ -140,6 +140,65 @@ namespace Adyen.Test.Transfers
             Assert.AreEqual("1W1UG35U8A9J5ZLG", response.TransferId);
         }
         
+        #region Tracking Discriminator
+        
+        [TestMethod]
+        public async Task Given_Deserialize_When_TrackingTypeConfirmation_Returns_ConfirmationTrackingData()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/transfers/transfer-data-confirmation-tracking.json");
+            
+            // Act
+            var response = JsonSerializer.Deserialize<TransferData>(json, _jsonSerializerOptionsProvider.Options);
+            
+            // Assert
+            Assert.IsNotNull(response.Tracking);
+            Assert.IsNotNull(response.Tracking.ConfirmationTrackingData);
+            Assert.IsNull(response.Tracking.EstimationTrackingData);
+            Assert.IsNull(response.Tracking.InternalReviewTrackingData);
+            Assert.AreEqual(ConfirmationTrackingData.TypeEnum.Confirmation, response.Tracking.ConfirmationTrackingData.Type);
+            Assert.AreEqual(ConfirmationTrackingData.StatusEnum.Credited, response.Tracking.ConfirmationTrackingData.Status);
+        }
+        
+        [TestMethod]
+        public async Task Given_Deserialize_When_TrackingTypeEstimation_Returns_EstimationTrackingData()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/transfers/transfer-data-estimation-tracking.json");
+            
+            // Act
+            var response = JsonSerializer.Deserialize<TransferData>(json, _jsonSerializerOptionsProvider.Options);
+            
+            // Assert
+            Assert.IsNotNull(response.Tracking);
+            Assert.IsNull(response.Tracking.ConfirmationTrackingData);
+            Assert.IsNotNull(response.Tracking.EstimationTrackingData);
+            Assert.IsNull(response.Tracking.InternalReviewTrackingData);
+            Assert.AreEqual(EstimationTrackingData.TypeEnum.Estimation, response.Tracking.EstimationTrackingData.Type);
+            Assert.AreEqual(new DateTimeOffset(2023, 8, 20, 13, 7, 40, TimeSpan.Zero), response.Tracking.EstimationTrackingData.EstimatedArrivalTime);
+        }
+        
+        [TestMethod]
+        public async Task Given_Deserialize_When_TrackingTypeInternalReview_Returns_InternalReviewTrackingData()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/transfers/transfer-data-internal-review-tracking.json");
+            
+            // Act
+            var response = JsonSerializer.Deserialize<TransferData>(json, _jsonSerializerOptionsProvider.Options);
+            
+            // Assert
+            Assert.IsNotNull(response.Tracking);
+            Assert.IsNull(response.Tracking.ConfirmationTrackingData);
+            Assert.IsNull(response.Tracking.EstimationTrackingData);
+            Assert.IsNotNull(response.Tracking.InternalReviewTrackingData);
+            Assert.AreEqual(InternalReviewTrackingData.TypeEnum.InternalReview, response.Tracking.InternalReviewTrackingData.Type);
+            Assert.AreEqual(InternalReviewTrackingData.StatusEnum.Pending, response.Tracking.InternalReviewTrackingData.Status);
+            Assert.AreEqual(InternalReviewTrackingData.ReasonEnum.RefusedForRegulatoryReasons, response.Tracking.InternalReviewTrackingData.Reason);
+        }
+        
+        #endregion
+        
         #region Grants
         
         [TestMethod]

--- a/Adyen.Test/Transfers/TransfersTest.cs
+++ b/Adyen.Test/Transfers/TransfersTest.cs
@@ -143,7 +143,7 @@ namespace Adyen.Test.Transfers
         #region Tracking Discriminator
         
         [TestMethod]
-        public async Task Given_Deserialize_When_TrackingTypeConfirmation_Returns_ConfirmationTrackingData()
+        public void Given_Deserialize_When_TrackingTypeConfirmation_Returns_ConfirmationTrackingData()
         {
             // Arrange
             string json = TestUtilities.GetTestFileContent("mocks/transfers/transfer-data-confirmation-tracking.json");
@@ -152,6 +152,7 @@ namespace Adyen.Test.Transfers
             var response = JsonSerializer.Deserialize<TransferData>(json, _jsonSerializerOptionsProvider.Options);
             
             // Assert
+            Assert.IsNotNull(response);
             Assert.IsNotNull(response.Tracking);
             Assert.IsNotNull(response.Tracking.ConfirmationTrackingData);
             Assert.IsNull(response.Tracking.EstimationTrackingData);
@@ -161,7 +162,7 @@ namespace Adyen.Test.Transfers
         }
         
         [TestMethod]
-        public async Task Given_Deserialize_When_TrackingTypeEstimation_Returns_EstimationTrackingData()
+        public void Given_Deserialize_When_TrackingTypeEstimation_Returns_EstimationTrackingData()
         {
             // Arrange
             string json = TestUtilities.GetTestFileContent("mocks/transfers/transfer-data-estimation-tracking.json");
@@ -170,6 +171,7 @@ namespace Adyen.Test.Transfers
             var response = JsonSerializer.Deserialize<TransferData>(json, _jsonSerializerOptionsProvider.Options);
             
             // Assert
+            Assert.IsNotNull(response);
             Assert.IsNotNull(response.Tracking);
             Assert.IsNull(response.Tracking.ConfirmationTrackingData);
             Assert.IsNotNull(response.Tracking.EstimationTrackingData);
@@ -179,7 +181,7 @@ namespace Adyen.Test.Transfers
         }
         
         [TestMethod]
-        public async Task Given_Deserialize_When_TrackingTypeInternalReview_Returns_InternalReviewTrackingData()
+        public void Given_Deserialize_When_TrackingTypeInternalReview_Returns_InternalReviewTrackingData()
         {
             // Arrange
             string json = TestUtilities.GetTestFileContent("mocks/transfers/transfer-data-internal-review-tracking.json");
@@ -188,6 +190,7 @@ namespace Adyen.Test.Transfers
             var response = JsonSerializer.Deserialize<TransferData>(json, _jsonSerializerOptionsProvider.Options);
             
             // Assert
+            Assert.IsNotNull(response);
             Assert.IsNotNull(response.Tracking);
             Assert.IsNull(response.Tracking.ConfirmationTrackingData);
             Assert.IsNull(response.Tracking.EstimationTrackingData);

--- a/Adyen.Test/mocks/checkout/payment-details-response-authorised.json
+++ b/Adyen.Test/mocks/checkout/payment-details-response-authorised.json
@@ -1,0 +1,4 @@
+{
+  "pspReference": "V4HZ4RBFJGXXGN82",
+  "resultCode": "Authorised"
+}

--- a/Adyen.Test/mocks/checkout/payment-details-response-threeDS2-action.json
+++ b/Adyen.Test/mocks/checkout/payment-details-response-threeDS2-action.json
@@ -1,0 +1,10 @@
+{
+  "resultCode": "ChallengeShopper",
+  "action": {
+    "paymentData": "test-payment-data",
+    "paymentMethodType": "scheme",
+    "authorisationToken": "test-authorisation-token",
+    "token": "test-token",
+    "type": "threeDS2"
+  }
+}

--- a/Adyen.Test/mocks/checkout/payment-response-redirect-action.json
+++ b/Adyen.Test/mocks/checkout/payment-response-redirect-action.json
@@ -1,0 +1,11 @@
+{
+  "pspReference": "JLCMPCQ8HXSKGK82",
+  "resultCode": "RedirectShopper",
+  "merchantReference": "Your order number",
+  "action": {
+    "paymentMethodType": "scheme",
+    "url": "https://checkoutshopper-test.adyen.com/checkoutshopper/threeDS/redirect",
+    "method": "GET",
+    "type": "redirect"
+  }
+}

--- a/Adyen.Test/mocks/checkout/payment-response-threeDS2-action.json
+++ b/Adyen.Test/mocks/checkout/payment-response-threeDS2-action.json
@@ -1,0 +1,10 @@
+{
+  "resultCode": "IdentifyShopper",
+  "action": {
+    "paymentData": "test-payment-data",
+    "paymentMethodType": "scheme",
+    "authorisationToken": "test-authorisation-token",
+    "token": "test-token",
+    "type": "threeDS2"
+  }
+}

--- a/Adyen.Test/mocks/transfers/transfer-data-confirmation-tracking.json
+++ b/Adyen.Test/mocks/transfers/transfer-data-confirmation-tracking.json
@@ -1,0 +1,16 @@
+{
+  "id": "1W1UG35U8A9J5ZLG",
+  "amount": {
+    "value": 110000,
+    "currency": "EUR"
+  },
+  "balanceAccountId": "BAB8B2C3D4E5F6G7H8D9J6GD4",
+  "category": "bank",
+  "direction": "outgoing",
+  "reason": "approved",
+  "status": "authorised",
+  "tracking": {
+    "type": "confirmation",
+    "status": "credited"
+  }
+}

--- a/Adyen.Test/mocks/transfers/transfer-data-estimation-tracking.json
+++ b/Adyen.Test/mocks/transfers/transfer-data-estimation-tracking.json
@@ -1,0 +1,16 @@
+{
+  "id": "1W1UG35U8A9J5ZLG",
+  "amount": {
+    "value": 110000,
+    "currency": "EUR"
+  },
+  "balanceAccountId": "BAB8B2C3D4E5F6G7H8D9J6GD4",
+  "category": "bank",
+  "direction": "outgoing",
+  "reason": "approved",
+  "status": "authorised",
+  "tracking": {
+    "type": "estimation",
+    "estimatedArrivalTime": "2023-08-20T13:07:40Z"
+  }
+}

--- a/Adyen.Test/mocks/transfers/transfer-data-internal-review-tracking.json
+++ b/Adyen.Test/mocks/transfers/transfer-data-internal-review-tracking.json
@@ -1,0 +1,17 @@
+{
+  "id": "1W1UG35U8A9J5ZLG",
+  "amount": {
+    "value": 110000,
+    "currency": "EUR"
+  },
+  "balanceAccountId": "BAB8B2C3D4E5F6G7H8D9J6GD4",
+  "category": "bank",
+  "direction": "outgoing",
+  "reason": "approved",
+  "status": "authorised",
+  "tracking": {
+    "type": "internalReview",
+    "status": "pending",
+    "reason": "refusedForRegulatoryReasons"
+  }
+}


### PR DESCRIPTION
## Description

Adds unit tests covering `oneOf` deserialization and serialization for the Transfers and Checkout APIs.

### Transfers — `TransferDataTracking` (3 tests)

The `tracking` field on `TransferData` is a `oneOf` of `ConfirmationTrackingData`, `EstimationTrackingData`, and `InternalReviewTrackingData`, distinguished by a `type` field. Tests verify each variant deserializes to the correct model:

- `type: confirmation` → `ConfirmationTrackingData` (status, type asserted)
- `type: estimation` → `EstimationTrackingData` (estimatedArrivalTime, type asserted)
- `type: internalReview` → `InternalReviewTrackingData` (status, reason, type asserted)

### Checkout — `PaymentResponse.action` (3 tests)

The `action` field on `PaymentResponse` is a `oneOf` wrapping multiple action types. Tests cover:

- Deserialize with `type: redirect` → `CheckoutRedirectAction` populated, others null
- Deserialize with `type: threeDS2` → `CheckoutThreeDS2Action` populated, others null
- Serialize with redirect action → verifies `type`, `paymentMethodType`, `method` round-trip correctly

### Checkout — `PaymentDetailsResponse.action` (3 tests)

The `action` field on `PaymentDetailsResponse` is typed directly as `CheckoutThreeDS2Action?`. Tests cover:

- Deserialize without action → `ResultCode: Authorised`, `Action` is null
- Deserialize with `type: threeDS2` → correct type, paymentMethodType, token asserted
- Serialize with threeDS2 action → verifies `type` and `paymentMethodType` round-trip correctly

## How deserialization currently works

The current generated code does **not** use discriminator-based matching. It uses a **try-all-schemas** approach (`ClientUtils.TryDeserialize` on every `oneOf` variant) and returns the first one that successfully deserializes. This is functional but inefficient.

These tests pass with the current approach and will continue to pass once the discriminator-based code path is activated — which requires both the template fix in #1616 **and** the OpenAPI specs to include explicit `discriminator.mapping` entries.

## Tested scenarios

All 549 tests pass (0 failures).