### PR TITLE
Add mpiData CAVV byte[] serialization tests (3DS)

### DIFF
--- a/Adyen.Test/Checkout/CheckoutPaymentsBareSerializationTests.cs
+++ b/Adyen.Test/Checkout/CheckoutPaymentsBareSerializationTests.cs
@@ -320,6 +320,109 @@ namespace Adyen.Test.Checkout
         }
 
         [TestMethod]
+        public void Given_PaymentRequest_With_MpiData_When_BareSerialize_Then_CavvIsBase64Encoded()
+        {
+            // "3q2+78r+ur7erb7vyv66vv////8=" is the CAVV from the Adyen 3DS mpiData docs sample.
+            // ByteArrayConverter stores the UTF-8 bytes of the base64 string, so when written back
+            // it produces the same base64 string in JSON.
+            byte[] cavvBytes = Encoding.UTF8.GetBytes("3q2+78r+ur7erb7vyv66vv////8=");
+            var request = new PaymentRequest
+            {
+                MerchantAccount = "YOUR_MERCHANT_ACCOUNT",
+                Amount = new Amount { Currency = "EUR", Value = 1000 },
+                Reference = "YOUR_ORDER_NUMBER",
+                Channel = PaymentRequest.ChannelEnum.Web,
+                PaymentMethod = new CheckoutPaymentMethod(new CardDetails { Type = CardDetails.TypeEnum.Card }),
+                ReturnUrl = "https://your-company.com/checkout",
+                MpiData = new ThreeDSecureData
+                {
+                    Cavv = cavvBytes,
+                    Eci = "05",
+                    DsTransID = "c4e59ceb-a382-4d6a-bc87-385d591fa09d",
+                    DirectoryResponse = ThreeDSecureData.DirectoryResponseEnum.C,
+                    AuthenticationResponse = ThreeDSecureData.AuthenticationResponseEnum.Y,
+                    ThreeDSVersion = "2.1.0",
+                },
+            };
+
+            string result = JsonSerializer.Serialize(request);
+
+            using JsonDocument json = JsonDocument.Parse(result);
+            JsonElement mpiData = json.RootElement.GetProperty("mpiData");
+            Assert.AreEqual("3q2+78r+ur7erb7vyv66vv////8=", mpiData.GetProperty("cavv").GetString());
+            Assert.AreEqual("05", mpiData.GetProperty("eci").GetString());
+            Assert.AreEqual("c4e59ceb-a382-4d6a-bc87-385d591fa09d", mpiData.GetProperty("dsTransID").GetString());
+            Assert.AreEqual("C", mpiData.GetProperty("directoryResponse").GetString());
+            Assert.AreEqual("Y", mpiData.GetProperty("authenticationResponse").GetString());
+            Assert.AreEqual("2.1.0", mpiData.GetProperty("threeDSVersion").GetString());
+        }
+
+        [TestMethod]
+        public void Given_PaymentRequest_Json_With_MpiData_When_BareDeserialize_Then_CavvBytesAreCorrect()
+        {
+            string json = """
+                {
+                  "amount": { "currency": "EUR", "value": 1000 },
+                  "merchantAccount": "YOUR_MERCHANT_ACCOUNT",
+                  "reference": "YOUR_ORDER_NUMBER",
+                  "channel": "Web",
+                  "mpiData": {
+                    "cavv": "3q2+78r+ur7erb7vyv66vv////8=",
+                    "eci": "05",
+                    "dsTransID": "c4e59ceb-a382-4d6a-bc87-385d591fa09d",
+                    "directoryResponse": "C",
+                    "authenticationResponse": "Y",
+                    "threeDSVersion": "2.1.0"
+                  },
+                  "paymentMethod": { "type": "card" },
+                  "returnUrl": "https://your-company.com/checkout"
+                }
+                """;
+
+            var result = JsonSerializer.Deserialize<PaymentRequest>(json);
+
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.MpiData);
+            CollectionAssert.AreEqual(Encoding.UTF8.GetBytes("3q2+78r+ur7erb7vyv66vv////8="), result.MpiData.Cavv);
+            Assert.AreEqual("05", result.MpiData.Eci);
+            Assert.AreEqual("c4e59ceb-a382-4d6a-bc87-385d591fa09d", result.MpiData.DsTransID);
+            Assert.AreEqual(ThreeDSecureData.DirectoryResponseEnum.C, result.MpiData.DirectoryResponse);
+            Assert.AreEqual(ThreeDSecureData.AuthenticationResponseEnum.Y, result.MpiData.AuthenticationResponse);
+            Assert.AreEqual("2.1.0", result.MpiData.ThreeDSVersion);
+        }
+
+        [TestMethod]
+        public void Given_ThreeDSecureData_With_TokenAuthenticationVerificationValue_When_BareRoundTrip_Then_ValuesPreserved()
+        {
+            byte[] tavvBytes = Encoding.UTF8.GetBytes("3q2+78r+ur7erb7vyv66vv////8=");
+            var original = new ThreeDSecureData
+            {
+                Cavv = tavvBytes,
+                TokenAuthenticationVerificationValue = tavvBytes,
+                Xid = tavvBytes,
+            };
+
+            string json = JsonSerializer.Serialize(original);
+            var deserialized = JsonSerializer.Deserialize<ThreeDSecureData>(json);
+
+            Assert.IsNotNull(deserialized);
+            CollectionAssert.AreEqual(tavvBytes, deserialized.Cavv);
+            CollectionAssert.AreEqual(tavvBytes, deserialized.TokenAuthenticationVerificationValue);
+            CollectionAssert.AreEqual(tavvBytes, deserialized.Xid);
+        }
+
+        [TestMethod]
+        public void Given_ThreeDSecureData_With_NullCavv_When_BareSerialize_Then_CavvIsJsonNull()
+        {
+            var data = new ThreeDSecureData { Cavv = null };
+
+            string result = JsonSerializer.Serialize(data);
+
+            using JsonDocument json = JsonDocument.Parse(result);
+            Assert.AreEqual(JsonValueKind.Null, json.RootElement.GetProperty("cavv").ValueKind);
+        }
+
+        [TestMethod]
         public void Given_PaymentRequest_When_BareSerialize_AccountInfo_NotSet_Then_KeyIsAbsent()
         {
             var request = new PaymentRequest

--- a/Adyen.Test/Payment/PaymentBareSerializationTests.cs
+++ b/Adyen.Test/Payment/PaymentBareSerializationTests.cs
@@ -128,6 +128,26 @@ namespace Adyen.Test.Payment
         }
 
         [TestMethod]
+        public void Given_ThreeDSecureData_With_TokenAuthenticationVerificationValue_When_BareRoundTrip_Then_ValuesPreserved()
+        {
+            byte[] tavvBytes = Encoding.UTF8.GetBytes("3q2+78r+ur7erb7vyv66vv////8=");
+            var original = new ThreeDSecureData
+            {
+                Cavv = tavvBytes,
+                TokenAuthenticationVerificationValue = tavvBytes,
+                Xid = tavvBytes,
+            };
+
+            string json = JsonSerializer.Serialize(original);
+            var deserialized = JsonSerializer.Deserialize<ThreeDSecureData>(json);
+
+            Assert.IsNotNull(deserialized);
+            CollectionAssert.AreEqual(tavvBytes, deserialized.Cavv);
+            CollectionAssert.AreEqual(tavvBytes, deserialized.TokenAuthenticationVerificationValue);
+            CollectionAssert.AreEqual(tavvBytes, deserialized.Xid);
+        }
+
+        [TestMethod]
         public void Given_ThreeDSecureDataObject_When_BareSerialize_Then_DoesNotThrow()
         {
             var data = new ThreeDSecureData

--- a/Adyen.Test/Payment/PaymentBareSerializationTests.cs
+++ b/Adyen.Test/Payment/PaymentBareSerializationTests.cs
@@ -65,6 +65,69 @@ namespace Adyen.Test.Payment
         }
 
         [TestMethod]
+        public void Given_PaymentRequest_With_MpiData_When_BareSerialize_Then_CavvIsBase64Encoded()
+        {
+            byte[] cavvBytes = Encoding.UTF8.GetBytes("3q2+78r+ur7erb7vyv66vv////8=");
+            var request = new PaymentRequest
+            {
+                MerchantAccount = "YOUR_MERCHANT_ACCOUNT",
+                Amount = new Amount { Currency = "EUR", Value = 1000 },
+                Reference = "YOUR_ORDER_NUMBER",
+                MpiData = new ThreeDSecureData
+                {
+                    Cavv = cavvBytes,
+                    Eci = "05",
+                    DsTransID = "c4e59ceb-a382-4d6a-bc87-385d591fa09d",
+                    DirectoryResponse = ThreeDSecureData.DirectoryResponseEnum.C,
+                    AuthenticationResponse = ThreeDSecureData.AuthenticationResponseEnum.Y,
+                    ThreeDSVersion = "2.1.0",
+                },
+            };
+
+            string result = JsonSerializer.Serialize(request);
+
+            using JsonDocument json = JsonDocument.Parse(result);
+            JsonElement mpiData = json.RootElement.GetProperty("mpiData");
+            Assert.AreEqual("3q2+78r+ur7erb7vyv66vv////8=", mpiData.GetProperty("cavv").GetString());
+            Assert.AreEqual("05", mpiData.GetProperty("eci").GetString());
+            Assert.AreEqual("c4e59ceb-a382-4d6a-bc87-385d591fa09d", mpiData.GetProperty("dsTransID").GetString());
+            Assert.AreEqual("C", mpiData.GetProperty("directoryResponse").GetString());
+            Assert.AreEqual("Y", mpiData.GetProperty("authenticationResponse").GetString());
+            Assert.AreEqual("2.1.0", mpiData.GetProperty("threeDSVersion").GetString());
+        }
+
+        [TestMethod]
+        public void Given_PaymentRequest_Json_With_MpiData_When_BareDeserialize_Then_CavvBytesAreCorrect()
+        {
+            string json = """
+                {
+                  "amount": { "currency": "EUR", "value": 1000 },
+                  "merchantAccount": "YOUR_MERCHANT_ACCOUNT",
+                  "reference": "YOUR_ORDER_NUMBER",
+                  "mpiData": {
+                    "cavv": "3q2+78r+ur7erb7vyv66vv////8=",
+                    "eci": "05",
+                    "dsTransID": "c4e59ceb-a382-4d6a-bc87-385d591fa09d",
+                    "directoryResponse": "C",
+                    "authenticationResponse": "Y",
+                    "threeDSVersion": "2.1.0"
+                  }
+                }
+                """;
+
+            var result = JsonSerializer.Deserialize<PaymentRequest>(json);
+
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.MpiData);
+            CollectionAssert.AreEqual(Encoding.UTF8.GetBytes("3q2+78r+ur7erb7vyv66vv////8="), result.MpiData.Cavv);
+            Assert.AreEqual("05", result.MpiData.Eci);
+            Assert.AreEqual("c4e59ceb-a382-4d6a-bc87-385d591fa09d", result.MpiData.DsTransID);
+            Assert.AreEqual(ThreeDSecureData.DirectoryResponseEnum.C, result.MpiData.DirectoryResponse);
+            Assert.AreEqual(ThreeDSecureData.AuthenticationResponseEnum.Y, result.MpiData.AuthenticationResponse);
+            Assert.AreEqual("2.1.0", result.MpiData.ThreeDSVersion);
+        }
+
+        [TestMethod]
         public void Given_ThreeDSecureDataObject_When_BareSerialize_Then_DoesNotThrow()
         {
             var data = new ThreeDSecureData

--- a/README.md
+++ b/README.md
@@ -135,6 +135,28 @@ long? rounded = AmountUtil.AmountToMinorUnits(12.345m, "EUR"); // Returns 1234
 decimal? amount = AmountUtil.MinorUnitsToAmount(1234L, "EUR"); // Returns 12.34
 ```
 
+### Working with `byte[]` fields
+
+Some API fields (e.g. `cavv`, `xid`, `tokenAuthenticationVerificationValue` on `ThreeDSecureData`) are typed as `byte[]`. The library serializes these using a UTF-8 pass-through: bytes are written as a UTF-8 string in JSON and read back as UTF-8 bytes — **no base64 encoding/decoding is applied by the library**.
+
+Because the Adyen API expects these values as base64 strings in JSON, you must assign the **UTF-8 bytes of the base64 string** (not the raw decoded binary):
+
+```csharp
+// Correct: store the UTF-8 bytes of the base64 string
+request.MpiData = new ThreeDSecureData
+{
+    Cavv = Encoding.UTF8.GetBytes("3q2+78r+ur7erb7vyv66vv////8="),
+};
+
+// Incorrect: raw binary bytes would produce garbled JSON
+request.MpiData = new ThreeDSecureData
+{
+    Cavv = Convert.FromBase64String("3q2+78r+ur7erb7vyv66vv////8="),
+};
+```
+
+The same applies to all other `byte[]` fields in the library.
+
 ### Serializing and Deserializing JSON Strings
 The library uses custom JSON converters for all model types, handling oneOf polymorphism, optional-field omission, enum mapping, and more. Each model carries a class-level `[JsonConverter]` attribute, so `System.Text.Json` (STJ) discovers and applies the correct converter automatically — no explicit options are required for most models.
 


### PR DESCRIPTION
## Description

Adds serialization and deserialization tests for `byte[]` fields on `ThreeDSecureData` used as `mpiData` in a `/payments` request (3D Secure third-party authentication flow). The test values are taken directly from the [Adyen 3DS authorize-mpidata docs](https://docs.adyen.com/online-payments/3d-secure/authorize-mpidata?tab=4).

### Tests added

**`CheckoutPaymentsBareSerializationTests`**
- Full `PaymentRequest` with `mpiData` — serialize and verify `cavv` and other fields appear correctly in JSON
- Full `PaymentRequest` with `mpiData` — deserialize a JSON matching the docs sample and verify `cavv` bytes
- `ThreeDSecureData` round-trip covering all three `byte[]` fields: `cavv`, `tokenAuthenticationVerificationValue`, `xid`
- `ThreeDSecureData` with explicit `null` cavv — verify `null` is written to JSON

**`PaymentBareSerializationTests`** (classic `/authorise` endpoint)
- Full `PaymentRequest` with `mpiData` — same serialize and deserialize coverage for the Payment namespace

---

## How `byte[]` serialization works in this library

The .NET library uses `ByteArrayConverter` for all `byte[]` fields, which treats them as **UTF-8 strings**:

```csharp
// Write: bytes → UTF-8 string → JSON string
writer.WriteStringValue(Encoding.UTF8.GetString(value));

// Read: JSON string → UTF-8 bytes
return Encoding.UTF8.GetBytes(reader.GetString());
```

This means the `byte[]` field in the model holds the **UTF-8 bytes of whatever string appears in JSON**, not decoded binary data.

---

## Alignment with the Java library

The [adyen-java-api-library](https://github.com/Adyen/adyen-java-api-library) uses the same approach via a custom `ByteArraySerializer`/`ByteArrayDeserializer` registered on the Jackson `ObjectMapper`:

```java
// Serialize
jsonGenerator.writeString(new String(bytes)); // bytes → UTF-8 string

// Deserialize
return jsonParser.getValueAsString().getBytes(StandardCharsets.UTF_8);
```

The .NET and Java libraries are **fully aligned** in their `byte[]` handling.

---

## Developer note: how to use `byte[]` fields (e.g. `cavv`)

The Adyen API expects `cavv` as a base64-encoded string in the JSON payload:

```json
{ "mpiData": { "cavv": "3q2+78r+ur7erb7vyv66vv////8=", ... } }
```

Because the library uses UTF-8 pass-through (not binary-to-base64 encoding), the `byte[]` field must be populated with the **UTF-8 bytes of the base64 string** — not the raw decoded binary bytes:

```csharp
// Correct: store the UTF-8 bytes of the base64 string
request.MpiData = new ThreeDSecureData
{
    Cavv = Encoding.UTF8.GetBytes("3q2+78r+ur7erb7vyv66vv////8="),
    ...
};

// Incorrect: this would write garbage characters to the JSON
request.MpiData = new ThreeDSecureData
{
    Cavv = Convert.FromBase64String("3q2+78r+ur7erb7vyv66vv////8="),
    ...
};
```

The same applies to `xid` and `tokenAuthenticationVerificationValue`.

---

## Tested scenarios

- Serialize `PaymentRequest` with `mpiData` (Checkout and Payment namespaces)
- Deserialize JSON `mpiData` with all relevant fields
- Round-trip all three `byte[]` fields on `ThreeDSecureData`
- Null `byte[]` serialization

## Fixed issue

N/A — documentation and coverage improvement
