### PR TITLE
test: add TransferFundsAsync 202 response test and use TryDeserialize methods

### DIFF
--- a/Adyen.Test/Transfers/TransfersServiceTest.cs
+++ b/Adyen.Test/Transfers/TransfersServiceTest.cs
@@ -53,9 +53,61 @@ namespace Adyen.Test.Transfers
             var response = await transfersService.TransferFundsAsync(transferInfo);
 
             // Assert - response
-            Assert.IsTrue(response.IsOk);
+            Assert.IsTrue(response.TryDeserializeOkResponse(out var transfer));
             Assert.IsFalse(response.IsAccepted);
-            var transfer = response.Ok();
+            Assert.IsNotNull(transfer);
+            Assert.AreEqual("1W1UG35U8A9J5ZLG", transfer.Id);
+            Assert.AreEqual(Transfer.StatusEnum.Authorised, transfer.Status);
+            Assert.AreEqual(Transfer.CategoryEnum.Bank, transfer.Category);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Post, capturedRequest.Method);
+            Assert.IsNotNull(capturedRequest.RequestUri);
+            Assert.AreEqual("/btl/v4/transfers", capturedRequest.RequestUri.AbsolutePath);
+        }
+
+        [TestMethod]
+        public async Task TransferFundsAsync_Returns202Accepted_WithCorrectVerbAndPath()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/transfers/transfer-funds.json");
+
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.Accepted)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigureTransfers((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddTransfersService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var transfersService = testHost.Services.GetRequiredService<ITransfersService>();
+            var transferInfo = new TransferInfo
+            {
+                Amount = new Amount { Currency = "EUR", Value = 110000 },
+                Category = TransferInfo.CategoryEnum.Bank,
+                Counterparty = new CounterpartyInfoV3()
+            };
+
+            // Act
+            var response = await transfersService.TransferFundsAsync(transferInfo);
+
+            // Assert - response
+            Assert.IsFalse(response.IsOk);
+            Assert.IsTrue(response.TryDeserializeAcceptedResponse(out var transfer));
             Assert.IsNotNull(transfer);
             Assert.AreEqual("1W1UG35U8A9J5ZLG", transfer.Id);
             Assert.AreEqual(Transfer.StatusEnum.Authorised, transfer.Status);


### PR DESCRIPTION
This PR adds a test case for the 202 Accepted response in TransferFundsAsync and updates the existing test case to use the TryDeserializeOkResponse and TryDeserializeAcceptedResponse methods for better verification.