### PR TITLE
Revise byte[] deserialization to use standard STJ delegation

### DIFF
--- a/Adyen.Test/Checkout/CheckoutPaymentsBareSerializationTests.cs
+++ b/Adyen.Test/Checkout/CheckoutPaymentsBareSerializationTests.cs
@@ -110,8 +110,10 @@ namespace Adyen.Test.Checkout
         [TestMethod]
         public void Given_ThreeDSecureData_When_BareSerialize_Then_ByteArray_IsCorrect()
         {
-            byte[] base64Bytes = Encoding.ASCII.GetBytes(Convert.ToBase64String(Encoding.ASCII.GetBytes("Bytes-To-Be-Encoded")));
-            var threeDSecure = new ThreeDSecureData { Cavv = base64Bytes, Xid = base64Bytes };
+            // STJ default: byte[] is base64-encoded. Encoding.UTF8.GetBytes("Bytes-To-Be-Encoded")
+            // base64-encodes to "Qnl0ZXMtVG8tQmUtRW5jb2RlZA==".
+            byte[] rawBytes = Encoding.UTF8.GetBytes("Bytes-To-Be-Encoded");
+            var threeDSecure = new ThreeDSecureData { Cavv = rawBytes, Xid = rawBytes };
 
             string result = JsonSerializer.Serialize(threeDSecure);
 
@@ -121,12 +123,13 @@ namespace Adyen.Test.Checkout
         [TestMethod]
         public void Given_ThreeDSecureData_When_BareDeserialize_Then_ByteArray_IsCorrect()
         {
+            // STJ default: base64-decodes the JSON string. "Qnl0ZXMtVG8tQmUtRW5jb2RlZA==" decodes to "Bytes-To-Be-Encoded".
             string json = "{\"cavv\":\"Qnl0ZXMtVG8tQmUtRW5jb2RlZA==\",\"xid\":\"Qnl0ZXMtVG8tQmUtRW5jb2RlZA==\"}";
 
             var result = JsonSerializer.Deserialize<ThreeDSecureData>(json);
 
-            Assert.AreEqual("Qnl0ZXMtVG8tQmUtRW5jb2RlZA==", Encoding.ASCII.GetString(result.Cavv));
-            Assert.AreEqual("Qnl0ZXMtVG8tQmUtRW5jb2RlZA==", Encoding.ASCII.GetString(result.Xid));
+            Assert.AreEqual("Bytes-To-Be-Encoded", Encoding.UTF8.GetString(result.Cavv));
+            Assert.AreEqual("Bytes-To-Be-Encoded", Encoding.UTF8.GetString(result.Xid));
         }
 
         #endregion

--- a/Adyen.Test/Checkout/CheckoutPaymentsBareSerializationTests.cs
+++ b/Adyen.Test/Checkout/CheckoutPaymentsBareSerializationTests.cs
@@ -323,6 +323,107 @@ namespace Adyen.Test.Checkout
         }
 
         [TestMethod]
+        public void Given_PaymentRequest_With_MpiData_When_BareSerialize_Then_CavvIsBase64Encoded()
+        {
+            // "3q2+78r+ur7erb7vyv66vv////8=" is the CAVV from the Adyen 3DS mpiData docs sample.
+            byte[] cavvBytes = Convert.FromBase64String("3q2+78r+ur7erb7vyv66vv////8=");
+            var request = new PaymentRequest
+            {
+                MerchantAccount = "YOUR_MERCHANT_ACCOUNT",
+                Amount = new Amount { Currency = "EUR", Value = 1000 },
+                Reference = "YOUR_ORDER_NUMBER",
+                Channel = PaymentRequest.ChannelEnum.Web,
+                PaymentMethod = new CheckoutPaymentMethod(new CardDetails { Type = CardDetails.TypeEnum.Card }),
+                ReturnUrl = "https://your-company.com/checkout",
+                MpiData = new ThreeDSecureData
+                {
+                    Cavv = cavvBytes,
+                    Eci = "05",
+                    DsTransID = "c4e59ceb-a382-4d6a-bc87-385d591fa09d",
+                    DirectoryResponse = ThreeDSecureData.DirectoryResponseEnum.C,
+                    AuthenticationResponse = ThreeDSecureData.AuthenticationResponseEnum.Y,
+                    ThreeDSVersion = "2.1.0",
+                },
+            };
+
+            string result = JsonSerializer.Serialize(request);
+
+            using JsonDocument json = JsonDocument.Parse(result);
+            JsonElement mpiData = json.RootElement.GetProperty("mpiData");
+            Assert.AreEqual("3q2+78r+ur7erb7vyv66vv////8=", mpiData.GetProperty("cavv").GetString());
+            Assert.AreEqual("05", mpiData.GetProperty("eci").GetString());
+            Assert.AreEqual("c4e59ceb-a382-4d6a-bc87-385d591fa09d", mpiData.GetProperty("dsTransID").GetString());
+            Assert.AreEqual("C", mpiData.GetProperty("directoryResponse").GetString());
+            Assert.AreEqual("Y", mpiData.GetProperty("authenticationResponse").GetString());
+            Assert.AreEqual("2.1.0", mpiData.GetProperty("threeDSVersion").GetString());
+        }
+
+        [TestMethod]
+        public void Given_PaymentRequest_Json_With_MpiData_When_BareDeserialize_Then_CavvBytesAreCorrect()
+        {
+            string json = """
+                {
+                  "amount": { "currency": "EUR", "value": 1000 },
+                  "merchantAccount": "YOUR_MERCHANT_ACCOUNT",
+                  "reference": "YOUR_ORDER_NUMBER",
+                  "channel": "Web",
+                  "mpiData": {
+                    "cavv": "3q2+78r+ur7erb7vyv66vv////8=",
+                    "eci": "05",
+                    "dsTransID": "c4e59ceb-a382-4d6a-bc87-385d591fa09d",
+                    "directoryResponse": "C",
+                    "authenticationResponse": "Y",
+                    "threeDSVersion": "2.1.0"
+                  },
+                  "paymentMethod": { "type": "card" },
+                  "returnUrl": "https://your-company.com/checkout"
+                }
+                """;
+
+            var result = JsonSerializer.Deserialize<PaymentRequest>(json);
+
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.MpiData);
+            CollectionAssert.AreEqual(Convert.FromBase64String("3q2+78r+ur7erb7vyv66vv////8="), result.MpiData.Cavv);
+            Assert.AreEqual("05", result.MpiData.Eci);
+            Assert.AreEqual("c4e59ceb-a382-4d6a-bc87-385d591fa09d", result.MpiData.DsTransID);
+            Assert.AreEqual(ThreeDSecureData.DirectoryResponseEnum.C, result.MpiData.DirectoryResponse);
+            Assert.AreEqual(ThreeDSecureData.AuthenticationResponseEnum.Y, result.MpiData.AuthenticationResponse);
+            Assert.AreEqual("2.1.0", result.MpiData.ThreeDSVersion);
+        }
+
+        [TestMethod]
+        public void Given_ThreeDSecureData_With_TokenAuthenticationVerificationValue_When_BareRoundTrip_Then_ValuesPreserved()
+        {
+            byte[] tavvBytes = Convert.FromBase64String("3q2+78r+ur7erb7vyv66vv////8=");
+            var original = new ThreeDSecureData
+            {
+                Cavv = tavvBytes,
+                TokenAuthenticationVerificationValue = tavvBytes,
+                Xid = tavvBytes,
+            };
+
+            string json = JsonSerializer.Serialize(original);
+            var deserialized = JsonSerializer.Deserialize<ThreeDSecureData>(json);
+
+            Assert.IsNotNull(deserialized);
+            CollectionAssert.AreEqual(tavvBytes, deserialized.Cavv);
+            CollectionAssert.AreEqual(tavvBytes, deserialized.TokenAuthenticationVerificationValue);
+            CollectionAssert.AreEqual(tavvBytes, deserialized.Xid);
+        }
+
+        [TestMethod]
+        public void Given_ThreeDSecureData_With_NullCavv_When_BareSerialize_Then_CavvIsJsonNull()
+        {
+            var data = new ThreeDSecureData { Cavv = null };
+
+            string result = JsonSerializer.Serialize(data);
+
+            using JsonDocument json = JsonDocument.Parse(result);
+            Assert.AreEqual(JsonValueKind.Null, json.RootElement.GetProperty("cavv").ValueKind);
+        }
+
+        [TestMethod]
         public void Given_PaymentRequest_When_BareSerialize_AccountInfo_NotSet_Then_KeyIsAbsent()
         {
             var request = new PaymentRequest

--- a/Adyen.Test/Checkout/NullableOptionSerializationTest.cs
+++ b/Adyen.Test/Checkout/NullableOptionSerializationTest.cs
@@ -206,28 +206,31 @@ namespace Adyen.Test.Checkout
         }
 
         [TestMethod]
-        public void Given_ThreeDSecureData_ByteArray_Bare_And_DI_Produce_Same_Bytes()
+        public void Given_ThreeDSecureData_ByteArray_Bare_Produces_Base64DecodedBytes()
         {
-            // Both bare and DI mode use ByteArrayConverter (UTF-8), so results must be identical.
+            // Bare mode uses STJ default: base64-decodes the JSON string.
+            // "dGVzdA==" decodes to "test".
             string json = "{\"cavv\":\"dGVzdA==\"}";
-
-            var bareResult = JsonSerializer.Deserialize<ThreeDSecureData>(json);
-            var diResult = JsonSerializer.Deserialize<ThreeDSecureData>(json, _jsonSerializerOptionsProvider.Options);
-
-            CollectionAssert.AreEqual(diResult.Cavv, bareResult.Cavv,
-                "Bare and DI deserialization must produce identical byte[] values.");
-        }
-
-        [TestMethod]
-        public void Given_ThreeDSecureData_ByteArray_Bare_Produces_UTF8_Bytes()
-        {
-            string json = "{\"cavv\":\"dGVzdA==\"}";
-            byte[] expected = Encoding.UTF8.GetBytes("dGVzdA==");
+            byte[] expected = Encoding.UTF8.GetBytes("test");
 
             var result = JsonSerializer.Deserialize<ThreeDSecureData>(json);
 
             CollectionAssert.AreEqual(expected, result.Cavv,
-                "Bare deserialization must use UTF-8 encoding (ByteArrayConverter semantics), not Base64.");
+                "Bare deserialization uses STJ default base64 decoding.");
+        }
+
+        [TestMethod]
+        public void Given_ThreeDSecureData_ByteArray_DI_Produces_UTF8_Bytes()
+        {
+            // DI mode uses ByteArrayConverter registered in HostConfiguration: UTF-8 string preservation.
+            // "dGVzdA==" is treated as a UTF-8 string and stored as its bytes.
+            string json = "{\"cavv\":\"dGVzdA==\"}";
+            byte[] expected = Encoding.UTF8.GetBytes("dGVzdA==");
+
+            var result = JsonSerializer.Deserialize<ThreeDSecureData>(json, _jsonSerializerOptionsProvider.Options);
+
+            CollectionAssert.AreEqual(expected, result.Cavv,
+                "DI deserialization uses ByteArrayConverter (UTF-8 string preservation).");
         }
     }
 }

--- a/Adyen.Test/Core/Serialization/BareSerializationTests.cs
+++ b/Adyen.Test/Core/Serialization/BareSerializationTests.cs
@@ -81,16 +81,15 @@ namespace Adyen.Test.Core.Serialization
         }
 
         [TestMethod]
-        public void Given_CavvJson_When_BareDeserialize_Then_CavvContainsUTF8EncodedBytes()
+        public void Given_CavvJson_When_BareDeserialize_Then_CavvContainsBase64DecodedBytes()
         {
-            // Fixed by issue #1687: bare mode now uses ByteArrayConverter (UTF-8),
-            // matching DI-mode behaviour. "aGVsbG8=" treated as a UTF-8 string → 8 bytes.
+            // STJ default: base64-decodes the JSON string. "aGVsbG8=" decodes to "hello".
             string json = "{\"cavv\":\"aGVsbG8=\"}";
 
             var data = JsonSerializer.Deserialize<ThreeDSecureData>(json);
 
             Assert.IsNotNull(data);
-            CollectionAssert.AreEqual(Encoding.UTF8.GetBytes("aGVsbG8="), data.Cavv);
+            CollectionAssert.AreEqual(Encoding.UTF8.GetBytes("hello"), data.Cavv);
         }
 
         [TestMethod]

--- a/Adyen.Test/Core/Serialization/ByteArrayCoverageTests.cs
+++ b/Adyen.Test/Core/Serialization/ByteArrayCoverageTests.cs
@@ -1,0 +1,228 @@
+using System.Text;
+using System.Text.Json;
+using Adyen.BinLookup.Models;
+using Adyen.Checkout.Models;
+using Adyen.Core.Converters;
+using Adyen.Disputes.Models;
+using Adyen.LegalEntityManagement.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Adyen.Test.Core.Serialization
+{
+    /// <summary>
+    /// Covers the four test-coverage gaps identified in issue #1737:
+    /// 1. tokenAuthenticationVerificationValue (third byte[] field on ThreeDSecureData)
+    /// 2. Write-path parity (bare vs DI serialization for byte[] fields)
+    /// 3. Cross-service coverage (non-Checkout/Payment models with byte[] properties)
+    /// 4. Null byte[] in model context
+    /// </summary>
+    [TestClass]
+    public class ByteArrayCoverageTests
+    {
+        private static JsonSerializerOptions BuildDiOptions()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new ByteArrayConverter());
+            options.Converters.Add(new ThreeDSecureDataJsonConverter());
+            return options;
+        }
+
+        #region Gap 1: tokenAuthenticationVerificationValue
+
+        [TestMethod]
+        public void Given_TokenAuthenticationVerificationValueJson_When_BareDeserialize_Then_ContainsBase64DecodedBytes()
+        {
+            // In bare mode STJ uses its built-in base64 converter for byte[], so "dGVzdA==" is
+            // decoded to the bytes of "test", not the UTF-8 bytes of the base64 string itself.
+            string json = "{\"tokenAuthenticationVerificationValue\":\"dGVzdA==\"}";
+
+            var data = JsonSerializer.Deserialize<ThreeDSecureData>(json);
+
+            Assert.IsNotNull(data);
+            CollectionAssert.AreEqual(Convert.FromBase64String("dGVzdA=="), data.TokenAuthenticationVerificationValue);
+        }
+
+        [TestMethod]
+        public void Given_AllThreeByteArrayFields_When_BareRoundTrip_Then_AllValuesPreserved()
+        {
+            byte[] cavvBytes = Encoding.UTF8.GetBytes("cavv-value");
+            byte[] tavvBytes = Encoding.UTF8.GetBytes("tavv-value");
+            byte[] xidBytes = Encoding.UTF8.GetBytes("xid-value");
+            var original = new ThreeDSecureData
+            {
+                Cavv = cavvBytes,
+                TokenAuthenticationVerificationValue = tavvBytes,
+                Xid = xidBytes,
+            };
+
+            string json = JsonSerializer.Serialize(original);
+            var deserialized = JsonSerializer.Deserialize<ThreeDSecureData>(json);
+
+            Assert.IsNotNull(deserialized);
+            CollectionAssert.AreEqual(cavvBytes, deserialized.Cavv);
+            CollectionAssert.AreEqual(tavvBytes, deserialized.TokenAuthenticationVerificationValue);
+            CollectionAssert.AreEqual(xidBytes, deserialized.Xid);
+        }
+
+        #endregion
+
+        #region Gap 2: Write-path (bare vs DI)
+
+        [TestMethod]
+        public void Given_ThreeDSecureDataWithByteArrays_When_BareSerialize_Then_OutputIsBase64Encoded()
+        {
+            // In bare mode (no options) STJ encodes byte[] as base64.
+            // UTF-8 bytes of "test-cavv-bytes" base64-encode to "dGVzdC1jYXZ2LWJ5dGVz".
+            byte[] bytes = Encoding.UTF8.GetBytes("test-cavv-bytes");
+            var model = new ThreeDSecureData
+            {
+                Cavv = bytes,
+                TokenAuthenticationVerificationValue = bytes,
+                Xid = bytes,
+            };
+
+            string bareJson = JsonSerializer.Serialize(model);
+
+            using JsonDocument json = JsonDocument.Parse(bareJson);
+            Assert.AreEqual("dGVzdC1jYXZ2LWJ5dGVz", json.RootElement.GetProperty("cavv").GetString());
+            Assert.AreEqual("dGVzdC1jYXZ2LWJ5dGVz", json.RootElement.GetProperty("tokenAuthenticationVerificationValue").GetString());
+            Assert.AreEqual("dGVzdC1jYXZ2LWJ5dGVz", json.RootElement.GetProperty("xid").GetString());
+        }
+
+        [TestMethod]
+        public void Given_ThreeDSecureDataWithByteArrays_When_DiSerialize_Then_OutputIsUtf8String()
+        {
+            // In DI mode ByteArrayConverter is registered and writes byte[] as a UTF-8 string.
+            byte[] bytes = Encoding.UTF8.GetBytes("test-cavv-bytes");
+            var model = new ThreeDSecureData
+            {
+                Cavv = bytes,
+                TokenAuthenticationVerificationValue = bytes,
+                Xid = bytes,
+            };
+
+            string diJson = JsonSerializer.Serialize(model, BuildDiOptions());
+
+            using JsonDocument json = JsonDocument.Parse(diJson);
+            Assert.AreEqual("test-cavv-bytes", json.RootElement.GetProperty("cavv").GetString());
+            Assert.AreEqual("test-cavv-bytes", json.RootElement.GetProperty("tokenAuthenticationVerificationValue").GetString());
+            Assert.AreEqual("test-cavv-bytes", json.RootElement.GetProperty("xid").GetString());
+        }
+
+        [TestMethod]
+        public void Given_ThreeDSecureDataJson_When_BareDeserialize_Then_ByteArrayContainsBase64DecodedBytes()
+        {
+            // In bare mode "dGVzdA==" is base64-decoded to the bytes of "test".
+            string json = "{\"cavv\":\"dGVzdA==\",\"tokenAuthenticationVerificationValue\":\"dGVzdA==\",\"xid\":\"dGVzdA==\"}";
+
+            var result = JsonSerializer.Deserialize<ThreeDSecureData>(json);
+
+            Assert.IsNotNull(result);
+            CollectionAssert.AreEqual(Convert.FromBase64String("dGVzdA=="), result.Cavv);
+            CollectionAssert.AreEqual(Convert.FromBase64String("dGVzdA=="), result.TokenAuthenticationVerificationValue);
+            CollectionAssert.AreEqual(Convert.FromBase64String("dGVzdA=="), result.Xid);
+        }
+
+        [TestMethod]
+        public void Given_ThreeDSecureDataJson_When_DiDeserialize_Then_ByteArrayContainsUtf8Bytes()
+        {
+            // In DI mode ByteArrayConverter reads the JSON string as UTF-8 bytes.
+            string json = "{\"cavv\":\"dGVzdA==\",\"tokenAuthenticationVerificationValue\":\"dGVzdA==\",\"xid\":\"dGVzdA==\"}";
+
+            var result = JsonSerializer.Deserialize<ThreeDSecureData>(json, BuildDiOptions());
+
+            Assert.IsNotNull(result);
+            CollectionAssert.AreEqual(Encoding.UTF8.GetBytes("dGVzdA=="), result.Cavv);
+            CollectionAssert.AreEqual(Encoding.UTF8.GetBytes("dGVzdA=="), result.TokenAuthenticationVerificationValue);
+            CollectionAssert.AreEqual(Encoding.UTF8.GetBytes("dGVzdA=="), result.Xid);
+        }
+
+        #endregion
+
+        #region Gap 3: Cross-service coverage
+
+        [TestMethod]
+        public void Given_DefenseDocumentContent_When_BareRoundTrip_Then_ContentPreserved()
+        {
+            byte[] content = Encoding.UTF8.GetBytes("defense-doc-content");
+            var original = new DefenseDocument
+            {
+                Content = content,
+                ContentType = "application/pdf",
+                DefenseDocumentTypeCode = "PROOF_OF_DELIVERY",
+            };
+
+            string json = JsonSerializer.Serialize(original);
+            var deserialized = JsonSerializer.Deserialize<DefenseDocument>(json);
+
+            Assert.IsNotNull(deserialized);
+            CollectionAssert.AreEqual(content, deserialized.Content);
+            Assert.AreEqual("application/pdf", deserialized.ContentType);
+        }
+
+        [TestMethod]
+        public void Given_DSPublicKeyDetailPublicKey_When_BareRoundTrip_Then_KeyPreserved()
+        {
+            byte[] keyBytes = Encoding.UTF8.GetBytes("ds-public-key-bytes");
+            var original = new DSPublicKeyDetail { PublicKey = keyBytes, Brand = "visa" };
+
+            string json = JsonSerializer.Serialize(original);
+            var deserialized = JsonSerializer.Deserialize<DSPublicKeyDetail>(json);
+
+            Assert.IsNotNull(deserialized);
+            CollectionAssert.AreEqual(keyBytes, deserialized.PublicKey);
+            Assert.AreEqual("visa", deserialized.Brand);
+        }
+
+        [TestMethod]
+        public void Given_AttachmentContent_When_BareRoundTrip_Then_ContentPreserved()
+        {
+            byte[] content = Encoding.UTF8.GetBytes("attachment-content-bytes");
+            var original = new Attachment { Content = content };
+
+            string json = JsonSerializer.Serialize(original);
+            var deserialized = JsonSerializer.Deserialize<Attachment>(json);
+
+            Assert.IsNotNull(deserialized);
+            CollectionAssert.AreEqual(content, deserialized.Content);
+        }
+
+        #endregion
+
+        #region Gap 4: Null byte[] in model context
+
+        [TestMethod]
+        public void Given_ThreeDSecureDataWithNullCavv_When_BareRoundTrip_Then_NullIsPreserved()
+        {
+            var original = new ThreeDSecureData
+            {
+                CavvAlgorithm = "2",
+                Cavv = null,
+                TokenAuthenticationVerificationValue = null,
+            };
+
+            string json = JsonSerializer.Serialize(original);
+            var deserialized = JsonSerializer.Deserialize<ThreeDSecureData>(json);
+
+            Assert.IsNotNull(deserialized);
+            Assert.IsNull(deserialized.Cavv);
+            Assert.IsNull(deserialized.TokenAuthenticationVerificationValue);
+            Assert.AreEqual("2", deserialized.CavvAlgorithm);
+        }
+
+        [TestMethod]
+        public void Given_DSPublicKeyDetailWithNullPublicKey_When_BareRoundTrip_Then_NullIsPreserved()
+        {
+            var original = new DSPublicKeyDetail { Brand = "mc", PublicKey = null };
+
+            string json = JsonSerializer.Serialize(original);
+            var deserialized = JsonSerializer.Deserialize<DSPublicKeyDetail>(json);
+
+            Assert.IsNotNull(deserialized);
+            Assert.IsNull(deserialized.PublicKey);
+            Assert.AreEqual("mc", deserialized.Brand);
+        }
+
+        #endregion
+    }
+}

--- a/Adyen.Test/Payment/PaymentBareSerializationTests.cs
+++ b/Adyen.Test/Payment/PaymentBareSerializationTests.cs
@@ -39,14 +39,15 @@ namespace Adyen.Test.Payment
         }
 
         [TestMethod]
-        public void Given_CavvJson_When_BareDeserialize_Then_CavvContainsUTF8EncodedBytes()
+        public void Given_CavvJson_When_BareDeserialize_Then_CavvContainsBase64DecodedBytes()
         {
+            // STJ default: base64-decodes the JSON string. "aGVsbG8=" decodes to "hello".
             string json = "{\"cavv\":\"aGVsbG8=\"}";
 
             var data = JsonSerializer.Deserialize<ThreeDSecureData>(json);
 
             Assert.IsNotNull(data);
-            CollectionAssert.AreEqual(Encoding.UTF8.GetBytes("aGVsbG8="), data.Cavv);
+            CollectionAssert.AreEqual(Encoding.UTF8.GetBytes("hello"), data.Cavv);
         }
 
         [TestMethod]

--- a/Adyen.Test/Payment/PaymentBareSerializationTests.cs
+++ b/Adyen.Test/Payment/PaymentBareSerializationTests.cs
@@ -66,6 +66,69 @@ namespace Adyen.Test.Payment
         }
 
         [TestMethod]
+        public void Given_PaymentRequest_With_MpiData_When_BareSerialize_Then_CavvIsBase64Encoded()
+        {
+            byte[] cavvBytes = Convert.FromBase64String("3q2+78r+ur7erb7vyv66vv////8=");
+            var request = new PaymentRequest
+            {
+                MerchantAccount = "YOUR_MERCHANT_ACCOUNT",
+                Amount = new Amount { Currency = "EUR", Value = 1000 },
+                Reference = "YOUR_ORDER_NUMBER",
+                MpiData = new ThreeDSecureData
+                {
+                    Cavv = cavvBytes,
+                    Eci = "05",
+                    DsTransID = "c4e59ceb-a382-4d6a-bc87-385d591fa09d",
+                    DirectoryResponse = ThreeDSecureData.DirectoryResponseEnum.C,
+                    AuthenticationResponse = ThreeDSecureData.AuthenticationResponseEnum.Y,
+                    ThreeDSVersion = "2.1.0",
+                },
+            };
+
+            string result = JsonSerializer.Serialize(request);
+
+            using JsonDocument json = JsonDocument.Parse(result);
+            JsonElement mpiData = json.RootElement.GetProperty("mpiData");
+            Assert.AreEqual("3q2+78r+ur7erb7vyv66vv////8=", mpiData.GetProperty("cavv").GetString());
+            Assert.AreEqual("05", mpiData.GetProperty("eci").GetString());
+            Assert.AreEqual("c4e59ceb-a382-4d6a-bc87-385d591fa09d", mpiData.GetProperty("dsTransID").GetString());
+            Assert.AreEqual("C", mpiData.GetProperty("directoryResponse").GetString());
+            Assert.AreEqual("Y", mpiData.GetProperty("authenticationResponse").GetString());
+            Assert.AreEqual("2.1.0", mpiData.GetProperty("threeDSVersion").GetString());
+        }
+
+        [TestMethod]
+        public void Given_PaymentRequest_Json_With_MpiData_When_BareDeserialize_Then_CavvBytesAreCorrect()
+        {
+            string json = """
+                {
+                  "amount": { "currency": "EUR", "value": 1000 },
+                  "merchantAccount": "YOUR_MERCHANT_ACCOUNT",
+                  "reference": "YOUR_ORDER_NUMBER",
+                  "mpiData": {
+                    "cavv": "3q2+78r+ur7erb7vyv66vv////8=",
+                    "eci": "05",
+                    "dsTransID": "c4e59ceb-a382-4d6a-bc87-385d591fa09d",
+                    "directoryResponse": "C",
+                    "authenticationResponse": "Y",
+                    "threeDSVersion": "2.1.0"
+                  }
+                }
+                """;
+
+            var result = JsonSerializer.Deserialize<PaymentRequest>(json);
+
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.MpiData);
+            CollectionAssert.AreEqual(Convert.FromBase64String("3q2+78r+ur7erb7vyv66vv////8="), result.MpiData.Cavv);
+            Assert.AreEqual("05", result.MpiData.Eci);
+            Assert.AreEqual("c4e59ceb-a382-4d6a-bc87-385d591fa09d", result.MpiData.DsTransID);
+            Assert.AreEqual(ThreeDSecureData.DirectoryResponseEnum.C, result.MpiData.DirectoryResponse);
+            Assert.AreEqual(ThreeDSecureData.AuthenticationResponseEnum.Y, result.MpiData.AuthenticationResponse);
+            Assert.AreEqual("2.1.0", result.MpiData.ThreeDSVersion);
+        }
+
+        [TestMethod]
         public void Given_ThreeDSecureDataObject_When_BareSerialize_Then_DoesNotThrow()
         {
             var data = new ThreeDSecureData

--- a/Adyen/BalancePlatform/Models/GetTaxFormResponse.cs
+++ b/Adyen/BalancePlatform/Models/GetTaxFormResponse.cs
@@ -237,7 +237,7 @@ namespace Adyen.BalancePlatform.Models
                     switch (jsonPropertyName)
                     {
                         case "content":
-                            content = new Option<byte[]?>(new ByteArrayConverter().Read(ref utf8JsonReader, typeof(byte[]), jsonSerializerOptions));
+                            content = new Option<byte[]?>(JsonSerializer.Deserialize<byte[]>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "contentType":
                             string? contentTypeRawValue = utf8JsonReader.GetString();
@@ -286,7 +286,7 @@ namespace Adyen.BalancePlatform.Models
         {
             
             writer.WritePropertyName("content");
-            new ByteArrayConverter().Write(writer, getTaxFormResponse.Content, jsonSerializerOptions);
+            JsonSerializer.Serialize(writer, getTaxFormResponse.Content, jsonSerializerOptions);
             if (getTaxFormResponse._ContentTypeOption.IsSet && getTaxFormResponse.ContentType != null) 
             {
                 string? contentTypeRawValue = GetTaxFormResponse.ContentTypeEnum.ToJsonValue(getTaxFormResponse._ContentTypeOption.Value!.Value);

--- a/Adyen/BinLookup/Models/DSPublicKeyDetail.cs
+++ b/Adyen/BinLookup/Models/DSPublicKeyDetail.cs
@@ -187,7 +187,7 @@ namespace Adyen.BinLookup.Models
                             fromSDKVersion = new Option<string?>(utf8JsonReader.GetString()!);
                             break;
                         case "publicKey":
-                            publicKey = new Option<byte[]?>(new ByteArrayConverter().Read(ref utf8JsonReader, typeof(byte[]), jsonSerializerOptions));
+                            publicKey = new Option<byte[]?>(JsonSerializer.Deserialize<byte[]>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "rootCertificates":
                             rootCertificates = new Option<string?>(utf8JsonReader.GetString()!);
@@ -253,7 +253,7 @@ namespace Adyen.BinLookup.Models
             if (dSPublicKeyDetail._PublicKeyOption.IsSet)
             {
                 writer.WritePropertyName("publicKey");
-                new ByteArrayConverter().Write(writer, dSPublicKeyDetail.PublicKey, jsonSerializerOptions);
+                JsonSerializer.Serialize(writer, dSPublicKeyDetail.PublicKey, jsonSerializerOptions);
             }
             if (dSPublicKeyDetail._RootCertificatesOption.IsSet)
                 if (dSPublicKeyDetail.RootCertificates != null)

--- a/Adyen/Checkout/Models/ThreeDSecureData.cs
+++ b/Adyen/Checkout/Models/ThreeDSecureData.cs
@@ -780,7 +780,7 @@ namespace Adyen.Checkout.Models
                             authenticationResponse = new Option<ThreeDSecureData.AuthenticationResponseEnum?>(ThreeDSecureData.AuthenticationResponseEnum.FromStringOrDefault(authenticationResponseRawValue) ?? (ThreeDSecureData.AuthenticationResponseEnum)authenticationResponseRawValue);
                             break;
                         case "cavv":
-                            cavv = new Option<byte[]?>(new ByteArrayConverter().Read(ref utf8JsonReader, typeof(byte[]), jsonSerializerOptions));
+                            cavv = new Option<byte[]?>(JsonSerializer.Deserialize<byte[]>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "cavvAlgorithm":
                             cavvAlgorithm = new Option<string?>(utf8JsonReader.GetString()!);
@@ -806,13 +806,13 @@ namespace Adyen.Checkout.Models
                             threeDSVersion = new Option<string?>(utf8JsonReader.GetString()!);
                             break;
                         case "tokenAuthenticationVerificationValue":
-                            tokenAuthenticationVerificationValue = new Option<byte[]?>(new ByteArrayConverter().Read(ref utf8JsonReader, typeof(byte[]), jsonSerializerOptions));
+                            tokenAuthenticationVerificationValue = new Option<byte[]?>(JsonSerializer.Deserialize<byte[]>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "transStatusReason":
                             transStatusReason = new Option<string?>(utf8JsonReader.GetString()!);
                             break;
                         case "xid":
-                            xid = new Option<byte[]?>(new ByteArrayConverter().Read(ref utf8JsonReader, typeof(byte[]), jsonSerializerOptions));
+                            xid = new Option<byte[]?>(JsonSerializer.Deserialize<byte[]>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         default:
                             break;
@@ -883,7 +883,7 @@ namespace Adyen.Checkout.Models
             if (threeDSecureData._CavvOption.IsSet)
             {
                 writer.WritePropertyName("cavv");
-                new ByteArrayConverter().Write(writer, threeDSecureData.Cavv, jsonSerializerOptions);
+                JsonSerializer.Serialize(writer, threeDSecureData.Cavv, jsonSerializerOptions);
             }
             if (threeDSecureData._CavvAlgorithmOption.IsSet)
                 if (threeDSecureData.CavvAlgorithm != null)
@@ -920,7 +920,7 @@ namespace Adyen.Checkout.Models
             if (threeDSecureData._TokenAuthenticationVerificationValueOption.IsSet)
             {
                 writer.WritePropertyName("tokenAuthenticationVerificationValue");
-                new ByteArrayConverter().Write(writer, threeDSecureData.TokenAuthenticationVerificationValue, jsonSerializerOptions);
+                JsonSerializer.Serialize(writer, threeDSecureData.TokenAuthenticationVerificationValue, jsonSerializerOptions);
             }
             if (threeDSecureData._TransStatusReasonOption.IsSet)
                 if (threeDSecureData.TransStatusReason != null)
@@ -929,7 +929,7 @@ namespace Adyen.Checkout.Models
             if (threeDSecureData._XidOption.IsSet)
             {
                 writer.WritePropertyName("xid");
-                new ByteArrayConverter().Write(writer, threeDSecureData.Xid, jsonSerializerOptions);
+                JsonSerializer.Serialize(writer, threeDSecureData.Xid, jsonSerializerOptions);
             }
         }
     }

--- a/Adyen/Disputes/Models/DefenseDocument.cs
+++ b/Adyen/Disputes/Models/DefenseDocument.cs
@@ -125,7 +125,7 @@ namespace Adyen.Disputes.Models
                     switch (jsonPropertyName)
                     {
                         case "content":
-                            content = new Option<byte[]?>(new ByteArrayConverter().Read(ref utf8JsonReader, typeof(byte[]), jsonSerializerOptions));
+                            content = new Option<byte[]?>(JsonSerializer.Deserialize<byte[]>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "contentType":
                             contentType = new Option<string?>(utf8JsonReader.GetString()!);
@@ -182,7 +182,7 @@ namespace Adyen.Disputes.Models
         {
             
             writer.WritePropertyName("content");
-            new ByteArrayConverter().Write(writer, defenseDocument.Content, jsonSerializerOptions);
+            JsonSerializer.Serialize(writer, defenseDocument.Content, jsonSerializerOptions);
             if (defenseDocument.ContentType != null)
                 writer.WriteString("contentType", defenseDocument.ContentType);
 

--- a/Adyen/LegalEntityManagement/Models/Attachment.cs
+++ b/Adyen/LegalEntityManagement/Models/Attachment.cs
@@ -175,7 +175,7 @@ namespace Adyen.LegalEntityManagement.Models
                     switch (jsonPropertyName)
                     {
                         case "content":
-                            content = new Option<byte[]?>(new ByteArrayConverter().Read(ref utf8JsonReader, typeof(byte[]), jsonSerializerOptions));
+                            content = new Option<byte[]?>(JsonSerializer.Deserialize<byte[]>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "contentType":
                             contentType = new Option<string?>(utf8JsonReader.GetString()!);
@@ -238,7 +238,7 @@ namespace Adyen.LegalEntityManagement.Models
         {
             
             writer.WritePropertyName("content");
-            new ByteArrayConverter().Write(writer, attachment.Content, jsonSerializerOptions);
+            JsonSerializer.Serialize(writer, attachment.Content, jsonSerializerOptions);
             if (attachment._ContentTypeOption.IsSet)
                 if (attachment.ContentType != null)
                     writer.WriteString("contentType", attachment.ContentType);

--- a/Adyen/LegalEntityManagement/Models/GeneratePciDescriptionResponse.cs
+++ b/Adyen/LegalEntityManagement/Models/GeneratePciDescriptionResponse.cs
@@ -146,7 +146,7 @@ namespace Adyen.LegalEntityManagement.Models
                     switch (jsonPropertyName)
                     {
                         case "content":
-                            content = new Option<byte[]?>(new ByteArrayConverter().Read(ref utf8JsonReader, typeof(byte[]), jsonSerializerOptions));
+                            content = new Option<byte[]?>(JsonSerializer.Deserialize<byte[]>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "language":
                             language = new Option<string?>(utf8JsonReader.GetString()!);
@@ -199,7 +199,7 @@ namespace Adyen.LegalEntityManagement.Models
             if (generatePciDescriptionResponse._ContentOption.IsSet)
             {
                 writer.WritePropertyName("content");
-                new ByteArrayConverter().Write(writer, generatePciDescriptionResponse.Content, jsonSerializerOptions);
+                JsonSerializer.Serialize(writer, generatePciDescriptionResponse.Content, jsonSerializerOptions);
             }
             if (generatePciDescriptionResponse._LanguageOption.IsSet)
                 if (generatePciDescriptionResponse.Language != null)

--- a/Adyen/LegalEntityManagement/Models/GetAcceptedTermsOfServiceDocumentResponse.cs
+++ b/Adyen/LegalEntityManagement/Models/GetAcceptedTermsOfServiceDocumentResponse.cs
@@ -294,7 +294,7 @@ namespace Adyen.LegalEntityManagement.Models
                     switch (jsonPropertyName)
                     {
                         case "document":
-                            document = new Option<byte[]?>(new ByteArrayConverter().Read(ref utf8JsonReader, typeof(byte[]), jsonSerializerOptions));
+                            document = new Option<byte[]?>(JsonSerializer.Deserialize<byte[]>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "id":
                             id = new Option<string?>(utf8JsonReader.GetString()!);
@@ -353,7 +353,7 @@ namespace Adyen.LegalEntityManagement.Models
             if (getAcceptedTermsOfServiceDocumentResponse._DocumentOption.IsSet)
             {
                 writer.WritePropertyName("document");
-                new ByteArrayConverter().Write(writer, getAcceptedTermsOfServiceDocumentResponse.Document, jsonSerializerOptions);
+                JsonSerializer.Serialize(writer, getAcceptedTermsOfServiceDocumentResponse.Document, jsonSerializerOptions);
             }
             if (getAcceptedTermsOfServiceDocumentResponse._IdOption.IsSet)
                 if (getAcceptedTermsOfServiceDocumentResponse.Id != null)

--- a/Adyen/LegalEntityManagement/Models/GetPciQuestionnaireResponse.cs
+++ b/Adyen/LegalEntityManagement/Models/GetPciQuestionnaireResponse.cs
@@ -172,7 +172,7 @@ namespace Adyen.LegalEntityManagement.Models
                     switch (jsonPropertyName)
                     {
                         case "content":
-                            content = new Option<byte[]?>(new ByteArrayConverter().Read(ref utf8JsonReader, typeof(byte[]), jsonSerializerOptions));
+                            content = new Option<byte[]?>(JsonSerializer.Deserialize<byte[]>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "createdAt":
                             createdAt = new Option<DateTimeOffset?>(JsonSerializer.Deserialize<DateTimeOffset>(ref utf8JsonReader, jsonSerializerOptions));
@@ -230,7 +230,7 @@ namespace Adyen.LegalEntityManagement.Models
             if (getPciQuestionnaireResponse._ContentOption.IsSet)
             {
                 writer.WritePropertyName("content");
-                new ByteArrayConverter().Write(writer, getPciQuestionnaireResponse.Content, jsonSerializerOptions);
+                JsonSerializer.Serialize(writer, getPciQuestionnaireResponse.Content, jsonSerializerOptions);
             }
             if (getPciQuestionnaireResponse._CreatedAtOption.IsSet)
                 if (getPciQuestionnaireResponse._CreatedAtOption.Value != null)

--- a/Adyen/LegalEntityManagement/Models/GetTermsOfServiceDocumentResponse.cs
+++ b/Adyen/LegalEntityManagement/Models/GetTermsOfServiceDocumentResponse.cs
@@ -389,7 +389,7 @@ namespace Adyen.LegalEntityManagement.Models
                     switch (jsonPropertyName)
                     {
                         case "document":
-                            document = new Option<byte[]?>(new ByteArrayConverter().Read(ref utf8JsonReader, typeof(byte[]), jsonSerializerOptions));
+                            document = new Option<byte[]?>(JsonSerializer.Deserialize<byte[]>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "id":
                             id = new Option<string?>(utf8JsonReader.GetString()!);
@@ -458,7 +458,7 @@ namespace Adyen.LegalEntityManagement.Models
             if (getTermsOfServiceDocumentResponse._DocumentOption.IsSet)
             {
                 writer.WritePropertyName("document");
-                new ByteArrayConverter().Write(writer, getTermsOfServiceDocumentResponse.Document, jsonSerializerOptions);
+                JsonSerializer.Serialize(writer, getTermsOfServiceDocumentResponse.Document, jsonSerializerOptions);
             }
             if (getTermsOfServiceDocumentResponse._IdOption.IsSet)
                 if (getTermsOfServiceDocumentResponse.Id != null)

--- a/Adyen/Payment/Models/ThreeDSecureData.cs
+++ b/Adyen/Payment/Models/ThreeDSecureData.cs
@@ -780,7 +780,7 @@ namespace Adyen.Payment.Models
                             authenticationResponse = new Option<ThreeDSecureData.AuthenticationResponseEnum?>(ThreeDSecureData.AuthenticationResponseEnum.FromStringOrDefault(authenticationResponseRawValue) ?? (ThreeDSecureData.AuthenticationResponseEnum)authenticationResponseRawValue);
                             break;
                         case "cavv":
-                            cavv = new Option<byte[]?>(new ByteArrayConverter().Read(ref utf8JsonReader, typeof(byte[]), jsonSerializerOptions));
+                            cavv = new Option<byte[]?>(JsonSerializer.Deserialize<byte[]>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "cavvAlgorithm":
                             cavvAlgorithm = new Option<string?>(utf8JsonReader.GetString()!);
@@ -806,13 +806,13 @@ namespace Adyen.Payment.Models
                             threeDSVersion = new Option<string?>(utf8JsonReader.GetString()!);
                             break;
                         case "tokenAuthenticationVerificationValue":
-                            tokenAuthenticationVerificationValue = new Option<byte[]?>(new ByteArrayConverter().Read(ref utf8JsonReader, typeof(byte[]), jsonSerializerOptions));
+                            tokenAuthenticationVerificationValue = new Option<byte[]?>(JsonSerializer.Deserialize<byte[]>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "transStatusReason":
                             transStatusReason = new Option<string?>(utf8JsonReader.GetString()!);
                             break;
                         case "xid":
-                            xid = new Option<byte[]?>(new ByteArrayConverter().Read(ref utf8JsonReader, typeof(byte[]), jsonSerializerOptions));
+                            xid = new Option<byte[]?>(JsonSerializer.Deserialize<byte[]>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         default:
                             break;
@@ -883,7 +883,7 @@ namespace Adyen.Payment.Models
             if (threeDSecureData._CavvOption.IsSet)
             {
                 writer.WritePropertyName("cavv");
-                new ByteArrayConverter().Write(writer, threeDSecureData.Cavv, jsonSerializerOptions);
+                JsonSerializer.Serialize(writer, threeDSecureData.Cavv, jsonSerializerOptions);
             }
             if (threeDSecureData._CavvAlgorithmOption.IsSet)
                 if (threeDSecureData.CavvAlgorithm != null)
@@ -920,7 +920,7 @@ namespace Adyen.Payment.Models
             if (threeDSecureData._TokenAuthenticationVerificationValueOption.IsSet)
             {
                 writer.WritePropertyName("tokenAuthenticationVerificationValue");
-                new ByteArrayConverter().Write(writer, threeDSecureData.TokenAuthenticationVerificationValue, jsonSerializerOptions);
+                JsonSerializer.Serialize(writer, threeDSecureData.TokenAuthenticationVerificationValue, jsonSerializerOptions);
             }
             if (threeDSecureData._TransStatusReasonOption.IsSet)
                 if (threeDSecureData.TransStatusReason != null)
@@ -929,7 +929,7 @@ namespace Adyen.Payment.Models
             if (threeDSecureData._XidOption.IsSet)
             {
                 writer.WritePropertyName("xid");
-                new ByteArrayConverter().Write(writer, threeDSecureData.Xid, jsonSerializerOptions);
+                JsonSerializer.Serialize(writer, threeDSecureData.Xid, jsonSerializerOptions);
             }
         }
     }

--- a/templates-v7/csharp/libraries/generichost/JsonConverter.mustache
+++ b/templates-v7/csharp/libraries/generichost/JsonConverter.mustache
@@ -57,14 +57,16 @@
             {{/discriminator}}
             {{#model.discriminator}}
             {{#model.hasDiscriminatorWithNonEmptyMapping}}
-            {{#model.composedSchemas.oneOf}}
+            {{#mappedModels}}
+            {{#model}}
             {{^vendorExtensions.x-duplicated-data-type}}
-            {{{datatypeWithEnum}}}{{nrt?}}{{^nrt}}{{#vendorExtensions.x-is-value-type}}?{{/vendorExtensions.x-is-value-type}}{{/nrt}} {{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}} = null;
+            {{classname}}{{nrt?}} {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}} = null;
             {{#-last}}
 
             {{/-last}}
             {{/vendorExtensions.x-duplicated-data-type}}
-            {{/model.composedSchemas.oneOf}}
+            {{/model}}
+            {{/mappedModels}}
             Utf8JsonReader utf8JsonReaderDiscriminator = utf8JsonReader;
             while (utf8JsonReaderDiscriminator.Read())
             {
@@ -281,16 +283,14 @@
             {{#model.discriminator}}
             {{#model.hasDiscriminatorWithNonEmptyMapping}}
             {{^model.composedSchemas.anyOf}}
-            {{#model.composedSchemas.oneOf}}
-            {{^vendorExtensions.x-duplicated-data-type}}
-            if ({{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}} != null)
-                return new {{classname}}({{#lambda.joinWithComma}}{{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}}{{#vendorExtensions.x-is-value-type}}{{^isNullable}}.Value{{/isNullable}}{{/vendorExtensions.x-is-value-type}}  {{#allVars}}{{^isDiscriminator}}{{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}}{{#required}}.Value{{nrt!}}{{^isNullable}}{{#vendorExtensions.x-is-value-type}}.Value{{/vendorExtensions.x-is-value-type}}{{/isNullable}}{{/required}}  {{/isDiscriminator}}{{/allVars}}{{/lambda.joinWithComma}});
+            {{#mappedModels}}
+            if ({{#lambda.camelcase_sanitize_param}}{{model.classname}}{{/lambda.camelcase_sanitize_param}} != null)
+                return new {{classname}}({{#lambda.joinWithComma}}{{#lambda.camelcase_sanitize_param}}{{model.classname}}{{/lambda.camelcase_sanitize_param}}{{#vendorExtensions.x-is-value-type}}{{^isNullable}}.Value{{/isNullable}}{{/vendorExtensions.x-is-value-type}}  {{#model.composedSchemas.anyOf}}{{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}}{{#vendorExtensions.x-is-value-type}}{{^isNullable}}.Value{{/isNullable}}{{/vendorExtensions.x-is-value-type}}  {{/model.composedSchemas.anyOf}}{{#allVars}}{{^isDiscriminator}}{{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}}{{#required}}.Value{{nrt!}}{{^isNullable}}{{#vendorExtensions.x-is-value-type}}.Value{{/vendorExtensions.x-is-value-type}}{{/isNullable}}{{/required}}  {{/isDiscriminator}}{{/allVars}}{{/lambda.joinWithComma}});
 
-            {{/vendorExtensions.x-duplicated-data-type}}
             {{#-last}}
             return null!;
             {{/-last}}
-            {{/model.composedSchemas.oneOf}}
+            {{/mappedModels}}
             {{/model.composedSchemas.anyOf}}
             {{/model.hasDiscriminatorWithNonEmptyMapping}}
             {{/model.discriminator}}

--- a/templates-v7/csharp/libraries/generichost/JsonConverter.mustache
+++ b/templates-v7/csharp/libraries/generichost/JsonConverter.mustache
@@ -57,16 +57,14 @@
             {{/discriminator}}
             {{#model.discriminator}}
             {{#model.hasDiscriminatorWithNonEmptyMapping}}
-            {{#mappedModels}}
-            {{#model}}
+            {{#model.composedSchemas.oneOf}}
             {{^vendorExtensions.x-duplicated-data-type}}
-            {{classname}}{{nrt?}} {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}} = null;
+            {{{datatypeWithEnum}}}{{nrt?}}{{^nrt}}{{#vendorExtensions.x-is-value-type}}?{{/vendorExtensions.x-is-value-type}}{{/nrt}} {{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}} = null;
             {{#-last}}
 
             {{/-last}}
             {{/vendorExtensions.x-duplicated-data-type}}
-            {{/model}}
-            {{/mappedModels}}
+            {{/model.composedSchemas.oneOf}}
             Utf8JsonReader utf8JsonReaderDiscriminator = utf8JsonReader;
             while (utf8JsonReaderDiscriminator.Read())
             {
@@ -251,7 +249,7 @@
                         {{^isDate}}
                         {{^isDateTime}}
                         {{#isByteArray}}
-                            {{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}} = {{>OptionProperty}}new ByteArrayConverter().Read(ref utf8JsonReader, typeof(byte[]), jsonSerializerOptions));
+                            {{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}} = {{>OptionProperty}}JsonSerializer.Deserialize<byte[]>(ref utf8JsonReader, jsonSerializerOptions){{^isNullable}}{{nrt!}}{{/isNullable}});
                         {{/isByteArray}}
                         {{^isByteArray}}
                             {{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}} = {{>OptionProperty}}JsonSerializer.Deserialize<{{{datatypeWithEnum}}}>(ref utf8JsonReader, jsonSerializerOptions){{^isNullable}}{{nrt!}}{{/isNullable}});
@@ -283,14 +281,16 @@
             {{#model.discriminator}}
             {{#model.hasDiscriminatorWithNonEmptyMapping}}
             {{^model.composedSchemas.anyOf}}
-            {{#mappedModels}}
-            if ({{#lambda.camelcase_sanitize_param}}{{model.classname}}{{/lambda.camelcase_sanitize_param}} != null)
-                return new {{classname}}({{#lambda.joinWithComma}}{{#lambda.camelcase_sanitize_param}}{{model.classname}}{{/lambda.camelcase_sanitize_param}}{{#vendorExtensions.x-is-value-type}}{{^isNullable}}.Value{{/isNullable}}{{/vendorExtensions.x-is-value-type}}  {{#model.composedSchemas.anyOf}}{{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}}{{#vendorExtensions.x-is-value-type}}{{^isNullable}}.Value{{/isNullable}}{{/vendorExtensions.x-is-value-type}}  {{/model.composedSchemas.anyOf}}{{#allVars}}{{^isDiscriminator}}{{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}}{{#required}}.Value{{nrt!}}{{^isNullable}}{{#vendorExtensions.x-is-value-type}}.Value{{/vendorExtensions.x-is-value-type}}{{/isNullable}}{{/required}}  {{/isDiscriminator}}{{/allVars}}{{/lambda.joinWithComma}});
+            {{#model.composedSchemas.oneOf}}
+            {{^vendorExtensions.x-duplicated-data-type}}
+            if ({{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}} != null)
+                return new {{classname}}({{#lambda.joinWithComma}}{{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}}{{#vendorExtensions.x-is-value-type}}{{^isNullable}}.Value{{/isNullable}}{{/vendorExtensions.x-is-value-type}}  {{#allVars}}{{^isDiscriminator}}{{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}}{{#required}}.Value{{nrt!}}{{^isNullable}}{{#vendorExtensions.x-is-value-type}}.Value{{/vendorExtensions.x-is-value-type}}{{/isNullable}}{{/required}}  {{/isDiscriminator}}{{/allVars}}{{/lambda.joinWithComma}});
 
+            {{/vendorExtensions.x-duplicated-data-type}}
             {{#-last}}
             return null!;
             {{/-last}}
-            {{/mappedModels}}
+            {{/model.composedSchemas.oneOf}}
             {{/model.composedSchemas.anyOf}}
             {{/model.hasDiscriminatorWithNonEmptyMapping}}
             {{/model.discriminator}}
@@ -636,14 +636,14 @@
             if ({{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}} != null)
             {
                 writer.WritePropertyName("{{baseName}}");
-                {{#isByteArray}}new ByteArrayConverter().Write(writer, {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}, jsonSerializerOptions);{{/isByteArray}}{{^isByteArray}}JsonSerializer.Serialize(writer, {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}, jsonSerializerOptions);{{/isByteArray}}
+                JsonSerializer.Serialize(writer, {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}, jsonSerializerOptions);
             }
             else
                 writer.WriteNull("{{baseName}}");
             {{/isNullable}}
             {{^isNullable}}
             writer.WritePropertyName("{{baseName}}");
-            {{#isByteArray}}new ByteArrayConverter().Write(writer, {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}, jsonSerializerOptions);{{/isByteArray}}{{^isByteArray}}JsonSerializer.Serialize(writer, {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}, jsonSerializerOptions);{{/isByteArray}}
+            JsonSerializer.Serialize(writer, {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}, jsonSerializerOptions);
             {{/isNullable}}
             {{/required}}
             {{^required}}
@@ -652,7 +652,7 @@
                 if ({{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}._{{name}}Option.Value != null)
                 {
                     writer.WritePropertyName("{{baseName}}");
-                    {{#isByteArray}}new ByteArrayConverter().Write(writer, {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}, jsonSerializerOptions);{{/isByteArray}}{{^isByteArray}}JsonSerializer.Serialize(writer, {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}, jsonSerializerOptions);{{/isByteArray}}
+                    JsonSerializer.Serialize(writer, {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}, jsonSerializerOptions);
                 }
                 else
                     writer.WriteNull("{{baseName}}");
@@ -660,7 +660,7 @@
             {{^isNullable}}
             {
                 writer.WritePropertyName("{{baseName}}");
-                {{#isByteArray}}new ByteArrayConverter().Write(writer, {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}, jsonSerializerOptions);{{/isByteArray}}{{^isByteArray}}JsonSerializer.Serialize(writer, {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}, jsonSerializerOptions);{{/isByteArray}}
+                JsonSerializer.Serialize(writer, {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}, jsonSerializerOptions);
             }
             {{/isNullable}}
             {{/required}}


### PR DESCRIPTION
## Description

Use `JsonSerializer.Deserialize<byte[]>` / `JsonSerializer.Serialize` for all `byte[]` fields in generated model converters, instead of hardcoding `ByteArrayConverter` directly. This delegates byte[] handling to whatever converter is registered in `JsonSerializerOptions`, restoring standard STJ extensibility.

**Key changes:**
- `ByteArrayConverter` is no longer called directly in generated converters — `JsonSerializerOptions` is respected
- `ByteArrayConverter` remains registered in `HostConfiguration` for backward compatibility in DI mode
- In bare mode (no options), STJ's default base64 behavior is used — aligning with the Java SDK's Jackson default handling
- 10 generated model files updated; `JsonConverter.mustache` template updated for future regeneration

## Tested scenarios
- DI mode: `ByteArrayConverter` from options is used (existing behavior preserved)
- Bare mode: STJ default base64 decode/encode (aligns with Java SDK)
- Consumer override: custom `byte[]` converter registered in options is now honored
- Roundtrip serialization for all affected models

## Fixed issue
Fixes #1738