### PR TITLE
Fix Terminal API deserializer crash when eventType present at root level

### DIFF
--- a/Adyen.Test/TerminalApi/DeserializerTest.cs
+++ b/Adyen.Test/TerminalApi/DeserializerTest.cs
@@ -1,5 +1,6 @@
 ﻿using Adyen.ApiSerialization;
 using Adyen.Model.TerminalApi;
+using Adyen.Model.TerminalApi.Message;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Adyen.Test
@@ -7,6 +8,116 @@ namespace Adyen.Test
     [TestClass]
     public class DeserializerTest
     {
+        // Regression test for https://github.com/Adyen/adyen-dotnet-api-library/issues/1771
+        // DeserializeNotification should handle responses that include an "eventType" field at the root level.
+        [TestMethod]
+        public void DeserializeNotification_WithEventTypeAtRootLevel_ShouldNotThrow()
+        {
+            var serializer = new SaleToPoiMessageSerializer();
+            const string json = @"{
+                ""eventType"": ""REJECT"",
+                ""SaleToPOIRequest"": {
+                    ""MessageHeader"": {
+                        ""DeviceID"": ""device123"",
+                        ""MessageCategory"": ""Event"",
+                        ""MessageClass"": ""Event"",
+                        ""MessageType"": ""Notification"",
+                        ""POIID"": ""S1EL-device123"",
+                        ""ProtocolVersion"": ""3.0"",
+                        ""SaleID"": ""000"",
+                        ""ServiceID"": ""89bd8837e0""
+                    },
+                    ""EventNotification"": {
+                        ""RejectedMessage"": ""c29tZSBtZXNzYWdl"",
+                        ""EventToNotify"": ""Reject"",
+                        ""TimeStamp"": ""2026-06-01T12:51:26.438Z"",
+                        ""EventDetails"": ""message=Failed+to+send+message+to+POI.""
+                    }
+                }
+            }";
+
+            var result = serializer.DeserializeNotification(json);
+
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.MessageHeader);
+            Assert.IsNotNull(result.MessagePayload);
+            Assert.IsInstanceOfType(result.MessagePayload, typeof(EventNotification));
+        }
+
+        // Regression test for https://github.com/Adyen/adyen-dotnet-api-library/issues/1771
+        // Deserialize should handle responses that include an "eventType" field at the root level.
+        [TestMethod]
+        public void Deserialize_WithEventTypeAtRootLevel_ShouldNotThrow()
+        {
+            var serializer = new SaleToPoiMessageSerializer();
+            const string json = @"{
+                ""eventType"": ""REJECT"",
+                ""SaleToPOIResponse"": {
+                    ""MessageHeader"": {
+                        ""ProtocolVersion"": ""3.0"",
+                        ""SaleID"": ""POSSystemID12345"",
+                        ""MessageClass"": ""Service"",
+                        ""MessageCategory"": ""Payment"",
+                        ""ServiceID"": ""20095135"",
+                        ""POIID"": ""MX925-260390740"",
+                        ""MessageType"": ""Response""
+                    },
+                    ""PaymentResponse"": {
+                        ""POIData"": {},
+                        ""PaymentResult"": {
+                            ""PaymentType"": ""Normal""
+                        },
+                        ""Response"": {
+                            ""Result"": ""Success""
+                        }
+                    }
+                }
+            }";
+
+            var result = serializer.Deserialize(json);
+
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.MessageHeader);
+            Assert.IsNotNull(result.MessagePayload);
+            Assert.IsInstanceOfType(result.MessagePayload, typeof(PaymentResponse));
+        }
+
+        // Regression test for https://github.com/Adyen/adyen-dotnet-api-library/issues/1771
+        // SaleToPoiMessageSecuredSerializer.Deserialize should handle responses with an "eventType" field at the root level.
+        [TestMethod]
+        public void SecuredDeserialize_WithEventTypeAtRootLevel_ShouldNotThrow()
+        {
+            var serializer = new SaleToPoiMessageSecuredSerializer();
+            const string json = @"{
+                ""eventType"": ""REJECT"",
+                ""SaleToPOIResponse"": {
+                    ""MessageHeader"": {
+                        ""ProtocolVersion"": ""3.0"",
+                        ""SaleID"": ""John"",
+                        ""MessageClass"": ""Service"",
+                        ""MessageCategory"": ""Payment"",
+                        ""ServiceID"": ""9739"",
+                        ""POIID"": ""MX915-284251016"",
+                        ""MessageType"": ""Response""
+                    },
+                    ""NexoBlob"": ""dummyblob"",
+                    ""SecurityTrailer"": {
+                        ""AdyenCryptoVersion"": 1,
+                        ""Nonce"": ""YIyJBzjWFCAZn31QfAvGLA=="",
+                        ""KeyIdentifier"": ""testkey"",
+                        ""Hmac"": ""hpptt0KfxlALCMSo35tTwtgw6fDNbQEESOTdD0AD9Sg="",
+                        ""KeyVersion"": 1
+                    }
+                }
+            }";
+
+            var result = serializer.Deserialize(json);
+
+            Assert.IsNotNull(result);
+            Assert.IsNotNull(result.MessageHeader);
+            Assert.AreEqual("dummyblob", result.NexoBlob);
+        }
+
         [TestMethod]
         public void PrinterStatusSerializerTest()
         {

--- a/Adyen/TerminalApi/ApiSerialization/SaleToPoiMessageSecuredSerializer.cs
+++ b/Adyen/TerminalApi/ApiSerialization/SaleToPoiMessageSecuredSerializer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Runtime.Serialization;
 using Adyen.Exceptions;
 using Adyen.Model.TerminalApi;
@@ -24,8 +25,10 @@ namespace Adyen.ApiSerialization
 
             CheckForTerminalError(saleToPoiMessageSecuredJObject);
 
-            var saleToPoiMessageSecuredJObjectRoot = saleToPoiMessageSecuredJObject.First;
-            var saleToPoiMessageSecuredJObjectWithoutRoot = saleToPoiMessageSecuredJObjectRoot?.First;
+            var saleToPoiMessageSecuredJObjectWithoutRoot = saleToPoiMessageSecuredJObject
+                .Properties()
+                .FirstOrDefault(p => p.Value.Type == JTokenType.Object)
+                ?.Value;
             if (saleToPoiMessageSecuredJObjectWithoutRoot != null)
             {
                 return ParseSaleToPoiMessageSecured(saleToPoiMessageSecuredJObjectWithoutRoot);

--- a/Adyen/TerminalApi/ApiSerialization/SaleToPoiMessageSerializer.cs
+++ b/Adyen/TerminalApi/ApiSerialization/SaleToPoiMessageSerializer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Adyen.Model.TerminalApi;
 using Adyen.Model.TerminalApi.Message;
 using Adyen.Security;
@@ -19,8 +20,10 @@ namespace Adyen.ApiSerialization
         public SaleToPOIResponse Deserialize(string saleToPoiMessageDto)
         {
             var saleToPoiMessageJObject = JObject.Parse(saleToPoiMessageDto);
-            var saleToPoiMessageRootJToken = saleToPoiMessageJObject.First;
-            var saleToPoiMessageWithoutRootJToken = saleToPoiMessageRootJToken.First;
+            var saleToPoiMessageWithoutRootJToken = saleToPoiMessageJObject
+                .Properties()
+                .FirstOrDefault(p => p.Value.Type == JTokenType.Object)
+                ?.Value ?? throw new ArgumentException("Root object (e.g., SaleToPOIResponse) not found in the JSON payload.", nameof(saleToPoiMessageDto));
             //Messageheader
             var messageHeader = DeserializeMessageHeader(saleToPoiMessageWithoutRootJToken);
             //Message payload
@@ -47,9 +50,11 @@ namespace Adyen.ApiSerialization
         {
             // Parse JsonObject
             var saleToPoiRequestJson = JObject.Parse(terminalNotificationJson);
-            var saleToPoiRequestItem = saleToPoiRequestJson.First;
-            var saleToPoiRequestType = saleToPoiRequestItem?.First;
-            var saleToPoiString = saleToPoiRequestType?.ToString() ?? throw new ArgumentNullException(nameof(terminalNotificationJson));
+            var saleToPoiRequestType = saleToPoiRequestJson
+                .Properties()
+                .FirstOrDefault(p => p.Value.Type == JTokenType.Object)
+                ?.Value ?? throw new ArgumentException("Root object (e.g., SaleToPOIRequest) not found in the JSON payload.", nameof(terminalNotificationJson));
+            var saleToPoiString = saleToPoiRequestType.ToString();
 
             // Get Message Header
             var messageHeader = DeserializeMessageHeader(saleToPoiRequestType);


### PR DESCRIPTION
## Description

Fixes a `NullReferenceException` in `SaleToPoiMessageSerializer.DeserializeNotification` (and the same fragility in `Deserialize` and `SaleToPoiMessageSecuredSerializer.Deserialize`) when Adyen's backend returns a notification envelope that includes an `eventType` field before `SaleToPOIRequest`.

**Note**: this is not an expected scenario, however the SDK code should be able to handle new attributes at any level (including new root attributes).

## Root cause
All three deserializers used positional `.First?.First` navigation on the parsed `JObject`, assuming the first JSON property is always the message root (`SaleToPOIRequest`/`SaleToPOIResponse`). When `eventType` appears first, `.First` returns that string property instead, and the subsequent navigation yields `null`.

Fix: replace positional navigation with `.Properties().FirstOrDefault(p => p.Value.Type == JTokenType.Object)?.Value`, which skips any scalar root-level properties and reliably finds the message envelope regardless of field ordering.

## Tested scenarios

- `DeserializeNotification` with `eventType` before `SaleToPOIRequest` (regression test for #1771)
- `Deserialize` with `eventType` before `SaleToPOIResponse`
- `SaleToPoiMessageSecuredSerializer.Deserialize` with `eventType` before `SaleToPOIResponse`
- All 766 existing tests continue to pass

## Fixed issue

Fixes #1771