### PR TITLE
Fix SONAR_TOKEN secret exposed via command-line argument

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -45,6 +45,6 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         shell: powershell
         run: |
-          .\.sonar\scanner\dotnet-sonarscanner begin /k:"Adyen_adyen-dotnet-api-library" /o:"adyen" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
+          .\.sonar\scanner\dotnet-sonarscanner begin /k:"Adyen_adyen-dotnet-api-library" /o:"adyen" /d:sonar.host.url="https://sonarcloud.io"
           dotnet build
-          .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
+          .\.sonar\scanner\dotnet-sonarscanner end


### PR DESCRIPTION
## Description
Remove `SONAR_TOKEN` from command-line arguments in `.github/workflows/sonarcloud.yml`. The secret was being passed as `/d:sonar.token="..."` to both `dotnet-sonarscanner begin` and `end`, which can expose it in verbose build logs or via process inspection. The `SONAR_TOKEN` env var is already set and is picked up automatically by the scanner.

## Tested scenarios
- `dotnet build` passes with 0 errors

## Fixed issue
Fixes VAST-935