### PR TITLE
Security: scope release workflow permissions and restrict pull_request trigger to merged PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,15 @@ on:
       - main
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Prepare the next main release


### PR DESCRIPTION
## Description
Addresses security issue: over-privileged token and risky trigger in `.github/workflows/release.yml`.

**Changes:**
- Set workflow-level `permissions` to `contents: read` (least-privilege default)
- Move `contents: write` and `pull-requests: write` to the job level, where they are actually needed by `release-automation-action`
- Add `if` condition to the job so it only executes on `workflow_dispatch` or when a PR is actually **merged** (not just closed), eliminating the risk of the job running for closed-but-unmerged PRs that could contain attacker-controlled workflow modifications

## Tested scenarios
- Workflow YAML validated (syntax check)
- Logic: `workflow_dispatch` continues to work; `pull_request: closed` events on unmerged PRs no longer trigger the job

