### PR TITLE
test: add tests for oneOf unknown type deserialization

### DIFF
--- a/Adyen.Test/Checkout/PaymentsTest.cs
+++ b/Adyen.Test/Checkout/PaymentsTest.cs
@@ -1237,7 +1237,7 @@ namespace Adyen.Test.Checkout
         public void Given_CheckoutPaymentMethod_With_Unknown_Type_When_Deserialized_Then_Throws_JsonException()
         {
             // Arrange
-            string json = "{\"type\":\"unknown_payment_method\",\"someField\":\"someValue\"}";
+            string json = @"{""type"":""unknown_payment_method"",""someField"":""someValue""}";
 
             // Act & Assert
             Assert.ThrowsException<JsonException>(() =>
@@ -1250,7 +1250,7 @@ namespace Adyen.Test.Checkout
         public void Given_PaymentResponseAction_With_Unknown_Type_When_Deserialized_Then_Throws_JsonException()
         {
             // Arrange
-            string json = "{\"type\":\"unknown_action\",\"url\":\"https://example.com\"}";
+            string json = @"{""type"":""unknown_action"",""url"":""https://example.com""}";
 
             // Act & Assert
             Assert.ThrowsException<JsonException>(() =>

--- a/Adyen.Test/Checkout/PaymentsTest.cs
+++ b/Adyen.Test/Checkout/PaymentsTest.cs
@@ -1230,5 +1230,35 @@ namespace Adyen.Test.Checkout
         }
 
         #endregion
+
+        #region oneOf unknown type
+
+        [TestMethod]
+        public void Given_CheckoutPaymentMethod_With_Unknown_Type_When_Deserialized_Then_Throws_JsonException()
+        {
+            // Arrange
+            string json = "{\"type\":\"unknown_payment_method\",\"someField\":\"someValue\"}";
+
+            // Act & Assert
+            Assert.ThrowsException<JsonException>(() =>
+            {
+                JsonSerializer.Deserialize<CheckoutPaymentMethod>(json, _jsonSerializerOptionsProvider.Options);
+            });
+        }
+
+        [TestMethod]
+        public void Given_PaymentResponseAction_With_Unknown_Type_When_Deserialized_Then_Throws_JsonException()
+        {
+            // Arrange
+            string json = "{\"type\":\"unknown_action\",\"url\":\"https://example.com\"}";
+
+            // Act & Assert
+            Assert.ThrowsException<JsonException>(() =>
+            {
+                JsonSerializer.Deserialize<PaymentResponseAction>(json, _jsonSerializerOptionsProvider.Options);
+            });
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Confirmed that oneOf models (composition) throw JsonException when an unknown type is encountered. Added tests for CheckoutPaymentMethod and PaymentResponseAction to verify this behavior.