### PR TITLE
Fix missing X-API-Key header in PaymentsAppService

### DIFF
--- a/Adyen.Test/PaymentsApp/PaymentsAppServiceTest.cs
+++ b/Adyen.Test/PaymentsApp/PaymentsAppServiceTest.cs
@@ -1,18 +1,22 @@
+using System.Linq;
+using System.Net;
+using System.Text;
+using Adyen.Core;
 using Adyen.Core.Options;
-using Adyen.PaymentsApp.Client;
-using Adyen.PaymentsApp.Models;
 using Adyen.PaymentsApp.Extensions;
+using Adyen.PaymentsApp.Models;
+using Adyen.PaymentsApp.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Text.Json;
-using Adyen.PaymentsApp.Services;
 
 namespace Adyen.Test.PaymentsApp
 {
     [TestClass]
-    public class PaymentsAppTest
+    public class PaymentsAppServiceTest
     {
+        #region URL verification
+
         [TestMethod]
         public async Task Given_PaymentsAppService_When_Initialized_Result_Should_Return_Management_Test_Url()
         {
@@ -25,17 +29,16 @@ namespace Adyen.Test.PaymentsApp
                     {
                         options.Environment = AdyenEnvironment.Test;
                     });
-
                     services.AddPaymentsAppService();
                 })
                 .Build();
-            
+
             var paymentsAppService = testHost.Services.GetRequiredService<IPaymentsAppService>();
-            
+
             // Assert
             Assert.AreEqual("https://management-test.adyen.com/v1", paymentsAppService.HttpClient.BaseAddress.ToString());
         }
-        
+
         [TestMethod]
         public void Given_PaymentsAppService_When_Initialized_Result_Should_Return_Management_Live_Url()
         {
@@ -48,17 +51,16 @@ namespace Adyen.Test.PaymentsApp
                     {
                         options.Environment = AdyenEnvironment.Live;
                     });
-
                     services.AddPaymentsAppService();
                 })
                 .Build();
-            
+
             var paymentsAppService = testHost.Services.GetRequiredService<IPaymentsAppService>();
-            
+
             // Assert
             Assert.AreEqual("https://management-live.adyen.com/v1", paymentsAppService.HttpClient.BaseAddress.ToString());
         }
-        
+
         [TestMethod]
         public void Given_PaymentsAppService_When_Initialized_Result_Should_Return_Management_Live_Url_And_No_Prefix()
         {
@@ -72,15 +74,538 @@ namespace Adyen.Test.PaymentsApp
                         options.Environment = AdyenEnvironment.Live;
                         options.LiveEndpointUrlPrefix = "prefix";
                     });
-                    
                     services.AddPaymentsAppService();
                 })
                 .Build();
-            
+
             var paymentsAppService = testHost.Services.GetRequiredService<IPaymentsAppService>();
-            
+
             // Assert
             Assert.AreEqual("https://management-live.adyen.com/v1", paymentsAppService.HttpClient.BaseAddress.ToString());
+        }
+
+        #endregion
+
+        #region GeneratePaymentsAppBoardingTokenForMerchantAsync
+
+        [TestMethod]
+        public async Task GeneratePaymentsAppBoardingTokenForMerchantAsync_Returns200Ok_WithCorrectVerbAndPath()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/paymentsapp/boarding-token-response-merchant.json");
+
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigurePaymentsApp((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddPaymentsAppService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var paymentsAppService = testHost.Services.GetRequiredService<IPaymentsAppService>();
+            var boardingRequest = new BoardingTokenRequest
+            {
+                BoardingRequestToken = "test-boarding-token"
+            };
+
+            // Act
+            var response = await paymentsAppService.GeneratePaymentsAppBoardingTokenForMerchantAsync(
+                "TestMerchantAccount", boardingRequest);
+
+            // Assert - response
+            Assert.IsTrue(response.TryDeserializeOkResponse(out var boardingTokenResponse));
+            Assert.IsNotNull(boardingTokenResponse);
+            Assert.AreEqual("install-merchant-001", boardingTokenResponse.InstallationId);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Post, capturedRequest.Method);
+            Assert.IsNotNull(capturedRequest.RequestUri);
+            Assert.AreEqual("/v1/merchants/TestMerchantAccount/generatePaymentsAppBoardingToken", capturedRequest.RequestUri.AbsolutePath);
+        }
+
+        [TestMethod]
+        public async Task GeneratePaymentsAppBoardingTokenForMerchantAsync_Returns400BadRequest()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/paymentsapp/error-response-400.json");
+
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.BadRequest)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigurePaymentsApp((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddPaymentsAppService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var paymentsAppService = testHost.Services.GetRequiredService<IPaymentsAppService>();
+            var boardingRequest = new BoardingTokenRequest
+            {
+                BoardingRequestToken = "invalid-token"
+            };
+
+            // Act
+            var response = await paymentsAppService.GeneratePaymentsAppBoardingTokenForMerchantAsync(
+                "TestMerchantAccount", boardingRequest);
+
+            // Assert - response
+            Assert.IsFalse(response.IsOk);
+            Assert.IsTrue(response.IsBadRequest);
+            Assert.IsTrue(response.TryDeserializeBadRequestResponse(out var errorResponse));
+            Assert.IsNotNull(errorResponse);
+            Assert.AreEqual(400, errorResponse.Status);
+            Assert.AreEqual("Invalid request", errorResponse.Title);
+            Assert.AreEqual("PAYMENTAPP_001", errorResponse.ErrorCode);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Post, capturedRequest.Method);
+            Assert.IsNotNull(capturedRequest.RequestUri);
+            Assert.AreEqual("/v1/merchants/TestMerchantAccount/generatePaymentsAppBoardingToken", capturedRequest.RequestUri.AbsolutePath);
+        }
+
+        [TestMethod]
+        public async Task GeneratePaymentsAppBoardingTokenForMerchantAsync_ReturnsApiResponseOn500InternalServerError()
+        {
+            // Arrange
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.InternalServerError)
+                {
+                    Content = new StringContent("{}", Encoding.UTF8, "application/json")
+                };
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigurePaymentsApp((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddPaymentsAppService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var paymentsAppService = testHost.Services.GetRequiredService<IPaymentsAppService>();
+            var boardingRequest = new BoardingTokenRequest
+            {
+                BoardingRequestToken = "test-token"
+            };
+
+            // Act
+            var response = await paymentsAppService.GeneratePaymentsAppBoardingTokenForMerchantAsync(
+                "TestMerchantAccount", boardingRequest);
+
+            // Assert - response
+            Assert.AreEqual(500, (int)response.StatusCode);
+            Assert.IsTrue(response.IsInternalServerError);
+            Assert.IsTrue(response.TryDeserializeInternalServerErrorResponse(out var errorResponse));
+            Assert.IsNotNull(errorResponse);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Post, capturedRequest.Method);
+            Assert.IsNotNull(capturedRequest.RequestUri);
+            Assert.AreEqual("/v1/merchants/TestMerchantAccount/generatePaymentsAppBoardingToken", capturedRequest.RequestUri.AbsolutePath);
+        }
+
+        #endregion
+
+        #region GeneratePaymentsAppBoardingTokenForStoreAsync
+
+        [TestMethod]
+        public async Task GeneratePaymentsAppBoardingTokenForStoreAsync_Returns200Ok_WithCorrectVerbAndPath()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/paymentsapp/boarding-token-response-store.json");
+
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigurePaymentsApp((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddPaymentsAppService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var paymentsAppService = testHost.Services.GetRequiredService<IPaymentsAppService>();
+            var boardingRequest = new BoardingTokenRequest
+            {
+                BoardingRequestToken = "store-boarding-token"
+            };
+
+            // Act
+            var response = await paymentsAppService.GeneratePaymentsAppBoardingTokenForStoreAsync(
+                "TestMerchantAccount", "TestStore", boardingRequest);
+
+            // Assert - response
+            Assert.IsTrue(response.TryDeserializeOkResponse(out var boardingTokenResponse));
+            Assert.IsNotNull(boardingTokenResponse);
+            Assert.AreEqual("install-store-001", boardingTokenResponse.InstallationId);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Post, capturedRequest.Method);
+            Assert.IsNotNull(capturedRequest.RequestUri);
+            Assert.AreEqual("/v1/merchants/TestMerchantAccount/stores/TestStore/generatePaymentsAppBoardingToken", capturedRequest.RequestUri.AbsolutePath);
+        }
+
+        #endregion
+
+        #region ListPaymentsAppForMerchantAsync
+
+        [TestMethod]
+        public async Task ListPaymentsAppForMerchantAsync_Returns200Ok_WithCorrectVerbAndPath()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/paymentsapp/list-payments-apps-merchant.json");
+
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigurePaymentsApp((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddPaymentsAppService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var paymentsAppService = testHost.Services.GetRequiredService<IPaymentsAppService>();
+
+            // Act
+            var response = await paymentsAppService.ListPaymentsAppForMerchantAsync("TestMerchantAccount");
+
+            // Assert - response
+            Assert.IsTrue(response.TryDeserializeOkResponse(out var listResponse));
+            Assert.IsNotNull(listResponse);
+            Assert.AreEqual(3, listResponse.PaymentsApps.Count);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Get, capturedRequest.Method);
+            Assert.IsNotNull(capturedRequest.RequestUri);
+            Assert.AreEqual("/v1/merchants/TestMerchantAccount/paymentsApps", capturedRequest.RequestUri.AbsolutePath);
+        }
+
+        [TestMethod]
+        public async Task ListPaymentsAppForMerchantAsync_WithStatusFilter_Returns200Ok()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/paymentsapp/list-payments-apps-merchant.json");
+
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigurePaymentsApp((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddPaymentsAppService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var paymentsAppService = testHost.Services.GetRequiredService<IPaymentsAppService>();
+
+            // Act
+            var response = await paymentsAppService.ListPaymentsAppForMerchantAsync(
+                "TestMerchantAccount", statuses: new Option<string>("BOARDED"));
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Get, capturedRequest.Method);
+            Assert.IsNotNull(capturedRequest.RequestUri);
+            Assert.AreEqual("/v1/merchants/TestMerchantAccount/paymentsApps", capturedRequest.RequestUri.AbsolutePath);
+            Assert.IsTrue(capturedRequest.RequestUri!.Query.Contains("statuses=BOARDED"));
+        }
+
+        [TestMethod]
+        public async Task ListPaymentsAppForMerchantAsync_WithPagination_Returns200Ok()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/paymentsapp/list-payments-apps-merchant.json");
+
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigurePaymentsApp((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddPaymentsAppService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var paymentsAppService = testHost.Services.GetRequiredService<IPaymentsAppService>();
+
+            // Act
+            var response = await paymentsAppService.ListPaymentsAppForMerchantAsync(
+                "TestMerchantAccount",
+                statuses: new Option<string>("BOARDED"),
+                limit: new Option<int>(10),
+                offset: new Option<long>(0));
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Get, capturedRequest.Method);
+            Assert.IsNotNull(capturedRequest.RequestUri);
+            Assert.AreEqual("/v1/merchants/TestMerchantAccount/paymentsApps", capturedRequest.RequestUri.AbsolutePath);
+            Assert.IsTrue(capturedRequest.RequestUri!.Query.Contains("statuses=BOARDED"));
+            Assert.IsTrue(capturedRequest.RequestUri.Query.Contains("limit=10"));
+            Assert.IsTrue(capturedRequest.RequestUri.Query.Contains("offset=0"));
+        }
+
+        #endregion
+
+        #region ListPaymentsAppForStoreAsync
+
+        [TestMethod]
+        public async Task ListPaymentsAppForStoreAsync_Returns200Ok_WithCorrectVerbAndPath()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/paymentsapp/list-payments-apps-store.json");
+
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigurePaymentsApp((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddPaymentsAppService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var paymentsAppService = testHost.Services.GetRequiredService<IPaymentsAppService>();
+
+            // Act
+            var response = await paymentsAppService.ListPaymentsAppForStoreAsync(
+                "TestMerchantAccount", "TestStore");
+
+            // Assert - response
+            Assert.IsTrue(response.TryDeserializeOkResponse(out var listResponse));
+            Assert.IsNotNull(listResponse);
+            Assert.AreEqual(2, listResponse.PaymentsApps.Count);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Get, capturedRequest.Method);
+            Assert.IsNotNull(capturedRequest.RequestUri);
+            Assert.AreEqual("/v1/merchants/TestMerchantAccount/stores/TestStore/paymentsApps", capturedRequest.RequestUri.AbsolutePath);
+        }
+
+        #endregion
+
+        #region RevokePaymentsAppAsync
+
+        [TestMethod]
+        public async Task RevokePaymentsAppAsync_Returns200Ok_WithCorrectVerbAndPath()
+        {
+            // Arrange
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigurePaymentsApp((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddPaymentsAppService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var paymentsAppService = testHost.Services.GetRequiredService<IPaymentsAppService>();
+
+            // Act
+            var response = await paymentsAppService.RevokePaymentsAppAsync(
+                "TestMerchantAccount", "install-merchant-001");
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Post, capturedRequest.Method);
+            Assert.IsNotNull(capturedRequest.RequestUri);
+            Assert.AreEqual("/v1/merchants/TestMerchantAccount/paymentsApps/install-merchant-001/revoke", capturedRequest.RequestUri.AbsolutePath);
+        }
+
+        [TestMethod]
+        public async Task RevokePaymentsAppAsync_Returns400BadRequest()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/paymentsapp/error-response-400.json");
+
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.BadRequest)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigurePaymentsApp((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options => { options.Environment = AdyenEnvironment.Test; });
+                    services.AddPaymentsAppService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var paymentsAppService = testHost.Services.GetRequiredService<IPaymentsAppService>();
+
+            // Act
+            var response = await paymentsAppService.RevokePaymentsAppAsync(
+                "TestMerchantAccount", "install-merchant-001");
+
+            // Assert - response
+            Assert.IsFalse(response.IsOk);
+            Assert.IsTrue(response.IsBadRequest);
+            Assert.IsTrue(response.TryDeserializeBadRequestResponse(out var errorResponse));
+            Assert.IsNotNull(errorResponse);
+            Assert.AreEqual(400, errorResponse.Status);
+            Assert.AreEqual("Invalid request", errorResponse.Title);
+            Assert.AreEqual("PAYMENTAPP_001", errorResponse.ErrorCode);
+
+            // Assert - HTTP verb and path
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Post, capturedRequest.Method);
+            Assert.IsNotNull(capturedRequest.RequestUri);
+            Assert.AreEqual("/v1/merchants/TestMerchantAccount/paymentsApps/install-merchant-001/revoke", capturedRequest.RequestUri.AbsolutePath);
+        }
+
+        #endregion
+
+        [TestMethod]
+        public async Task GeneratePaymentsAppBoardingTokenForMerchantAsync_AddsXApiKeyHeader()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/paymentsapp/boarding-token-response-merchant.json");
+
+            HttpRequestMessage? capturedRequest = null;
+            var mockHandler = new MockDelegatingHandler(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+            IHost testHost = Host.CreateDefaultBuilder()
+                .ConfigurePaymentsApp((context, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options =>
+                    {
+                        options.Environment = AdyenEnvironment.Test;
+                        options.AdyenApiKey = "test-api-key";
+                    });
+                    services.AddPaymentsAppService(httpClientBuilderOptions: builder =>
+                    {
+                        builder.AddHttpMessageHandler(() => mockHandler);
+                    });
+                })
+                .Build();
+
+            var paymentsAppService = testHost.Services.GetRequiredService<IPaymentsAppService>();
+            var boardingRequest = new BoardingTokenRequest { BoardingRequestToken = "test-boarding-token" };
+
+            // Act
+            await paymentsAppService.GeneratePaymentsAppBoardingTokenForMerchantAsync("TestMerchantAccount", boardingRequest);
+
+            // Assert
+            Assert.IsNotNull(capturedRequest);
+            Assert.IsTrue(capturedRequest.Headers.TryGetValues("X-API-Key", out var values));
+            Assert.AreEqual("test-api-key", values.First());
         }
     }
 }

--- a/Adyen.Test/PaymentsApp/PaymentsAppTest.cs
+++ b/Adyen.Test/PaymentsApp/PaymentsAppTest.cs
@@ -1,0 +1,147 @@
+using Adyen.Core.Options;
+using Adyen.PaymentsApp.Models;
+using Adyen.PaymentsApp.Client;
+using Adyen.PaymentsApp.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+
+namespace Adyen.Test.PaymentsApp
+{
+    [TestClass]
+    public class PaymentsAppTest
+    {
+        private static IHost _host;
+        private static JsonSerializerOptionsProvider _jsonSerializerOptionsProvider;
+
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext context)
+        {
+            _host = Host.CreateDefaultBuilder()
+                .ConfigurePaymentsApp((ctx, services, config) =>
+                {
+                    config.ConfigureAdyenOptions(options =>
+                    {
+                        options.Environment = AdyenEnvironment.Test;
+                    });
+                })
+                .Build();
+
+            _jsonSerializerOptionsProvider = _host.Services.GetRequiredService<JsonSerializerOptionsProvider>();
+        }
+
+        [ClassCleanup]
+        public static void ClassCleanup()
+        {
+            _host?.Dispose();
+        }
+
+        [TestMethod]
+        public void Given_Deserialize_When_BoardingTokenResponseMerchant_Returns_Not_Null()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/paymentsapp/boarding-token-response-merchant.json");
+
+            // Act
+            var response = JsonSerializer.Deserialize<BoardingTokenResponse>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual("install-merchant-001", response.InstallationId);
+            Assert.IsNotNull(response.BoardingToken);
+        }
+
+        [TestMethod]
+        public void Given_Deserialize_When_BoardingTokenResponseStore_Returns_Not_Null()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/paymentsapp/boarding-token-response-store.json");
+
+            // Act
+            var response = JsonSerializer.Deserialize<BoardingTokenResponse>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual("install-store-001", response.InstallationId);
+            Assert.IsNotNull(response.BoardingToken);
+        }
+
+        [TestMethod]
+        public void Given_Deserialize_When_PaymentsAppResponseMerchant_Returns_Not_Null()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/paymentsapp/list-payments-apps-merchant.json");
+
+            // Act
+            var response = JsonSerializer.Deserialize<PaymentsAppResponse>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(response.PaymentsApps);
+            Assert.AreEqual(3, response.PaymentsApps.Count);
+            Assert.AreEqual("install-merchant-001", response.PaymentsApps[0].InstallationId);
+            Assert.AreEqual("TestMerchantAccount", response.PaymentsApps[0].MerchantAccountCode);
+            Assert.AreEqual("BOARDED", response.PaymentsApps[0].Status);
+            Assert.AreEqual("TestStore", response.PaymentsApps[0].MerchantStoreCode);
+            Assert.AreEqual("BOARDING", response.PaymentsApps[1].Status);
+            Assert.IsNull(response.PaymentsApps[1].MerchantStoreCode);
+            Assert.AreEqual("REVOKED", response.PaymentsApps[2].Status);
+        }
+
+        [TestMethod]
+        public void Given_Deserialize_When_PaymentsAppResponseStore_Returns_Not_Null()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/paymentsapp/list-payments-apps-store.json");
+
+            // Act
+            var response = JsonSerializer.Deserialize<PaymentsAppResponse>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(response.PaymentsApps);
+            Assert.AreEqual(2, response.PaymentsApps.Count);
+            Assert.AreEqual("install-store-001", response.PaymentsApps[0].InstallationId);
+            Assert.AreEqual("Store001", response.PaymentsApps[0].MerchantStoreCode);
+            Assert.AreEqual("BOARDED", response.PaymentsApps[0].Status);
+            Assert.AreEqual("install-store-002", response.PaymentsApps[1].InstallationId);
+            Assert.AreEqual("Store002", response.PaymentsApps[1].MerchantStoreCode);
+        }
+
+        [TestMethod]
+        public void Given_Deserialize_When_DefaultErrorResponseEntity_Returns_Not_Null()
+        {
+            // Arrange
+            string json = TestUtilities.GetTestFileContent("mocks/paymentsapp/error-response-400.json");
+
+            // Act
+            var response = JsonSerializer.Deserialize<DefaultErrorResponseEntity>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.AreEqual(400, response.Status);
+            Assert.AreEqual("Invalid request", response.Title);
+            Assert.AreEqual("PAYMENTAPP_001", response.ErrorCode);
+            Assert.AreEqual("The request is invalid.", response.Detail);
+        }
+
+        [TestMethod]
+        public void Given_Serialize_When_BoardingTokenRequest_Returns_Valid_Json()
+        {
+            // Arrange
+            var request = new BoardingTokenRequest
+            {
+                BoardingRequestToken = "test-boarding-token"
+            };
+
+            // Act
+            string json = JsonSerializer.Serialize(request, _jsonSerializerOptionsProvider.Options);
+            var deserialized = JsonSerializer.Deserialize<BoardingTokenRequest>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.IsNotNull(deserialized);
+            Assert.AreEqual("test-boarding-token", deserialized.BoardingRequestToken);
+        }
+    }
+}

--- a/Adyen.Test/mocks/paymentsapp/boarding-token-response-merchant.json
+++ b/Adyen.Test/mocks/paymentsapp/boarding-token-response-merchant.json
@@ -1,0 +1,4 @@
+{
+  "boardingToken": "test-boarding-token-merchant",
+  "installationId": "install-merchant-001"
+}

--- a/Adyen.Test/mocks/paymentsapp/boarding-token-response-store.json
+++ b/Adyen.Test/mocks/paymentsapp/boarding-token-response-store.json
@@ -1,0 +1,4 @@
+{
+  "boardingToken": "test-boarding-token-store",
+  "installationId": "install-store-001"
+}

--- a/Adyen.Test/mocks/paymentsapp/error-response-400.json
+++ b/Adyen.Test/mocks/paymentsapp/error-response-400.json
@@ -1,0 +1,7 @@
+{
+  "status": 400,
+  "title": "Invalid request",
+  "errorCode": "PAYMENTAPP_001",
+  "detail": "The request is invalid.",
+  "type": "https://docs.adyen.com/errors/invalid-request"
+}

--- a/Adyen.Test/mocks/paymentsapp/list-payments-apps-merchant.json
+++ b/Adyen.Test/mocks/paymentsapp/list-payments-apps-merchant.json
@@ -1,0 +1,20 @@
+{
+  "paymentsApps": [
+    {
+      "installationId": "install-merchant-001",
+      "merchantAccountCode": "TestMerchantAccount",
+      "status": "BOARDED",
+      "merchantStoreCode": "TestStore"
+    },
+    {
+      "installationId": "install-merchant-002",
+      "merchantAccountCode": "TestMerchantAccount",
+      "status": "BOARDING"
+    },
+    {
+      "installationId": "install-merchant-003",
+      "merchantAccountCode": "TestMerchantAccount",
+      "status": "REVOKED"
+    }
+  ]
+}

--- a/Adyen.Test/mocks/paymentsapp/list-payments-apps-store.json
+++ b/Adyen.Test/mocks/paymentsapp/list-payments-apps-store.json
@@ -1,0 +1,16 @@
+{
+  "paymentsApps": [
+    {
+      "installationId": "install-store-001",
+      "merchantAccountCode": "TestMerchantAccount",
+      "status": "BOARDED",
+      "merchantStoreCode": "Store001"
+    },
+    {
+      "installationId": "install-store-002",
+      "merchantAccountCode": "TestMerchantAccount",
+      "status": "BOARDED",
+      "merchantStoreCode": "Store002"
+    }
+  ]
+}

--- a/Adyen/PaymentsApp/Services/PaymentsAppService.cs
+++ b/Adyen/PaymentsApp/Services/PaymentsAppService.cs
@@ -507,6 +507,8 @@ namespace Adyen.PaymentsApp.Services
 
                     // Adds headers to the HttpRequestMessage header, these can be set in the RequestOptions (Idempotency-Key etc.)
                     requestOptions?.AddHeadersToHttpRequestMessage(httpRequestMessage);
+                    // Add authorization token to the HttpRequestMessage header
+                    ApiKeyProvider.Get().AddTokenToHttpRequestMessageHeader(httpRequestMessage);
                     httpRequestMessage.Content = (boardingTokenRequest as object) is System.IO.Stream stream
                         ? httpRequestMessage.Content = new StreamContent(stream)
                         : httpRequestMessage.Content = new StringContent(JsonSerializer.Serialize(boardingTokenRequest, _jsonSerializerOptions));
@@ -884,6 +886,8 @@ namespace Adyen.PaymentsApp.Services
 
                     // Adds headers to the HttpRequestMessage header, these can be set in the RequestOptions (Idempotency-Key etc.)
                     requestOptions?.AddHeadersToHttpRequestMessage(httpRequestMessage);
+                    // Add authorization token to the HttpRequestMessage header
+                    ApiKeyProvider.Get().AddTokenToHttpRequestMessageHeader(httpRequestMessage);
                     httpRequestMessage.Content = (boardingTokenRequest as object) is System.IO.Stream stream
                         ? httpRequestMessage.Content = new StreamContent(stream)
                         : httpRequestMessage.Content = new StringContent(JsonSerializer.Serialize(boardingTokenRequest, _jsonSerializerOptions));
@@ -1274,6 +1278,8 @@ namespace Adyen.PaymentsApp.Services
 
                     // Adds headers to the HttpRequestMessage header, these can be set in the RequestOptions (Idempotency-Key etc.)
                     requestOptions?.AddHeadersToHttpRequestMessage(httpRequestMessage);
+                    // Add authorization token to the HttpRequestMessage header
+                    ApiKeyProvider.Get().AddTokenToHttpRequestMessageHeader(httpRequestMessage);
                     httpRequestMessage.RequestUri = uriBuilder.Uri;
 
                     string[] accepts = new string[] {
@@ -1650,6 +1656,8 @@ namespace Adyen.PaymentsApp.Services
 
                     // Adds headers to the HttpRequestMessage header, these can be set in the RequestOptions (Idempotency-Key etc.)
                     requestOptions?.AddHeadersToHttpRequestMessage(httpRequestMessage);
+                    // Add authorization token to the HttpRequestMessage header
+                    ApiKeyProvider.Get().AddTokenToHttpRequestMessageHeader(httpRequestMessage);
                     httpRequestMessage.RequestUri = uriBuilder.Uri;
 
                     string[] accepts = new string[] {
@@ -2010,6 +2018,8 @@ namespace Adyen.PaymentsApp.Services
 
                     // Adds headers to the HttpRequestMessage header, these can be set in the RequestOptions (Idempotency-Key etc.)
                     requestOptions?.AddHeadersToHttpRequestMessage(httpRequestMessage);
+                    // Add authorization token to the HttpRequestMessage header
+                    ApiKeyProvider.Get().AddTokenToHttpRequestMessageHeader(httpRequestMessage);
                     httpRequestMessage.RequestUri = uriBuilder.Uri;
 
                     string[] accepts = new string[] {

--- a/templates-v7/csharp/libraries/generichost/api.mustache
+++ b/templates-v7/csharp/libraries/generichost/api.mustache
@@ -362,6 +362,13 @@ namespace {{packageName}}.{{apiPackage}}
                     {{/isKeyInCookie}}
                     {{/isApiKey}}
                     {{/authMethods}}
+                    {{^authMethods}}
+                    {{#hasApiKeyMethods}}
+                    // Add authorization token to the HttpRequestMessage header
+                    ApiKeyProvider.Get().AddTokenToHttpRequestMessageHeader(httpRequestMessage);
+
+                    {{/hasApiKeyMethods}}
+                    {{/authMethods}}
                     httpRequestMessage.RequestUri = uriBuilder.Uri;
                     {{#authMethods}}
                     {{#isBasicBearer}}


### PR DESCRIPTION
Fix a bug where `PaymentsAppService` was not adding the `X-API-Key` header to outgoing requests. 

The issue is caused by the `PaymentsAppService-v1.json` OpenAPI spec that it is missing the`security` field on all operations. 
Other specs (e.g. `Recurring`, `Checkout`) declare security: `[{ApiKeyAuth: []}]` per-operation, therefore they don't have the same problem. 

## Tested scenarios
- Serialization/deserialization of all PaymentsApp models
- HTTP verb and path for all 5 service methods
- Query parameters (statuses, limit, offset)
- Error responses (400, 500)
- X-API-Key header presence on outgoing requests


Fix #1719 