### PR TITLE
feat: add device-api endpoints to ClientConfig

### DIFF
--- a/Adyen.Test/TerminalApi/RegionTest.cs
+++ b/Adyen.Test/TerminalApi/RegionTest.cs
@@ -73,5 +73,35 @@ namespace Adyen.Test
             // Assert that the India region endpoint maps to null.
             Assert.IsNull(actualUrl);
         }
+
+        [TestMethod]
+        public void TestDeviceApiEndpointsMapping()
+        {
+            Dictionary<Region, string> expected = RegionMapping.DEVICE_API_ENDPOINTS_MAPPING
+                                    .ToDictionary(
+                                        entry => entry.Key,
+                                        entry => entry.Value
+                                    );
+
+            var actual = new Dictionary<Region, string>
+            {
+                { Region.EU, "https://device-api-live.adyen.com" },
+                { Region.AU, "https://device-api-live-au.adyen.com" },
+                { Region.US, "https://device-api-live-us.adyen.com" },
+                { Region.APSE, "https://device-api-live-apse.adyen.com" },
+            };
+
+            CollectionAssert.AreEquivalent(actual, expected);
+        }
+
+        [TestMethod]
+        public void TestDeviceApiClientConfigConstants()
+        {
+            Assert.AreEqual("https://device-api-test.adyen.com", ClientConfig.DeviceApiEndPointTest);
+            Assert.AreEqual("https://device-api-live.adyen.com", ClientConfig.DeviceApiEndPointEULive);
+            Assert.AreEqual("https://device-api-live-au.adyen.com", ClientConfig.DeviceApiEndPointAULive);
+            Assert.AreEqual("https://device-api-live-us.adyen.com", ClientConfig.DeviceApiEndPointUSLive);
+            Assert.AreEqual("https://device-api-live-apse.adyen.com", ClientConfig.DeviceApiEndPointAPSELive);
+        }
     }
 }

--- a/Adyen.Test/TerminalApi/RegionTest.cs
+++ b/Adyen.Test/TerminalApi/RegionTest.cs
@@ -77,11 +77,7 @@ namespace Adyen.Test
         [TestMethod]
         public void TestDeviceApiEndpointsMapping()
         {
-            Dictionary<Region, string> expected = RegionMapping.DEVICE_API_ENDPOINTS_MAPPING
-                                    .ToDictionary(
-                                        entry => entry.Key,
-                                        entry => entry.Value
-                                    );
+            var expected = RegionMapping.DEVICE_API_ENDPOINTS_MAPPING;
 
             var actual = new Dictionary<Region, string>
             {

--- a/Adyen/TerminalApi/Constants/ClientConfig.cs
+++ b/Adyen/TerminalApi/Constants/ClientConfig.cs
@@ -1,4 +1,4 @@
-﻿namespace Adyen.Constants
+namespace Adyen.Constants
 {
     public class ClientConfig
     {
@@ -10,6 +10,15 @@
         public const string CloudApiEndPointAULive = "https://terminal-api-live-au.adyen.com";
         public const string CloudApiEndPointUSLive = "https://terminal-api-live-us.adyen.com";
         public const string CloudApiEndPointAPSELive = "https://terminal-api-live-apse.adyen.com";
+
+        //Test device api endpoints
+        public const string DeviceApiEndPointTest = "https://device-api-test.adyen.com";
+
+        //Live device api endpoints
+        public const string DeviceApiEndPointEULive = "https://device-api-live.adyen.com";
+        public const string DeviceApiEndPointAULive = "https://device-api-live-au.adyen.com";
+        public const string DeviceApiEndPointUSLive = "https://device-api-live-us.adyen.com";
+        public const string DeviceApiEndPointAPSELive = "https://device-api-live-apse.adyen.com";
         
         public const string NexoProtocolVersion = "3.0";
         

--- a/Adyen/TerminalApi/Constants/Region.cs
+++ b/Adyen/TerminalApi/Constants/Region.cs
@@ -53,7 +53,7 @@ namespace Adyen.Constants
         /// <summary>
         /// Maps regions to their respective Cloud Device API live endpoints.
         /// </summary>
-        public static readonly Dictionary<Region, string> DEVICE_API_ENDPOINTS_MAPPING = new Dictionary<Region, string>()
+        public static readonly IReadOnlyDictionary<Region, string> DEVICE_API_ENDPOINTS_MAPPING = new Dictionary<Region, string>()
         {
             { Region.EU, "https://device-api-live.adyen.com" },
             { Region.AU, "https://device-api-live-au.adyen.com" },

--- a/Adyen/TerminalApi/Constants/Region.cs
+++ b/Adyen/TerminalApi/Constants/Region.cs
@@ -49,5 +49,16 @@ namespace Adyen.Constants
             { Region.US, "https://terminal-api-live-us.adyen.com" },
             { Region.APSE, "https://terminal-api-live-apse.adyen.com" }
         };
+
+        /// <summary>
+        /// Maps regions to their respective Cloud Device API live endpoints.
+        /// </summary>
+        public static readonly Dictionary<Region, string> DEVICE_API_ENDPOINTS_MAPPING = new Dictionary<Region, string>()
+        {
+            { Region.EU, "https://device-api-live.adyen.com" },
+            { Region.AU, "https://device-api-live-au.adyen.com" },
+            { Region.US, "https://device-api-live-us.adyen.com" },
+            { Region.APSE, "https://device-api-live-apse.adyen.com" }
+        };
     }
 }


### PR DESCRIPTION
Resolves #1787. Added device-api test and live endpoints (including regional live endpoints) to ClientConfig, as well as a DEVICE_API_ENDPOINTS_MAPPING dictionary to RegionMapping in Region.cs, matching the Terminal API endpoints mapping structure. Added unit tests verifying these additions.