### PR TITLE
Replace high-entropy test values with dummy placeholders

### DIFF
--- a/Adyen.Test/AcsWebhooks/AcsWebhooksTest.cs
+++ b/Adyen.Test/AcsWebhooks/AcsWebhooksTest.cs
@@ -138,7 +138,7 @@ namespace Adyen.Test.AcsWebhooks
         {
             // Arrange
             string json = "{ \"test\": \"value\" }";
-            string invalidHmacSignature = "Qz9S/0xpar1klkniKdshxpAhRKbiSAewPpWoxKefQA=";
+            string invalidHmacSignature = "invalid-hmac-signature";
 
             // Act
             bool isValid = _acsWebhooksHandler.IsValidHmacSignature(json, invalidHmacSignature);

--- a/Adyen.Test/Checkout/PaymentsTest.cs
+++ b/Adyen.Test/Checkout/PaymentsTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using Adyen.Core.Options;
 using Adyen.Checkout.Extensions;
 using Adyen.Checkout.Models;

--- a/Adyen.Test/Checkout/PaymentsTest.cs
+++ b/Adyen.Test/Checkout/PaymentsTest.cs
@@ -1,4 +1,4 @@
-using System.Net;
+﻿using System.Net;
 using Adyen.Core.Options;
 using Adyen.Checkout.Extensions;
 using Adyen.Checkout.Models;
@@ -84,7 +84,7 @@ namespace Adyen.Test.Checkout
         public async Task Given_CreateCheckoutSessionResponse_When_Deserialize_Returns_Not_Null()
         {
             // Arrange
-            string json = @"{""mode"": ""embedded"",""amount"": {""currency"": ""EUR"",""value"": 10000},""expiresAt"": ""2023-04-06T17:11:15+02:00"",""id"": ""CS0068299CB8DA273A"",""merchantAccount"": ""TestMerchantAccount"",""reference"": ""TestReference"",""returnUrl"": ""http://test-url.com"",""sessionData"": ""Ab02b4c0!BQABAgBoacRJuRbNM/typUKATopkZ3V+cINm0WTAvwl9uQJ2e8I00P2KFemlwp4nb1bOqqYh1zx48gDAHt0QDs2JTiQIqDQRizqopLFRk/wAJHFoCuam/GvOHflg9vwS3caHbkBToIolxcYcJoJheIN9o1fGmNIHZb9VrWfiKsXMgmYsSUifenayS2tkKCTquF7vguaAwk7q5ES1GDwzP/J2mChJGH04jGrVL4szPHGmznr897wIcFQyBSZe4Uifqoe0fpiIxZLNWadLMya6SnvQYNAQL1V6ti+7F4wHHyLwHWTCua993sttue70TE4918EV80HcAWx0LE1+uW6J5KBHCKdYNi9ESlGSZreRwLCpdNbmumB6MlyHZlz2umLiw0ZZJAEpdrwXA2NiyHzJDKDKfbAhd8uoTSACrbgwbrAXI1cvb1WjiOQjLn9MVW++fuJCq6vIeX+rUKMeltBAHMeBZyC54ndAucw9nS03uyckjphunE4tl4WTT475VkfUiyJCTT3S2IOVYS9V9M8pMQ1/GlDVNCLBJJfrYlVXoC8VX68QW1HERkhNYQbTgLQ9kI3cDeMP5d4TuUL3XR2Q6sNiOMdIPGDYQ9QFKFdOE3OQ5X9wxUYbX6j88wR2gRGJcS5agqFHOR1ZTNrjumOYrEkjL8ehFXEs/KluhURllfi0POUPGAwlUWBjDCZcKaeeR0kASnsia2V5IjoiQUYwQUFBMTAzQ0E1MzdFQUVEODdDMjRERDUzOTA5QjgwQTc4QTkyM0UzODIzRDY4REFDQzk0QjlGRjgzMDVEQyJ9E0Gs1T0RaO7NluuXP59fegcW6SQKq4BhC3ZzEKPm1vJuwAJ2gZUaicaXbRPW3IyadavKRlfGdFeAYt2B3ik8fGiK3ZkKU0CrZ0qL0IO5rrWrOg74HMnpxRAn1RhAHRHfGEk67FFPNjr0aLBJXSia7xZWiyKA+i4QU63roY2sxMI/q41mvJjRUz0rPKT3SbVDt1Of7K7BP8cmiboBkWexFBD/mkJyMOpYAOoFp/tKOUHTWZYcc1GpbyV1jInXVfEUhHROYCtS4p/xwF6DdT3bI0+HRU35/xNBTZH2yJN55u9i42Vb0ddCyhzOLZYQ3JVgglty6hLgVeQzuN4b2MoalhfTl11HsElJT1kB0mznVX8CL7UMTUp/2uSgL8DN6kB4owEZ45nWRxIR/2sCidMJ1tnSI1uSqkeqXRf1vat5qPq+BzpYE0Urn2ZZEmgJyb2u0ZLn2x1tfJyPtv+hqBoT7iqJ224dSbuB4HMT49YtcheUtR0jnrImJXm+M1TeIjWB3XWOScrNV8sWEJMAiIU="",""shopperLocale"": ""en-US""}";
+            string json = @"{""mode"": ""embedded"",""amount"": {""currency"": ""EUR"",""value"": 10000},""expiresAt"": ""2023-04-06T17:11:15+02:00"",""id"": ""CS0068299CB8DA273A"",""merchantAccount"": ""TestMerchantAccount"",""reference"": ""TestReference"",""returnUrl"": ""http://test-url.com"",""sessionData"": ""test-session-data"",""shopperLocale"": ""en-US""}";
             
             // Act
             CreateCheckoutSessionResponse response = JsonSerializer.Deserialize<CreateCheckoutSessionResponse>(json, _jsonSerializerOptionsProvider.Options);

--- a/Adyen.Test/LegalEntityManagement/PCIQuestionnaires/PCIQuestionnairesTest.cs
+++ b/Adyen.Test/LegalEntityManagement/PCIQuestionnaires/PCIQuestionnairesTest.cs
@@ -74,7 +74,7 @@ namespace Adyen.Test.LegalEntityManagement.PCIQuestionnaires
         public async Task GeneratePciQuestionnaireAsyncTest()
         {
             // Arrange
-            var json = "{\n  \"content\": \"JVBERi0xLjQKJcOkw7zDtsOfCjIgMCBv+f/ub0j6JPRX+E3EmC==\",\n  \"language\": \"fr\",\n  \"pciTemplateReferences\": [\n    \"PCIT-T7KC6VGL\",\n    \"PCIT-PKB6DKS4\"\n  ]\n}";
+            var json = "{\n  \"content\": \"dGVzdA==\",\n  \"language\": \"fr\",\n  \"pciTemplateReferences\": [\n    \"PCIT-T7KC6VGL\",\n    \"PCIT-PKB6DKS4\"\n  ]\n}";
             var legalEntityId = "LE123";
             var request = new GeneratePciDescriptionRequest();
 
@@ -111,7 +111,7 @@ namespace Adyen.Test.LegalEntityManagement.PCIQuestionnaires
         public async Task GetPciQuestionnaireAsyncTest()
         {
             // Arrange
-            var json = "{\n  \"content\": \"JVBERi0xLjQKJcOkw7zDtsOfCjIgMCBv+f/ub0j6JPRX+E3EmC==\",\n  \"createdAt\": \"2023-03-02T17:54:19.538365Z\",\n  \"id\": \"PCID422GZ22322565HHMH48CW63CPH\",\n  \"validUntil\": \"2024-03-01T17:54:19.538365Z\"\n}";
+            var json = "{\n  \"content\": \"dGVzdA==\",\n  \"createdAt\": \"2023-03-02T17:54:19.538365Z\",\n  \"id\": \"PCID422GZ22322565HHMH48CW63CPH\",\n  \"validUntil\": \"2024-03-01T17:54:19.538365Z\"\n}";
             var legalEntityId = "LE123";
             var pciId = "PCI123";
 

--- a/Adyen.Test/TokenizationWebhooks/TokenizationWebhooksTest.cs
+++ b/Adyen.Test/TokenizationWebhooks/TokenizationWebhooksTest.cs
@@ -138,7 +138,7 @@ namespace Adyen.Test.TokenizationWebhooks
         {
             // Arrange
             string json = "{ \"test\": \"value\" }";
-            string invalidHmacSignature = "Qz9S/0xpar1klkniKdshxpAhRKbiSAewPpWoxKefQA=";
+            string invalidHmacSignature = "invalid-hmac-signature";
 
             // Act
             bool isValid = _tokenizationWebhooksHandler.IsValidHmacSignature(json, invalidHmacSignature);

--- a/Adyen.Test/Webhooks/HmacValidatorTest.cs
+++ b/Adyen.Test/Webhooks/HmacValidatorTest.cs
@@ -118,7 +118,7 @@ namespace Adyen.Test.Webhooks
                         'cvcResult': '1 Matches',
                         'cvcResultRaw': 'M',
                         'expiryDate': '03/2030',
-                        'hmacSignature': 'CZErGCNQaSsxbaQfZaJlakqo7KPP+mIa8a+wx3yNs9A=',
+                        'hmacSignature': 'cyYGGNUYxRCIwmfET0zxNPQN/m9cKR6xNECwPzTfJIQ=',
                         'paymentMethod': 'visa',
                         'refusalReasonRaw': 'AUTHORISED',
                         'retry.attempt1.acquirer': 'TestPmmAcquirer',
@@ -148,7 +148,7 @@ namespace Adyen.Test.Webhooks
                 'success': 'true'
             }";
             NotificationRequestItem notificationRequestItem = JsonConvert.DeserializeObject<NotificationRequestItem>(jsonNotification);
-            bool isValidHmac = hmacValidator.IsValidHmac(notificationRequestItem, "74F490DD33F7327BAECC88B2947C011FC02D014A473AAA33A8EC93E4DC069174");
+            bool isValidHmac = hmacValidator.IsValidHmac(notificationRequestItem, "AABBCCDDEEFFAABBCCDDEEFFAABBCCDDEEFFAABBCCDDEEFFAABBCCDDEEFFAABB");
             Assert.IsTrue(isValidHmac);
         }
 

--- a/Adyen.Test/mocks/authorise-success-3d.json
+++ b/Adyen.Test/mocks/authorise-success-3d.json
@@ -82,6 +82,6 @@
   "pspReference": "7924836133944997",
   "resultCode": "RedirectShopper",
   "issuerUrl": "https://test.adyen.com/hpp/3d/validate.shtml",
-  "md": "qeQbxBB3pYYM+ggR0rXKb9Bdng0p0WRtFU206k+2+tpjnN/q2Jvlvr5GowN8bLHYuXa67otJ5LP10s0000ULw6tVLYFsQDR6JGL5+f7S3HajWtVe/q6LfZRce7x04Fo813aDftvSFW+hFmjTZWHu4guKZrC7GBUYnEmjcHrhMXQbLgC23asFr/Cg7FPMz7DAJBh2Frc/WluZ5/5DD6PN5XXGQvLOWxmVszT8rd0x05AiZTGq2evPWQTeB1qOkNxmA0KGEznTaXakHYpFAIN69GQOSnrx9Ys4f4/H9gechsdGGi/5jA3e0jeQvVJ5J74vAdD+0MRv1VyeX6g0CIupbgfm4L90zoWMBgG2SeeKRgc=",
-  "paRequest": "eNpVUttygjAQ/RXrB5CEi1xmzQwVZ+qDjGP1ucOEjFJK0BCK8PVNUGqbp3N2s5uzZwOHs+Q8eeeslZzCljdNduKzIl/OIz+03cBZEMcJXTcM/TmFXbznVwrfX000LSixsGUDmqgul+ycCUUhY9fXTUqJ7bjeAtCDQsXlJqEH3qhdVcXs2haSS0D3MIis4vQYf8Srl2irZQhVTx33RQlozAOrW6FkTz07ADQRaOUXPSt1iRDqus7K8p4Li9UVAmRSgJ7adq1BjW51K3KaDmWfJqch/VwP26HEaVJ6aRebswRkbkCeKU5tTHxMsDcjOHLDyHMBjXHIKqOBro/7GfEsjPW09whczEPxnRDPZP5GQFsuuWA9DX0zycSA3y610MNTbe0vBvSUvXozBjOlPXPtu8V+EGKNfGP1mDBdCm0MCXAwtjEEkClFjy2ix7Y1+vcLfgBLma8C"
+  "md": "test-md",
+  "paRequest": "test-pa-request"
 }

--- a/Adyen.Test/mocks/balanceplatform/BeginScaDeviceRegistrationResponse.json
+++ b/Adyen.Test/mocks/balanceplatform/BeginScaDeviceRegistrationResponse.json
@@ -4,5 +4,5 @@
     "name": "My Device",
     "type": "ios"
   },
-  "sdkInput": "eyJjaGFsbGVuZ2UiOiJVWEZaTURONGNXWjZUVFExUlhWV2JuaEJPVzVzTm05cVVEUktUbFZtZGtrPSJ9"
+  "sdkInput": "dGVzdA=="
 }

--- a/Adyen.Test/mocks/binlookup/get3dsavailability-success.json
+++ b/Adyen.Test/mocks/binlookup/get3dsavailability-success.json
@@ -1,16 +1,22 @@
 {
-  "dsPublicKeys": [{
-    "brand": "visa",
-    "directoryServerId": "F013371337",
-    "publicKey": "eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsIm4iOiI4VFBxZkFOWk4xSUEzcHFuMkdhUVZjZ1g4LUpWZ1Y0M2diWURtYmdTY0N5SkVSN3lPWEJqQmQyaTBEcVFBQWpVUVBXVUxZU1FsRFRKYm91bVB1aXVoeVMxUHN2NTM4UHBRRnEySkNaSERkaV85WThVZG9hbmlrU095c2NHQWtBVmJJWHA5cnVOSm1wTTBwZ0s5VGxJSWVHYlE3ZEJaR01OQVJLQXRKeTY3dVlvbVpXV0ZBbWpwM2d4SDVzNzdCR2xkaE9RUVlQTFdybDdyS0pLQlUwNm1tZlktUDNpazk5MmtPUTNEak02bHR2WmNvLThET2RCR0RKYmdWRGFmb29LUnVNd2NUTXhDdTRWYWpyNmQyZkppVXlqNUYzcVBrYng4WDl6a1c3UmlxVno2SU1qdE54NzZicmg3aU9Vd2JiWmoxYWF6VG1GQ2xEb0dyY2JxOV80Nnc9PSJ9"
-  }],
+  "dsPublicKeys": [
+    {
+      "brand": "visa",
+      "directoryServerId": "F013371337",
+      "publicKey": "test-public-key"
+    }
+  ],
   "threeDS1Supported": true,
-  "threeDS2CardRangeDetails": [{
-    "brandCode": "visa",
-    "endRange": "411111111111",
-    "startRange": "411111111111",
-    "threeDS2Versions": ["2.1.0"],
-    "threeDSMethodURL": "https://pal-test.adyen.com/threeds2simulator/acs/startMethod.shtml"
-  }],
+  "threeDS2CardRangeDetails": [
+    {
+      "brandCode": "visa",
+      "endRange": "411111111111",
+      "startRange": "411111111111",
+      "threeDS2Versions": [
+        "2.1.0"
+      ],
+      "threeDSMethodURL": "https://pal-test.adyen.com/threeds2simulator/acs/startMethod.shtml"
+    }
+  ],
   "threeDS2supported": true
 }

--- a/Adyen.Test/mocks/checkout/paymentResponse-3DS-ChallengeShopper.json
+++ b/Adyen.Test/mocks/checkout/paymentResponse-3DS-ChallengeShopper.json
@@ -1,7 +1,7 @@
 {
   "resultCode": "ChallengeShopper",
   "action": {
-    "paymentData": "Te1CMIy1vKQTYsSHZ+gRbFpQy4d4n2HLD3c2b7xKnRNpWzWPuI=",
+    "paymentData": "test-payment-data",
     "paymentMethodType": "scheme",
     "token": "S0zYWQ0MGEwMjU2MjEifQ==",
     "type": "threeDS2"
@@ -13,6 +13,6 @@
       "type": "text"
     }
   ],
-  "paymentData": "Te1CMIy1vKQTYsSHZ+gRbFpQy4d4n2HLD3c2b7xKnRNpWzWPuI="
+  "paymentData": "test-payment-data"
 }                                                 
                            

--- a/Adyen.Test/mocks/checkout/payments-3DS2-IdentifyShopper.json
+++ b/Adyen.Test/mocks/checkout/payments-3DS2-IdentifyShopper.json
@@ -1,11 +1,11 @@
 {
   "resultCode": "IdentifyShopper",
   "action": {
-    "paymentData": "Ab02b4c0!BQABAgCft+b7JYM9vj7s7aN+4uTZUPQla28bPGFb61rEEb7vjkvnjhAsxLc3Z/aWz+xfrOqjH+9qE6uRcrYbo1pOLhi/FudOw5VRD7IJw2Ta2OW6hD/f0dXxn1lRCCFnmZ62Bh/mDmDO4xitcPz/fFF1BMrw7JPbq6ou5Q53NPtODTXF/ekR75EJJWWKTv3+YPhQQSbwiZaMSlGpvLUNXFd4N3DwsPTWeSYFPvzGDqdwLg/zQ4evmk3aPGuZAnYAwQDvEecGZwWHY7yQVVaaugRKctcg6Oeg5+PDXBJFvQbDNLt/zQvfWX0LE0Y4a2cWmvQC2iyWFd6NhD5L9q4ATMHrzkOW6RX6tL3LLj0fQZHfycFqSxv8Xck0ZVfA43t0nMLsrCxtrV6+YZ9v7/ugSD9cl8R5mXc8uqHeh2/gs3Lr8I4I5ghv8bDKOe2INRYjoK28JayEHFnAklRAmch0orO4Eoy+rEszUHtdCQBkhzMVzZ5WCN3v1pigW0QndJvMVpIQbi4jS3EI0JMRTLn+N43qc6GV5XBLATv55brKhomjEXIp6dw8OekgYn1tuCWvsP5xAPk+gdrW+NnhZOnylApHj4eCC6MEd8lzBsqepaeVBh6g+7MvMcaMTESltRts0/5JS+fznR+3EUvCiwMmxBv2CZlJ3AWOCk1x0H69URfpMETfgCl4UhDPV3BHkuHbiIOiEugNPEfcOa8ltgeJ+xoJWwLD5GnFbkP/gKEIM0mSyZ8ONCqH3it3oL/An4mj2xA3oKESF6Xj9LeMjSYr3O9MYUHgG34EmwkML6owVqMVeGHlrXX7X/rcdB4Bk08H87y+CnYWP/HqWt7thMQGdUg4+eQdhq2KHom1V4KAAalj6IUj77IOQOigglccfS2JUzCfPg==",
+    "paymentData": "test-payment-data",
     "paymentMethodType": "scheme",
-    "authorisationToken": "FadZt...uj71dICJdsasouPQm3rpLYA/tT16looMfYRqeMVdsjHKUqy0ChUmkDw/Luzp1Oze4/bCI=",
+    "authorisationToken": "test-authorisation-token",
     "subtype": "fingerprint",
-    "token": "dmVyVHJhbnNJRCI6Im...JkNjI5NmU3LTllM2ItNGIxNi04Y2I1LTlkOTNkM2U2NjhhYSJ9",
+    "token": "test-token",
     "type": "threeDS2"
   }
 }


### PR DESCRIPTION
## Description
Replace high-entropy strings in test fixtures and test files with obviously dummy placeholder values to eliminate false-positive alerts from automated secret scanners (VAST).

No production code was changed. All 540 unit tests pass.

## Changes
- `mocks/checkout/payments-3DS2-IdentifyShopper.json` — `paymentData`, `authorisationToken`, `token`
- `mocks/checkout/paymentResponse-3DS-ChallengeShopper.json` — `paymentData`
- `mocks/binlookup/get3dsavailability-success.json` — `publicKey`
- `mocks/authorise-success-3d.json` — `md`, `paRequest`
- `mocks/balanceplatform/BeginScaDeviceRegistrationResponse.json` — `sdkInput`
- `Webhooks/HmacValidatorTest.cs` — replaced hex HMAC key with clearly patterned dummy; recomputed matching signature
- `LegalEntityManagement/PCIQuestionnaires/PCIQuestionnairesTest.cs` — PDF content blob
- `Checkout/PaymentsTest.cs` — `sessionData` blob
- `AcsWebhooks/AcsWebhooksTest.cs` — `invalidHmacSignature`
- `TokenizationWebhooks/TokenizationWebhooksTest.cs` — `invalidHmacSignature`

## Tested scenarios
- All 540 unit tests pass

