### PR TITLE
Fix required numeric null deserialization

### DIFF
--- a/Adyen.Test/Core/Serialization/BareSerializationTests.cs
+++ b/Adyen.Test/Core/Serialization/BareSerializationTests.cs
@@ -27,6 +27,50 @@ namespace Adyen.Test.Core.Serialization
         }
 
         [TestMethod]
+        public void Given_AmountJson_When_RequiredValueIsNull_Then_ThrowsJsonException()
+        {
+            string json = "{\"currency\":\"GBP\",\"value\":null}";
+
+            var exception = Assert.ThrowsExactly<JsonException>(() => JsonSerializer.Deserialize<Amount>(json));
+
+            StringAssert.Contains(exception.Message, "Property 'value' on 'Amount' cannot be null.");
+        }
+
+        [TestMethod]
+        public void Given_AmountJson_When_RequiredValueIsMissing_Then_UsesDefaultValue()
+        {
+            string json = "{\"currency\":\"GBP\"}";
+
+            var amount = JsonSerializer.Deserialize<Amount>(json);
+
+            Assert.IsNotNull(amount);
+            Assert.AreEqual("GBP", amount.Currency);
+            Assert.AreEqual(0L, amount.Value);
+        }
+
+        [TestMethod]
+        public void Given_InstallmentsJson_When_RequiredIntValueIsNull_Then_ThrowsJsonException()
+        {
+            string json = "{\"value\":null}";
+
+            var exception = Assert.ThrowsExactly<JsonException>(() => JsonSerializer.Deserialize<Installments>(json));
+
+            StringAssert.Contains(exception.Message, "Property 'value' on 'Installments' cannot be null.");
+        }
+
+        [TestMethod]
+        public void Given_InstallmentsJson_When_OptionalIntValueIsNull_Then_AcceptsNull()
+        {
+            string json = "{\"value\":1,\"extra\":null}";
+
+            var installments = JsonSerializer.Deserialize<Installments>(json);
+
+            Assert.IsNotNull(installments);
+            Assert.AreEqual(1, installments.Value);
+            Assert.IsNull(installments.Extra);
+        }
+
+        [TestMethod]
         public void Given_AmountObject_When_BareSerialize_Then_Returns_CorrectJson()
         {
             var amount = new Amount { Currency = "USD", Value = 500 };
@@ -107,6 +151,14 @@ namespace Adyen.Test.Core.Serialization
             Assert.IsNotNull(request.Amount);
             Assert.AreEqual("EUR", request.Amount.Currency);
             Assert.AreEqual(1000L, request.Amount.Value);
+        }
+
+        [TestMethod]
+        public void Given_PaymentRequestJson_When_NestedAmountValueIsNull_Then_ThrowsJsonException()
+        {
+            string json = "{\"amount\":{\"currency\":\"GBP\",\"value\":null}}";
+
+            Assert.ThrowsExactly<JsonException>(() => JsonSerializer.Deserialize<PaymentRequest>(json));
         }
 
         [TestMethod]

--- a/Adyen/Checkout/Models/Amount.cs
+++ b/Adyen/Checkout/Models/Amount.cs
@@ -119,6 +119,8 @@ namespace Adyen.Checkout.Models
                             currency = new Option<string?>(utf8JsonReader.GetString()!);
                             break;
                         case "value":
+                            if (utf8JsonReader.TokenType == JsonTokenType.Null)
+                                throw new JsonException("Property 'value' on 'Amount' cannot be null.");
                             value = new Option<long?>(utf8JsonReader.TokenType == JsonTokenType.Null ? (long?)null : utf8JsonReader.GetInt64());
                             break;
                         default:

--- a/Adyen/Checkout/Models/BrowserInfo.cs
+++ b/Adyen/Checkout/Models/BrowserInfo.cs
@@ -189,6 +189,8 @@ namespace Adyen.Checkout.Models
                             acceptHeader = new Option<string?>(utf8JsonReader.GetString()!);
                             break;
                         case "colorDepth":
+                            if (utf8JsonReader.TokenType == JsonTokenType.Null)
+                                throw new JsonException("Property 'colorDepth' on 'BrowserInfo' cannot be null.");
                             colorDepth = new Option<int?>(utf8JsonReader.TokenType == JsonTokenType.Null ? (int?)null : utf8JsonReader.GetInt32());
                             break;
                         case "javaEnabled":
@@ -198,12 +200,18 @@ namespace Adyen.Checkout.Models
                             language = new Option<string?>(utf8JsonReader.GetString()!);
                             break;
                         case "screenHeight":
+                            if (utf8JsonReader.TokenType == JsonTokenType.Null)
+                                throw new JsonException("Property 'screenHeight' on 'BrowserInfo' cannot be null.");
                             screenHeight = new Option<int?>(utf8JsonReader.TokenType == JsonTokenType.Null ? (int?)null : utf8JsonReader.GetInt32());
                             break;
                         case "screenWidth":
+                            if (utf8JsonReader.TokenType == JsonTokenType.Null)
+                                throw new JsonException("Property 'screenWidth' on 'BrowserInfo' cannot be null.");
                             screenWidth = new Option<int?>(utf8JsonReader.TokenType == JsonTokenType.Null ? (int?)null : utf8JsonReader.GetInt32());
                             break;
                         case "timeZoneOffset":
+                            if (utf8JsonReader.TokenType == JsonTokenType.Null)
+                                throw new JsonException("Property 'timeZoneOffset' on 'BrowserInfo' cannot be null.");
                             timeZoneOffset = new Option<int?>(utf8JsonReader.TokenType == JsonTokenType.Null ? (int?)null : utf8JsonReader.GetInt32());
                             break;
                         case "userAgent":

--- a/Adyen/Checkout/Models/ForexQuote.cs
+++ b/Adyen/Checkout/Models/ForexQuote.cs
@@ -277,6 +277,8 @@ namespace Adyen.Checkout.Models
                     switch (jsonPropertyName)
                     {
                         case "basePoints":
+                            if (utf8JsonReader.TokenType == JsonTokenType.Null)
+                                throw new JsonException("Property 'basePoints' on 'ForexQuote' cannot be null.");
                             basePoints = new Option<int?>(utf8JsonReader.TokenType == JsonTokenType.Null ? (int?)null : utf8JsonReader.GetInt32());
                             break;
                         case "validTill":

--- a/Adyen/Checkout/Models/FraudCheckResult.cs
+++ b/Adyen/Checkout/Models/FraudCheckResult.cs
@@ -125,9 +125,13 @@ namespace Adyen.Checkout.Models
                     switch (jsonPropertyName)
                     {
                         case "accountScore":
+                            if (utf8JsonReader.TokenType == JsonTokenType.Null)
+                                throw new JsonException("Property 'accountScore' on 'FraudCheckResult' cannot be null.");
                             accountScore = new Option<int?>(utf8JsonReader.TokenType == JsonTokenType.Null ? (int?)null : utf8JsonReader.GetInt32());
                             break;
                         case "checkId":
+                            if (utf8JsonReader.TokenType == JsonTokenType.Null)
+                                throw new JsonException("Property 'checkId' on 'FraudCheckResult' cannot be null.");
                             checkId = new Option<int?>(utf8JsonReader.TokenType == JsonTokenType.Null ? (int?)null : utf8JsonReader.GetInt32());
                             break;
                         case "name":

--- a/Adyen/Checkout/Models/FraudResult.cs
+++ b/Adyen/Checkout/Models/FraudResult.cs
@@ -123,6 +123,8 @@ namespace Adyen.Checkout.Models
                     switch (jsonPropertyName)
                     {
                         case "accountScore":
+                            if (utf8JsonReader.TokenType == JsonTokenType.Null)
+                                throw new JsonException("Property 'accountScore' on 'FraudResult' cannot be null.");
                             accountScore = new Option<int?>(utf8JsonReader.TokenType == JsonTokenType.Null ? (int?)null : utf8JsonReader.GetInt32());
                             break;
                         case "results":

--- a/Adyen/Checkout/Models/Installments.cs
+++ b/Adyen/Checkout/Models/Installments.cs
@@ -334,6 +334,8 @@ namespace Adyen.Checkout.Models
                     switch (jsonPropertyName)
                     {
                         case "value":
+                            if (utf8JsonReader.TokenType == JsonTokenType.Null)
+                                throw new JsonException("Property 'value' on 'Installments' cannot be null.");
                             value = new Option<int?>(utf8JsonReader.TokenType == JsonTokenType.Null ? (int?)null : utf8JsonReader.GetInt32());
                             break;
                         case "extra":

--- a/Adyen/Checkout/Models/SplitAmount.cs
+++ b/Adyen/Checkout/Models/SplitAmount.cs
@@ -123,6 +123,8 @@ namespace Adyen.Checkout.Models
                     switch (jsonPropertyName)
                     {
                         case "value":
+                            if (utf8JsonReader.TokenType == JsonTokenType.Null)
+                                throw new JsonException("Property 'value' on 'SplitAmount' cannot be null.");
                             value = new Option<long?>(utf8JsonReader.TokenType == JsonTokenType.Null ? (long?)null : utf8JsonReader.GetInt64());
                             break;
                         case "currency":

--- a/Adyen/Checkout/Models/Surcharge.cs
+++ b/Adyen/Checkout/Models/Surcharge.cs
@@ -107,6 +107,8 @@ namespace Adyen.Checkout.Models
                     switch (jsonPropertyName)
                     {
                         case "value":
+                            if (utf8JsonReader.TokenType == JsonTokenType.Null)
+                                throw new JsonException("Property 'value' on 'Surcharge' cannot be null.");
                             value = new Option<long?>(utf8JsonReader.TokenType == JsonTokenType.Null ? (long?)null : utf8JsonReader.GetInt64());
                             break;
                         default:

--- a/templates-v7/csharp/libraries/generichost/JsonConverter.mustache
+++ b/templates-v7/csharp/libraries/generichost/JsonConverter.mustache
@@ -194,6 +194,12 @@
                         {{/isBoolean}}
                         {{#isNumeric}}
                         {{^isEnum}}
+                        {{#required}}
+                        {{^isNullable}}
+                            if (utf8JsonReader.TokenType == JsonTokenType.Null)
+                                throw new JsonException("Property '{{baseName}}' on '{{classname}}' cannot be null.");
+                        {{/isNullable}}
+                        {{/required}}
                         {{#isDouble}}
                             {{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}} = {{>OptionProperty}}utf8JsonReader.TokenType == JsonTokenType.Null ? (double?)null : utf8JsonReader.GetDouble());
                         {{/isDouble}}


### PR DESCRIPTION
**Description**
Reject explicit JSON null values for required numeric Checkout properties with a descriptive `JsonException`. Update the JSON converter template and affected Checkout models.

**Tested scenarios**
`DOTNET_ROLL_FORWARD=Major dotnet test Adyen.Test/Adyen.Test.csproj --filter FullyQualifiedName~BareSerializationTests --no-restore` (61 passed)

**Fix**: #1835