### PR TITLE
feat: add AmountUtil for currency minor units conversion

### DIFF
--- a/Adyen.Test/Core/Utilities/AmountUtilTest.cs
+++ b/Adyen.Test/Core/Utilities/AmountUtilTest.cs
@@ -33,6 +33,10 @@ namespace Adyen.Test.Core.Utilities
             // Unknown currency code (should default to 2 decimals)
             Assert.AreEqual(1234L, AmountUtil.AmountToMinorUnits(12.34m, "XXX"));
 
+            // Case-insensitivity and trimming
+            Assert.AreEqual(1234L, AmountUtil.AmountToMinorUnits(12.34m, "eur"));
+            Assert.AreEqual(1234L, AmountUtil.AmountToMinorUnits(12.34m, " EUR "));
+
             // Large magnitudes
             Assert.AreEqual(100000000000L, AmountUtil.AmountToMinorUnits(1000000000.00m, "EUR"));
             Assert.AreEqual(-100000000000L, AmountUtil.AmountToMinorUnits(-1000000000.00m, "EUR"));
@@ -81,6 +85,9 @@ namespace Adyen.Test.Core.Utilities
             // Adyen deviations
             Assert.AreEqual(12.34m, AmountUtil.MinorUnitsToAmount(1234L, "CLP"));
             Assert.AreEqual(12.34m, AmountUtil.MinorUnitsToAmount(1234L, "ISK"));
+
+            // Case-insensitivity
+            Assert.AreEqual(12.34m, AmountUtil.MinorUnitsToAmount(1234L, "eur"));
             
             // Zero amounts
             Assert.AreEqual(0m, AmountUtil.MinorUnitsToAmount(0L, "EUR"));

--- a/Adyen.Test/Core/Utilities/AmountUtilTest.cs
+++ b/Adyen.Test/Core/Utilities/AmountUtilTest.cs
@@ -1,0 +1,135 @@
+using Adyen.Core.Utilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Adyen.Test.Core.Utilities
+{
+    [TestClass]
+    public class AmountUtilTest
+    {
+        [TestMethod]
+        public void AmountToMinorUnitsTest()
+        {
+            // Regular currencies (2 decimals)
+            Assert.AreEqual(1234L, AmountUtil.AmountToMinorUnits(12.34m, "EUR"));
+            Assert.AreEqual(1234L, AmountUtil.AmountToMinorUnits(12.34m, "GBP"));
+            Assert.AreEqual(1234L, AmountUtil.AmountToMinorUnits(12.34m, "USD"));
+            
+            // 0-decimal currencies
+            Assert.AreEqual(1234L, AmountUtil.AmountToMinorUnits(1234m, "JPY"));
+            Assert.AreEqual(1234L, AmountUtil.AmountToMinorUnits(1234m, "IDR"));
+            Assert.AreEqual(1234L, AmountUtil.AmountToMinorUnits(1234m, "CVE"));
+            
+            // 3-decimal currencies
+            Assert.AreEqual(12345L, AmountUtil.AmountToMinorUnits(12.345m, "BHD"));
+            
+            // Adyen deviations (CLP and ISK are 2 decimals in Adyen)
+            Assert.AreEqual(1234L, AmountUtil.AmountToMinorUnits(12.34m, "CLP"));
+            Assert.AreEqual(1234L, AmountUtil.AmountToMinorUnits(12.34m, "ISK"));
+            
+            // Zero amounts
+            Assert.AreEqual(0L, AmountUtil.AmountToMinorUnits(0m, "EUR"));
+            Assert.AreEqual(0L, AmountUtil.AmountToMinorUnits(0m, "JPY"));
+            
+            // Unknown currency code (should default to 2 decimals)
+            Assert.AreEqual(1234L, AmountUtil.AmountToMinorUnits(12.34m, "XXX"));
+
+            // Large magnitudes
+            Assert.AreEqual(100000000000L, AmountUtil.AmountToMinorUnits(1000000000.00m, "EUR"));
+            Assert.AreEqual(-100000000000L, AmountUtil.AmountToMinorUnits(-1000000000.00m, "EUR"));
+
+            // Null input
+            Assert.IsNull(AmountUtil.AmountToMinorUnits(null, "EUR"));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(System.ArgumentException))]
+        public void AmountToMinorUnitsNullCurrencyTest()
+        {
+            AmountUtil.AmountToMinorUnits(10.00m, null);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(System.ArgumentException))]
+        public void AmountToMinorUnitsEmptyCurrencyTest()
+        {
+            AmountUtil.AmountToMinorUnits(10.00m, "");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(System.ArgumentException))]
+        public void AmountToMinorUnitsWhitespaceCurrencyTest()
+        {
+            AmountUtil.AmountToMinorUnits(10.00m, " ");
+        }
+
+        [TestMethod]
+        public void MinorUnitsToAmountTest()
+        {
+            // Regular currencies (2 decimals)
+            Assert.AreEqual(12.34m, AmountUtil.MinorUnitsToAmount(1234L, "EUR"));
+            Assert.AreEqual(12.34m, AmountUtil.MinorUnitsToAmount(1234L, "GBP"));
+            Assert.AreEqual(12.34m, AmountUtil.MinorUnitsToAmount(1234L, "USD"));
+            
+            // 0-decimal currencies
+            Assert.AreEqual(1234m, AmountUtil.MinorUnitsToAmount(1234L, "JPY"));
+            Assert.AreEqual(1234m, AmountUtil.MinorUnitsToAmount(1234L, "IDR"));
+            Assert.AreEqual(1234m, AmountUtil.MinorUnitsToAmount(1234L, "CVE"));
+            
+            // 3-decimal currencies
+            Assert.AreEqual(12.345m, AmountUtil.MinorUnitsToAmount(12345L, "BHD"));
+            
+            // Adyen deviations
+            Assert.AreEqual(12.34m, AmountUtil.MinorUnitsToAmount(1234L, "CLP"));
+            Assert.AreEqual(12.34m, AmountUtil.MinorUnitsToAmount(1234L, "ISK"));
+            
+            // Zero amounts
+            Assert.AreEqual(0m, AmountUtil.MinorUnitsToAmount(0L, "EUR"));
+
+            // Large magnitudes
+            Assert.AreEqual(1000000000.00m, AmountUtil.MinorUnitsToAmount(100000000000L, "EUR"));
+
+            // Null input
+            Assert.IsNull(AmountUtil.MinorUnitsToAmount(null, "EUR"));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(System.ArgumentException))]
+        public void MinorUnitsToAmountNullCurrencyTest()
+        {
+            AmountUtil.MinorUnitsToAmount(1000L, null);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(System.ArgumentException))]
+        public void MinorUnitsToAmountEmptyCurrencyTest()
+        {
+            AmountUtil.MinorUnitsToAmount(1000L, "");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(System.ArgumentException))]
+        public void MinorUnitsToAmountWhitespaceCurrencyTest()
+        {
+            AmountUtil.MinorUnitsToAmount(1000L, " ");
+        }
+        
+        [TestMethod]
+        public void RoundingTest()
+        {
+            // banker's rounding (MidpointRounding.ToEven)
+            Assert.AreEqual(1234L, AmountUtil.AmountToMinorUnits(12.345m, "EUR"));
+            Assert.AreEqual(1234L, AmountUtil.AmountToMinorUnits(12.335m, "EUR"));
+            Assert.AreEqual(1234L, AmountUtil.AmountToMinorUnits(12.344m, "EUR"));
+            
+            Assert.AreEqual(-1234L, AmountUtil.AmountToMinorUnits(-12.345m, "EUR"));
+            Assert.AreEqual(-1234L, AmountUtil.AmountToMinorUnits(-12.335m, "EUR"));
+            Assert.AreEqual(-1234L, AmountUtil.AmountToMinorUnits(-12.344m, "EUR"));
+
+            // Edge cases for rounding
+            Assert.AreEqual(0L, AmountUtil.AmountToMinorUnits(0.005m, "EUR"));
+            Assert.AreEqual(0L, AmountUtil.AmountToMinorUnits(0.004m, "EUR"));
+            Assert.AreEqual(0L, AmountUtil.AmountToMinorUnits(-0.005m, "EUR"));
+            Assert.AreEqual(0L, AmountUtil.AmountToMinorUnits(-0.004m, "EUR"));
+        }
+    }
+}

--- a/Adyen/Core/Utilities/AmountUtil.cs
+++ b/Adyen/Core/Utilities/AmountUtil.cs
@@ -1,0 +1,107 @@
+using System;
+
+namespace Adyen.Core.Utilities
+{
+    /// <summary>
+    /// Utility class to help with currency minor units conversion.
+    /// </summary>
+    public static class AmountUtil
+    {
+        /// <summary>
+        /// Converts a decimal amount to minor units (long) for the given currency code.
+        /// </summary>
+        /// <param name="amount">The decimal amount (e.g., 10.50).</param>
+        /// <param name="currencyCode">The currency code (e.g., "EUR").</param>
+        /// <returns>The amount in minor units (e.g., 1050).</returns>
+        public static long? AmountToMinorUnits(decimal? amount, string currencyCode)
+        {
+            if (amount == null)
+            {
+                return null;
+            }
+
+            if (string.IsNullOrWhiteSpace(currencyCode))
+            {
+                throw new ArgumentException("Currency code cannot be null or empty.", nameof(currencyCode));
+            }
+            
+            int decimals = GetDecimals(currencyCode);
+            decimal multiplier = GetPowerOfTen(decimals);
+            return (long)Math.Round(amount.Value * multiplier, MidpointRounding.ToEven);
+        }
+
+        /// <summary>
+        /// Converts an amount in minor units (long) to a decimal amount for the given currency code.
+        /// </summary>
+        /// <param name="minorUnits">The amount in minor units (e.g., 1050).</param>
+        /// <param name="currencyCode">The currency code (e.g., "EUR").</param>
+        /// <returns>The decimal amount (e.g., 10.50).</returns>
+        public static decimal? MinorUnitsToAmount(long? minorUnits, string currencyCode)
+        {
+            if (minorUnits == null)
+            {
+                return null;
+            }
+
+            if (string.IsNullOrWhiteSpace(currencyCode))
+            {
+                throw new ArgumentException("Currency code cannot be null or empty.", nameof(currencyCode));
+            }
+            
+            int decimals = GetDecimals(currencyCode);
+            decimal divisor = GetPowerOfTen(decimals);
+            return minorUnits.Value / divisor;
+        }
+
+        /// <summary>
+        /// Returns 10^decimals using pure decimal arithmetic.
+        /// </summary>
+        private static decimal GetPowerOfTen(int decimals)
+        {
+            decimal result = 1m;
+            for (int i = 0; i < decimals; i++)
+            {
+                result *= 10m;
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Returns the number of decimals for a given currency code based on Adyen's specific decimal rules.
+        /// </summary>
+        /// <param name="currencyCode">The currency code.</param>
+        /// <returns>The number of decimals.</returns>
+        private static int GetDecimals(string currencyCode)
+        {
+            switch (currencyCode)
+            {
+                case "CVE":
+                case "DJF":
+                case "GNF":
+                case "IDR":
+                case "JPY":
+                case "KMF":
+                case "KRW":
+                case "PYG":
+                case "RWF":
+                case "UGX":
+                case "VND":
+                case "VUV":
+                case "XAF":
+                case "XOF":
+                case "XPF":
+                    return 0;
+                case "BHD":
+                case "IQD":
+                case "JOD":
+                case "KWD":
+                case "LYD":
+                case "OMR":
+                case "TND":
+                    return 3;
+                default:
+                    return 2;
+            }
+        }
+    }
+}

--- a/Adyen/Core/Utilities/AmountUtil.cs
+++ b/Adyen/Core/Utilities/AmountUtil.cs
@@ -24,8 +24,9 @@ namespace Adyen.Core.Utilities
             {
                 throw new ArgumentException("Currency code cannot be null or empty.", nameof(currencyCode));
             }
-            
-            int decimals = GetDecimals(currencyCode);
+
+            string code = currencyCode.Trim().ToUpperInvariant();
+            int decimals = GetDecimals(code);
             decimal multiplier = GetPowerOfTen(decimals);
             return (long)Math.Round(amount.Value * multiplier, MidpointRounding.ToEven);
         }
@@ -47,8 +48,9 @@ namespace Adyen.Core.Utilities
             {
                 throw new ArgumentException("Currency code cannot be null or empty.", nameof(currencyCode));
             }
-            
-            int decimals = GetDecimals(currencyCode);
+
+            string code = currencyCode.Trim().ToUpperInvariant();
+            int decimals = GetDecimals(code);
             decimal divisor = GetPowerOfTen(decimals);
             return minorUnits.Value / divisor;
         }
@@ -58,12 +60,22 @@ namespace Adyen.Core.Utilities
         /// </summary>
         private static decimal GetPowerOfTen(int decimals)
         {
-            decimal result = 1m;
-            for (int i = 0; i < decimals; i++)
+            switch (decimals)
             {
-                result *= 10m;
+                case 0:
+                    return 1m;
+                case 2:
+                    return 100m;
+                case 3:
+                    return 1000m;
+                default:
+                    decimal result = 1m;
+                    for (int i = 0; i < decimals; i++)
+                    {
+                        result *= 10m;
+                    }
+                    return result;
             }
-            return result;
         }
 
         /// <summary>

--- a/README.md
+++ b/README.md
@@ -116,15 +116,20 @@ var response = await paymentsService.PaymentsAsync(request, new RequestOptions()
 ```
 
 ### Working with amounts
-Adyen APIs work with minor units (e.g., 1000 for 10.00 EUR). The library provides an `AmountUtil` class to help you convert decimal amounts to minor units and vice versa, according to [Adyen's specific currency rules](https://docs.adyen.com/development-resources/currency-codes).
+Adyen APIs work with minor units (e.g., 1000 for 10.00 EUR). The library provides an `AmountUtil` class to help you convert decimal amounts to minor units and vice versa, according to [Adyen's specific currency rules](https://docs.adyen.com/development-resources/currency-codes). 
+
+The utility uses **banker's rounding** (`MidpointRounding.ToEven`) and is robust against case-sensitivity or whitespace in currency codes.
 
 ```csharp
 using Adyen.Core.Utilities;
 
 // Convert decimal amount to minor units (long)
 long? minorUnits = AmountUtil.AmountToMinorUnits(12.34m, "EUR"); // Returns 1234
-long? jpyMinorUnits = AmountUtil.AmountToMinorUnits(1234m, "JPY"); // Returns 1234 (0 decimals)
+long? jpyMinorUnits = AmountUtil.AmountToMinorUnits(1234m, "jpy"); // Returns 1234 (0 decimals, case-insensitive)
 long? bhdMinorUnits = AmountUtil.AmountToMinorUnits(12.345m, "BHD"); // Returns 12345 (3 decimals)
+
+// Example of banker's rounding (MidpointRounding.ToEven)
+long? rounded = AmountUtil.AmountToMinorUnits(12.345m, "EUR"); // Returns 1234
 
 // Convert minor units (long) to decimal amount
 decimal? amount = AmountUtil.MinorUnitsToAmount(1234L, "EUR"); // Returns 12.34

--- a/README.md
+++ b/README.md
@@ -114,6 +114,22 @@ Use the `RequestOptions` object to pass additional headers like the IdempotencyK
 ```csharp
 var response = await paymentsService.PaymentsAsync(request, new RequestOptions().AddIdempotencyKey(Guid.NewGuid().ToString()));
 ```
+
+### Working with amounts
+Adyen APIs work with minor units (e.g., 1000 for 10.00 EUR). The library provides an `AmountUtil` class to help you convert decimal amounts to minor units and vice versa, according to [Adyen's specific currency rules](https://docs.adyen.com/development-resources/currency-codes).
+
+```csharp
+using Adyen.Core.Utilities;
+
+// Convert decimal amount to minor units (long)
+long? minorUnits = AmountUtil.AmountToMinorUnits(12.34m, "EUR"); // Returns 1234
+long? jpyMinorUnits = AmountUtil.AmountToMinorUnits(1234m, "JPY"); // Returns 1234 (0 decimals)
+long? bhdMinorUnits = AmountUtil.AmountToMinorUnits(12.345m, "BHD"); // Returns 12345 (3 decimals)
+
+// Convert minor units (long) to decimal amount
+decimal? amount = AmountUtil.MinorUnitsToAmount(1234L, "EUR"); // Returns 12.34
+```
+
 ### Serializing and Deserializing JSON Strings
 The library uses custom JSON converters for all model types (handling oneOf polymorphism, optional-field omission, enum mapping, etc.). These converters are registered in the `JsonSerializerOptionsProvider` that is set up by the DI host. **Always pass `jsonSerializerOptionsProvider.Options` when calling `JsonSerializer.Serialize` or `JsonSerializer.Deserialize`** — using the default options will produce incorrect JSON (e.g. nested action wrappers, unexpected null fields).
 


### PR DESCRIPTION
## Description
Provides an `AmountUtil` class with helper functions to convert decimal amounts into minor units (long) for the Adyen API, and vice versa. 

The conversion:
- Respects Adyen's specific decimal rules (including deviations like CLP, ISK).
- Uses pure decimal arithmetic to avoid precision loss.
- Uses banker's rounding (`MidpointRounding.ToEven`) for financial accuracy.
- Validates inputs (`currencyCode` must not be null/empty/whitespace).

## Changes
- Created `Adyen/Core/Utilities/AmountUtil.cs`.
- Created `Adyen.Test/Core/Utilities/AmountUtilTest.cs` with comprehensive tests.
- Updated `README.md` with usage instructions.

Closes #1422