### PR TITLE
fix: use case-insensitive comparer in IEnum GetHashCode

### DIFF
--- a/Adyen.Test/Core/IEnumTest.cs
+++ b/Adyen.Test/Core/IEnumTest.cs
@@ -209,6 +209,32 @@ namespace Adyen.Test.Core
             Assert.AreEqual(ExampleEnum.A, result.ExampleEnum);
         }
 
+        [TestMethod]
+        public void Given_GetHashCode_When_SameValueDifferentCase_Then_HashCodesAreEqual()
+        {
+            ExampleEnum lower = (ExampleEnum)"active";
+            ExampleEnum upper = (ExampleEnum)"ACTIVE";
+
+            // Equals must be true (already works)
+            Assert.IsTrue(lower.Equals(upper));
+
+            // GetHashCode must also be equal — this is the contract being fixed
+            Assert.AreEqual(lower.GetHashCode(), upper.GetHashCode());
+        }
+
+        [TestMethod]
+        public void Given_DictionaryWithEnumKey_When_LookupWithDifferentCase_Then_FindsEntry()
+        {
+            var dict = new Dictionary<ExampleEnum, string>
+            {
+                { (ExampleEnum)"active", "found" }
+            };
+
+            // Before the fix this would silently return false — key not found
+            Assert.IsTrue(dict.ContainsKey((ExampleEnum)"ACTIVE"));
+            Assert.AreEqual("found", dict[(ExampleEnum)"ACTIVE"]);
+        }
+
         internal class ExampleModelResponse
         {
             /// <summary>
@@ -314,7 +340,7 @@ namespace Adyen.Test.Core
 
         public override bool Equals(object? obj) => obj is ExampleEnum other && string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
-        public override int GetHashCode() => Value?.GetHashCode() ?? 0;
+        public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
 
         public static bool operator ==(ExampleEnum? left, ExampleEnum? right) =>
             string.Equals(left?.Value, right?.Value, StringComparison.OrdinalIgnoreCase);

--- a/Adyen.Test/Core/IEnumTest.cs
+++ b/Adyen.Test/Core/IEnumTest.cs
@@ -340,7 +340,7 @@ namespace Adyen.Test.Core
 
         public override bool Equals(object? obj) => obj is ExampleEnum other && string.Equals(Value, other.Value, StringComparison.OrdinalIgnoreCase);
 
-        public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+        public override int GetHashCode() => Value != null ? StringComparer.OrdinalIgnoreCase.GetHashCode(Value) : 0;
 
         public static bool operator ==(ExampleEnum? left, ExampleEnum? right) =>
             string.Equals(left?.Value, right?.Value, StringComparison.OrdinalIgnoreCase);

--- a/templates-v7/csharp/libraries/generichost/modelEnum.mustache
+++ b/templates-v7/csharp/libraries/generichost/modelEnum.mustache
@@ -59,7 +59,7 @@
         /// <summary>
         /// Returns a hash code for this <see cref="{{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}"/> instance.
         /// </summary>
-        public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+        public override int GetHashCode() => Value != null ? StringComparer.OrdinalIgnoreCase.GetHashCode(Value) : 0;
 
         /// <summary>
         /// Returns the string value of the <see cref="{{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}"/> instance.

--- a/templates-v7/csharp/libraries/generichost/modelEnum.mustache
+++ b/templates-v7/csharp/libraries/generichost/modelEnum.mustache
@@ -59,7 +59,7 @@
         /// <summary>
         /// Returns a hash code for this <see cref="{{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}"/> instance.
         /// </summary>
-        public override int GetHashCode() => Value?.GetHashCode() ?? 0;
+        public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
 
         /// <summary>
         /// Returns the string value of the <see cref="{{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}"/> instance.

--- a/templates-v7/csharp/libraries/generichost/modelInnerEnum.mustache
+++ b/templates-v7/csharp/libraries/generichost/modelInnerEnum.mustache
@@ -66,7 +66,7 @@
             /// <summary>
             /// Returns a hash code for this <see cref="{{datatypeWithEnum}}"/> instance.
             /// </summary>
-            public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
+            public override int GetHashCode() => Value != null ? StringComparer.OrdinalIgnoreCase.GetHashCode(Value) : 0;
 
             /// <summary>
             /// Returns the string value of the <see cref="{{datatypeWithEnum}}"/> instance.

--- a/templates-v7/csharp/libraries/generichost/modelInnerEnum.mustache
+++ b/templates-v7/csharp/libraries/generichost/modelInnerEnum.mustache
@@ -66,7 +66,7 @@
             /// <summary>
             /// Returns a hash code for this <see cref="{{datatypeWithEnum}}"/> instance.
             /// </summary>
-            public override int GetHashCode() => Value?.GetHashCode() ?? 0;
+            public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty);
 
             /// <summary>
             /// Returns the string value of the <see cref="{{datatypeWithEnum}}"/> instance.


### PR DESCRIPTION
Fixes #1679

`GetHashCode()` in both `modelEnum.mustache` and `modelInnerEnum.mustache` used the default case-sensitive string hash, while `Equals()` and `==` use `StringComparison.OrdinalIgnoreCase`. This violates the .NET hash/equality contract, objects that compare equal must produce equal hash codes.

**Description**
`GetHashCode()` was returning `Value?.GetHashCode() ?? 0`, which is case-sensitive. Since `Equals()` uses `StringComparison.OrdinalIgnoreCase`, two instances with the same value but different casing (e.g. `"valid"` vs `"VALID"`) would be considered equal but produce different hash codes — causing silent lookup failures when used as dictionary keys or in hash sets.

Fixed by replacing with `StringComparer.OrdinalIgnoreCase.GetHashCode(Value ?? string.Empty)` in both templates.

**Tested scenarios**
- Same value with different casing produces equal hash codes
- Dictionary lookup succeeds when key casing differs from inserted key
- All existing IEnum tests continue to pass

**Fixed issue**: #1679