### PR TITLE
Fix Converter lookup for oneOf with discriminator

### DIFF
--- a/Adyen.Test/Transfers/TransfersTest.cs
+++ b/Adyen.Test/Transfers/TransfersTest.cs
@@ -205,6 +205,45 @@ namespace Adyen.Test.Transfers
         #region CategoryData Discriminator
 
         [TestMethod]
+        public void Given_CategoryData_When_SerializeWithConfiguredOptions_Returns_BankCategoryData()
+        {
+            var categoryData = new TransferCategoryData(new BankCategoryData
+            {
+                Priority = BankCategoryData.PriorityEnum.Wire
+            });
+
+            string json = JsonSerializer.Serialize(categoryData, _jsonSerializerOptionsProvider.Options);
+
+            AssertSerializedBankCategoryData(json);
+        }
+
+        [TestMethod]
+        public void Given_CategoryData_When_BareSerialize_Returns_BankCategoryData()
+        {
+            var categoryData = new TransferCategoryData(new BankCategoryData
+            {
+                Priority = BankCategoryData.PriorityEnum.Wire
+            });
+
+            string json = JsonSerializer.Serialize(categoryData);
+
+            AssertSerializedBankCategoryData(json);
+        }
+
+        [TestMethod]
+        public void Given_CategoryData_When_SerializeWithEmptyOptions_Returns_BankCategoryData()
+        {
+            var categoryData = new TransferCategoryData(new BankCategoryData
+            {
+                Priority = BankCategoryData.PriorityEnum.Wire
+            });
+
+            string json = JsonSerializer.Serialize(categoryData, new JsonSerializerOptions());
+
+            AssertSerializedBankCategoryData(json);
+        }
+
+        [TestMethod]
         public void Given_Deserialize_When_CategoryDataTypeBank_Returns_BankCategoryData()
         {
             string json = TestUtilities.GetTestFileContent("mocks/transfers/transfer-data-category-data-bank.json");
@@ -402,5 +441,14 @@ namespace Adyen.Test.Transfers
         }
         
         #endregion
+
+        private static void AssertSerializedBankCategoryData(string json)
+        {
+            using JsonDocument document = JsonDocument.Parse(json);
+            JsonElement root = document.RootElement;
+
+            Assert.AreEqual("bank", root.GetProperty("type").GetString());
+            Assert.AreEqual("wire", root.GetProperty("priority").GetString());
+        }
     }
 }

--- a/Adyen/ConfigurationWebhooks/Models/PaymentInstrumentAdditionalBankAccountIdentificationsInner.cs
+++ b/Adyen/ConfigurationWebhooks/Models/PaymentInstrumentAdditionalBankAccountIdentificationsInner.cs
@@ -276,7 +276,7 @@ namespace Adyen.ConfigurationWebhooks.Models
             
             if (paymentInstrumentAdditionalBankAccountIdentificationsInner.IbanAccountIdentification != null)
             {
-                IbanAccountIdentificationJsonConverter ibanAccountIdentificationJsonConverter = (IbanAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(paymentInstrumentAdditionalBankAccountIdentificationsInner.IbanAccountIdentification.GetType()));
+                IbanAccountIdentificationJsonConverter ibanAccountIdentificationJsonConverter = (IbanAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(paymentInstrumentAdditionalBankAccountIdentificationsInner.IbanAccountIdentification.GetType());
                 ibanAccountIdentificationJsonConverter.WriteProperties(writer, paymentInstrumentAdditionalBankAccountIdentificationsInner.IbanAccountIdentification, jsonSerializerOptions);
             }
 

--- a/Adyen/RelayedAuthorizationWebhooks/Models/PaymentInstrumentAdditionalBankAccountIdentificationsInner.cs
+++ b/Adyen/RelayedAuthorizationWebhooks/Models/PaymentInstrumentAdditionalBankAccountIdentificationsInner.cs
@@ -276,7 +276,7 @@ namespace Adyen.RelayedAuthorizationWebhooks.Models
             
             if (paymentInstrumentAdditionalBankAccountIdentificationsInner.IbanAccountIdentification != null)
             {
-                IbanAccountIdentificationJsonConverter ibanAccountIdentificationJsonConverter = (IbanAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(paymentInstrumentAdditionalBankAccountIdentificationsInner.IbanAccountIdentification.GetType()));
+                IbanAccountIdentificationJsonConverter ibanAccountIdentificationJsonConverter = (IbanAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(paymentInstrumentAdditionalBankAccountIdentificationsInner.IbanAccountIdentification.GetType());
                 ibanAccountIdentificationJsonConverter.WriteProperties(writer, paymentInstrumentAdditionalBankAccountIdentificationsInner.IbanAccountIdentification, jsonSerializerOptions);
             }
 

--- a/Adyen/TransactionWebhooks/Models/TransferViewCategoryData.cs
+++ b/Adyen/TransactionWebhooks/Models/TransferViewCategoryData.cs
@@ -381,25 +381,25 @@ namespace Adyen.TransactionWebhooks.Models
             
             if (transferViewCategoryData.BankCategoryData != null)
             {
-                BankCategoryDataJsonConverter bankCategoryDataJsonConverter = (BankCategoryDataJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferViewCategoryData.BankCategoryData.GetType()));
+                BankCategoryDataJsonConverter bankCategoryDataJsonConverter = (BankCategoryDataJsonConverter) jsonSerializerOptions.GetConverter(transferViewCategoryData.BankCategoryData.GetType());
                 bankCategoryDataJsonConverter.WriteProperties(writer, transferViewCategoryData.BankCategoryData, jsonSerializerOptions);
             }
 
             if (transferViewCategoryData.InternalCategoryData != null)
             {
-                InternalCategoryDataJsonConverter internalCategoryDataJsonConverter = (InternalCategoryDataJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferViewCategoryData.InternalCategoryData.GetType()));
+                InternalCategoryDataJsonConverter internalCategoryDataJsonConverter = (InternalCategoryDataJsonConverter) jsonSerializerOptions.GetConverter(transferViewCategoryData.InternalCategoryData.GetType());
                 internalCategoryDataJsonConverter.WriteProperties(writer, transferViewCategoryData.InternalCategoryData, jsonSerializerOptions);
             }
 
             if (transferViewCategoryData.IssuedCard != null)
             {
-                IssuedCardJsonConverter issuedCardJsonConverter = (IssuedCardJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferViewCategoryData.IssuedCard.GetType()));
+                IssuedCardJsonConverter issuedCardJsonConverter = (IssuedCardJsonConverter) jsonSerializerOptions.GetConverter(transferViewCategoryData.IssuedCard.GetType());
                 issuedCardJsonConverter.WriteProperties(writer, transferViewCategoryData.IssuedCard, jsonSerializerOptions);
             }
 
             if (transferViewCategoryData.PlatformPayment != null)
             {
-                PlatformPaymentJsonConverter platformPaymentJsonConverter = (PlatformPaymentJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferViewCategoryData.PlatformPayment.GetType()));
+                PlatformPaymentJsonConverter platformPaymentJsonConverter = (PlatformPaymentJsonConverter) jsonSerializerOptions.GetConverter(transferViewCategoryData.PlatformPayment.GetType());
                 platformPaymentJsonConverter.WriteProperties(writer, transferViewCategoryData.PlatformPayment, jsonSerializerOptions);
             }
 

--- a/Adyen/TransferWebhooks/Models/BankAccountV3AccountIdentification.cs
+++ b/Adyen/TransferWebhooks/Models/BankAccountV3AccountIdentification.cs
@@ -801,97 +801,97 @@ namespace Adyen.TransferWebhooks.Models
             
             if (bankAccountV3AccountIdentification.AULocalAccountIdentification != null)
             {
-                AULocalAccountIdentificationJsonConverter aULocalAccountIdentificationJsonConverter = (AULocalAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.AULocalAccountIdentification.GetType()));
+                AULocalAccountIdentificationJsonConverter aULocalAccountIdentificationJsonConverter = (AULocalAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.AULocalAccountIdentification.GetType());
                 aULocalAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.AULocalAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.BRLocalAccountIdentification != null)
             {
-                BRLocalAccountIdentificationJsonConverter bRLocalAccountIdentificationJsonConverter = (BRLocalAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.BRLocalAccountIdentification.GetType()));
+                BRLocalAccountIdentificationJsonConverter bRLocalAccountIdentificationJsonConverter = (BRLocalAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.BRLocalAccountIdentification.GetType());
                 bRLocalAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.BRLocalAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.CALocalAccountIdentification != null)
             {
-                CALocalAccountIdentificationJsonConverter cALocalAccountIdentificationJsonConverter = (CALocalAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.CALocalAccountIdentification.GetType()));
+                CALocalAccountIdentificationJsonConverter cALocalAccountIdentificationJsonConverter = (CALocalAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.CALocalAccountIdentification.GetType());
                 cALocalAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.CALocalAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.CZLocalAccountIdentification != null)
             {
-                CZLocalAccountIdentificationJsonConverter cZLocalAccountIdentificationJsonConverter = (CZLocalAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.CZLocalAccountIdentification.GetType()));
+                CZLocalAccountIdentificationJsonConverter cZLocalAccountIdentificationJsonConverter = (CZLocalAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.CZLocalAccountIdentification.GetType());
                 cZLocalAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.CZLocalAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.DKLocalAccountIdentification != null)
             {
-                DKLocalAccountIdentificationJsonConverter dKLocalAccountIdentificationJsonConverter = (DKLocalAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.DKLocalAccountIdentification.GetType()));
+                DKLocalAccountIdentificationJsonConverter dKLocalAccountIdentificationJsonConverter = (DKLocalAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.DKLocalAccountIdentification.GetType());
                 dKLocalAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.DKLocalAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.HKLocalAccountIdentification != null)
             {
-                HKLocalAccountIdentificationJsonConverter hKLocalAccountIdentificationJsonConverter = (HKLocalAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.HKLocalAccountIdentification.GetType()));
+                HKLocalAccountIdentificationJsonConverter hKLocalAccountIdentificationJsonConverter = (HKLocalAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.HKLocalAccountIdentification.GetType());
                 hKLocalAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.HKLocalAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.HULocalAccountIdentification != null)
             {
-                HULocalAccountIdentificationJsonConverter hULocalAccountIdentificationJsonConverter = (HULocalAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.HULocalAccountIdentification.GetType()));
+                HULocalAccountIdentificationJsonConverter hULocalAccountIdentificationJsonConverter = (HULocalAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.HULocalAccountIdentification.GetType());
                 hULocalAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.HULocalAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.IbanAccountIdentification != null)
             {
-                IbanAccountIdentificationJsonConverter ibanAccountIdentificationJsonConverter = (IbanAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.IbanAccountIdentification.GetType()));
+                IbanAccountIdentificationJsonConverter ibanAccountIdentificationJsonConverter = (IbanAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.IbanAccountIdentification.GetType());
                 ibanAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.IbanAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.NOLocalAccountIdentification != null)
             {
-                NOLocalAccountIdentificationJsonConverter nOLocalAccountIdentificationJsonConverter = (NOLocalAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.NOLocalAccountIdentification.GetType()));
+                NOLocalAccountIdentificationJsonConverter nOLocalAccountIdentificationJsonConverter = (NOLocalAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.NOLocalAccountIdentification.GetType());
                 nOLocalAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.NOLocalAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.NZLocalAccountIdentification != null)
             {
-                NZLocalAccountIdentificationJsonConverter nZLocalAccountIdentificationJsonConverter = (NZLocalAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.NZLocalAccountIdentification.GetType()));
+                NZLocalAccountIdentificationJsonConverter nZLocalAccountIdentificationJsonConverter = (NZLocalAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.NZLocalAccountIdentification.GetType());
                 nZLocalAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.NZLocalAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.NumberAndBicAccountIdentification != null)
             {
-                NumberAndBicAccountIdentificationJsonConverter numberAndBicAccountIdentificationJsonConverter = (NumberAndBicAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.NumberAndBicAccountIdentification.GetType()));
+                NumberAndBicAccountIdentificationJsonConverter numberAndBicAccountIdentificationJsonConverter = (NumberAndBicAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.NumberAndBicAccountIdentification.GetType());
                 numberAndBicAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.NumberAndBicAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.PLLocalAccountIdentification != null)
             {
-                PLLocalAccountIdentificationJsonConverter pLLocalAccountIdentificationJsonConverter = (PLLocalAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.PLLocalAccountIdentification.GetType()));
+                PLLocalAccountIdentificationJsonConverter pLLocalAccountIdentificationJsonConverter = (PLLocalAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.PLLocalAccountIdentification.GetType());
                 pLLocalAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.PLLocalAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.SELocalAccountIdentification != null)
             {
-                SELocalAccountIdentificationJsonConverter sELocalAccountIdentificationJsonConverter = (SELocalAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.SELocalAccountIdentification.GetType()));
+                SELocalAccountIdentificationJsonConverter sELocalAccountIdentificationJsonConverter = (SELocalAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.SELocalAccountIdentification.GetType());
                 sELocalAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.SELocalAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.SGLocalAccountIdentification != null)
             {
-                SGLocalAccountIdentificationJsonConverter sGLocalAccountIdentificationJsonConverter = (SGLocalAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.SGLocalAccountIdentification.GetType()));
+                SGLocalAccountIdentificationJsonConverter sGLocalAccountIdentificationJsonConverter = (SGLocalAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.SGLocalAccountIdentification.GetType());
                 sGLocalAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.SGLocalAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.UKLocalAccountIdentification != null)
             {
-                UKLocalAccountIdentificationJsonConverter uKLocalAccountIdentificationJsonConverter = (UKLocalAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.UKLocalAccountIdentification.GetType()));
+                UKLocalAccountIdentificationJsonConverter uKLocalAccountIdentificationJsonConverter = (UKLocalAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.UKLocalAccountIdentification.GetType());
                 uKLocalAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.UKLocalAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.USLocalAccountIdentification != null)
             {
-                USLocalAccountIdentificationJsonConverter uSLocalAccountIdentificationJsonConverter = (USLocalAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.USLocalAccountIdentification.GetType()));
+                USLocalAccountIdentificationJsonConverter uSLocalAccountIdentificationJsonConverter = (USLocalAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.USLocalAccountIdentification.GetType());
                 uSLocalAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.USLocalAccountIdentification, jsonSerializerOptions);
             }
 

--- a/Adyen/TransferWebhooks/Models/TransferDataCategoryData.cs
+++ b/Adyen/TransferWebhooks/Models/TransferDataCategoryData.cs
@@ -381,25 +381,25 @@ namespace Adyen.TransferWebhooks.Models
             
             if (transferDataCategoryData.BankCategoryData != null)
             {
-                BankCategoryDataJsonConverter bankCategoryDataJsonConverter = (BankCategoryDataJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferDataCategoryData.BankCategoryData.GetType()));
+                BankCategoryDataJsonConverter bankCategoryDataJsonConverter = (BankCategoryDataJsonConverter) jsonSerializerOptions.GetConverter(transferDataCategoryData.BankCategoryData.GetType());
                 bankCategoryDataJsonConverter.WriteProperties(writer, transferDataCategoryData.BankCategoryData, jsonSerializerOptions);
             }
 
             if (transferDataCategoryData.InternalCategoryData != null)
             {
-                InternalCategoryDataJsonConverter internalCategoryDataJsonConverter = (InternalCategoryDataJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferDataCategoryData.InternalCategoryData.GetType()));
+                InternalCategoryDataJsonConverter internalCategoryDataJsonConverter = (InternalCategoryDataJsonConverter) jsonSerializerOptions.GetConverter(transferDataCategoryData.InternalCategoryData.GetType());
                 internalCategoryDataJsonConverter.WriteProperties(writer, transferDataCategoryData.InternalCategoryData, jsonSerializerOptions);
             }
 
             if (transferDataCategoryData.IssuedCard != null)
             {
-                IssuedCardJsonConverter issuedCardJsonConverter = (IssuedCardJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferDataCategoryData.IssuedCard.GetType()));
+                IssuedCardJsonConverter issuedCardJsonConverter = (IssuedCardJsonConverter) jsonSerializerOptions.GetConverter(transferDataCategoryData.IssuedCard.GetType());
                 issuedCardJsonConverter.WriteProperties(writer, transferDataCategoryData.IssuedCard, jsonSerializerOptions);
             }
 
             if (transferDataCategoryData.PlatformPayment != null)
             {
-                PlatformPaymentJsonConverter platformPaymentJsonConverter = (PlatformPaymentJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferDataCategoryData.PlatformPayment.GetType()));
+                PlatformPaymentJsonConverter platformPaymentJsonConverter = (PlatformPaymentJsonConverter) jsonSerializerOptions.GetConverter(transferDataCategoryData.PlatformPayment.GetType());
                 platformPaymentJsonConverter.WriteProperties(writer, transferDataCategoryData.PlatformPayment, jsonSerializerOptions);
             }
 

--- a/Adyen/TransferWebhooks/Models/TransferDataTracing.cs
+++ b/Adyen/TransferWebhooks/Models/TransferDataTracing.cs
@@ -311,13 +311,13 @@ namespace Adyen.TransferWebhooks.Models
             
             if (transferDataTracing.UKFpsTracingData != null)
             {
-                UKFpsTracingDataJsonConverter uKFpsTracingDataJsonConverter = (UKFpsTracingDataJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferDataTracing.UKFpsTracingData.GetType()));
+                UKFpsTracingDataJsonConverter uKFpsTracingDataJsonConverter = (UKFpsTracingDataJsonConverter) jsonSerializerOptions.GetConverter(transferDataTracing.UKFpsTracingData.GetType());
                 uKFpsTracingDataJsonConverter.WriteProperties(writer, transferDataTracing.UKFpsTracingData, jsonSerializerOptions);
             }
 
             if (transferDataTracing.USAchTracingData != null)
             {
-                USAchTracingDataJsonConverter uSAchTracingDataJsonConverter = (USAchTracingDataJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferDataTracing.USAchTracingData.GetType()));
+                USAchTracingDataJsonConverter uSAchTracingDataJsonConverter = (USAchTracingDataJsonConverter) jsonSerializerOptions.GetConverter(transferDataTracing.USAchTracingData.GetType());
                 uSAchTracingDataJsonConverter.WriteProperties(writer, transferDataTracing.USAchTracingData, jsonSerializerOptions);
             }
 

--- a/Adyen/TransferWebhooks/Models/TransferDataTracking.cs
+++ b/Adyen/TransferWebhooks/Models/TransferDataTracking.cs
@@ -346,19 +346,19 @@ namespace Adyen.TransferWebhooks.Models
             
             if (transferDataTracking.ConfirmationTrackingData != null)
             {
-                ConfirmationTrackingDataJsonConverter confirmationTrackingDataJsonConverter = (ConfirmationTrackingDataJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferDataTracking.ConfirmationTrackingData.GetType()));
+                ConfirmationTrackingDataJsonConverter confirmationTrackingDataJsonConverter = (ConfirmationTrackingDataJsonConverter) jsonSerializerOptions.GetConverter(transferDataTracking.ConfirmationTrackingData.GetType());
                 confirmationTrackingDataJsonConverter.WriteProperties(writer, transferDataTracking.ConfirmationTrackingData, jsonSerializerOptions);
             }
 
             if (transferDataTracking.EstimationTrackingData != null)
             {
-                EstimationTrackingDataJsonConverter estimationTrackingDataJsonConverter = (EstimationTrackingDataJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferDataTracking.EstimationTrackingData.GetType()));
+                EstimationTrackingDataJsonConverter estimationTrackingDataJsonConverter = (EstimationTrackingDataJsonConverter) jsonSerializerOptions.GetConverter(transferDataTracking.EstimationTrackingData.GetType());
                 estimationTrackingDataJsonConverter.WriteProperties(writer, transferDataTracking.EstimationTrackingData, jsonSerializerOptions);
             }
 
             if (transferDataTracking.InternalReviewTrackingData != null)
             {
-                InternalReviewTrackingDataJsonConverter internalReviewTrackingDataJsonConverter = (InternalReviewTrackingDataJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferDataTracking.InternalReviewTrackingData.GetType()));
+                InternalReviewTrackingDataJsonConverter internalReviewTrackingDataJsonConverter = (InternalReviewTrackingDataJsonConverter) jsonSerializerOptions.GetConverter(transferDataTracking.InternalReviewTrackingData.GetType());
                 internalReviewTrackingDataJsonConverter.WriteProperties(writer, transferDataTracking.InternalReviewTrackingData, jsonSerializerOptions);
             }
 

--- a/Adyen/TransferWebhooks/Models/TransferEventEventsDataInner.cs
+++ b/Adyen/TransferWebhooks/Models/TransferEventEventsDataInner.cs
@@ -346,19 +346,19 @@ namespace Adyen.TransferWebhooks.Models
             
             if (transferEventEventsDataInner.InterchangeData != null)
             {
-                InterchangeDataJsonConverter interchangeDataJsonConverter = (InterchangeDataJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferEventEventsDataInner.InterchangeData.GetType()));
+                InterchangeDataJsonConverter interchangeDataJsonConverter = (InterchangeDataJsonConverter) jsonSerializerOptions.GetConverter(transferEventEventsDataInner.InterchangeData.GetType());
                 interchangeDataJsonConverter.WriteProperties(writer, transferEventEventsDataInner.InterchangeData, jsonSerializerOptions);
             }
 
             if (transferEventEventsDataInner.IssuingTransactionData != null)
             {
-                IssuingTransactionDataJsonConverter issuingTransactionDataJsonConverter = (IssuingTransactionDataJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferEventEventsDataInner.IssuingTransactionData.GetType()));
+                IssuingTransactionDataJsonConverter issuingTransactionDataJsonConverter = (IssuingTransactionDataJsonConverter) jsonSerializerOptions.GetConverter(transferEventEventsDataInner.IssuingTransactionData.GetType());
                 issuingTransactionDataJsonConverter.WriteProperties(writer, transferEventEventsDataInner.IssuingTransactionData, jsonSerializerOptions);
             }
 
             if (transferEventEventsDataInner.MerchantPurchaseData != null)
             {
-                MerchantPurchaseDataJsonConverter merchantPurchaseDataJsonConverter = (MerchantPurchaseDataJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferEventEventsDataInner.MerchantPurchaseData.GetType()));
+                MerchantPurchaseDataJsonConverter merchantPurchaseDataJsonConverter = (MerchantPurchaseDataJsonConverter) jsonSerializerOptions.GetConverter(transferEventEventsDataInner.MerchantPurchaseData.GetType());
                 merchantPurchaseDataJsonConverter.WriteProperties(writer, transferEventEventsDataInner.MerchantPurchaseData, jsonSerializerOptions);
             }
 

--- a/Adyen/TransferWebhooks/Models/TransferEventTracingData.cs
+++ b/Adyen/TransferWebhooks/Models/TransferEventTracingData.cs
@@ -311,13 +311,13 @@ namespace Adyen.TransferWebhooks.Models
             
             if (transferEventTracingData.UKFpsTracingData != null)
             {
-                UKFpsTracingDataJsonConverter uKFpsTracingDataJsonConverter = (UKFpsTracingDataJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferEventTracingData.UKFpsTracingData.GetType()));
+                UKFpsTracingDataJsonConverter uKFpsTracingDataJsonConverter = (UKFpsTracingDataJsonConverter) jsonSerializerOptions.GetConverter(transferEventTracingData.UKFpsTracingData.GetType());
                 uKFpsTracingDataJsonConverter.WriteProperties(writer, transferEventTracingData.UKFpsTracingData, jsonSerializerOptions);
             }
 
             if (transferEventTracingData.USAchTracingData != null)
             {
-                USAchTracingDataJsonConverter uSAchTracingDataJsonConverter = (USAchTracingDataJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferEventTracingData.USAchTracingData.GetType()));
+                USAchTracingDataJsonConverter uSAchTracingDataJsonConverter = (USAchTracingDataJsonConverter) jsonSerializerOptions.GetConverter(transferEventTracingData.USAchTracingData.GetType());
                 uSAchTracingDataJsonConverter.WriteProperties(writer, transferEventTracingData.USAchTracingData, jsonSerializerOptions);
             }
 

--- a/Adyen/TransferWebhooks/Models/TransferEventTrackingData.cs
+++ b/Adyen/TransferWebhooks/Models/TransferEventTrackingData.cs
@@ -346,19 +346,19 @@ namespace Adyen.TransferWebhooks.Models
             
             if (transferEventTrackingData.ConfirmationTrackingData != null)
             {
-                ConfirmationTrackingDataJsonConverter confirmationTrackingDataJsonConverter = (ConfirmationTrackingDataJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferEventTrackingData.ConfirmationTrackingData.GetType()));
+                ConfirmationTrackingDataJsonConverter confirmationTrackingDataJsonConverter = (ConfirmationTrackingDataJsonConverter) jsonSerializerOptions.GetConverter(transferEventTrackingData.ConfirmationTrackingData.GetType());
                 confirmationTrackingDataJsonConverter.WriteProperties(writer, transferEventTrackingData.ConfirmationTrackingData, jsonSerializerOptions);
             }
 
             if (transferEventTrackingData.EstimationTrackingData != null)
             {
-                EstimationTrackingDataJsonConverter estimationTrackingDataJsonConverter = (EstimationTrackingDataJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferEventTrackingData.EstimationTrackingData.GetType()));
+                EstimationTrackingDataJsonConverter estimationTrackingDataJsonConverter = (EstimationTrackingDataJsonConverter) jsonSerializerOptions.GetConverter(transferEventTrackingData.EstimationTrackingData.GetType());
                 estimationTrackingDataJsonConverter.WriteProperties(writer, transferEventTrackingData.EstimationTrackingData, jsonSerializerOptions);
             }
 
             if (transferEventTrackingData.InternalReviewTrackingData != null)
             {
-                InternalReviewTrackingDataJsonConverter internalReviewTrackingDataJsonConverter = (InternalReviewTrackingDataJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferEventTrackingData.InternalReviewTrackingData.GetType()));
+                InternalReviewTrackingDataJsonConverter internalReviewTrackingDataJsonConverter = (InternalReviewTrackingDataJsonConverter) jsonSerializerOptions.GetConverter(transferEventTrackingData.InternalReviewTrackingData.GetType());
                 internalReviewTrackingDataJsonConverter.WriteProperties(writer, transferEventTrackingData.InternalReviewTrackingData, jsonSerializerOptions);
             }
 

--- a/Adyen/Transfers/Models/BankAccountV3AccountIdentification.cs
+++ b/Adyen/Transfers/Models/BankAccountV3AccountIdentification.cs
@@ -801,97 +801,97 @@ namespace Adyen.Transfers.Models
             
             if (bankAccountV3AccountIdentification.AULocalAccountIdentification != null)
             {
-                AULocalAccountIdentificationJsonConverter aULocalAccountIdentificationJsonConverter = (AULocalAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.AULocalAccountIdentification.GetType()));
+                AULocalAccountIdentificationJsonConverter aULocalAccountIdentificationJsonConverter = (AULocalAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.AULocalAccountIdentification.GetType());
                 aULocalAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.AULocalAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.BRLocalAccountIdentification != null)
             {
-                BRLocalAccountIdentificationJsonConverter bRLocalAccountIdentificationJsonConverter = (BRLocalAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.BRLocalAccountIdentification.GetType()));
+                BRLocalAccountIdentificationJsonConverter bRLocalAccountIdentificationJsonConverter = (BRLocalAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.BRLocalAccountIdentification.GetType());
                 bRLocalAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.BRLocalAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.CALocalAccountIdentification != null)
             {
-                CALocalAccountIdentificationJsonConverter cALocalAccountIdentificationJsonConverter = (CALocalAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.CALocalAccountIdentification.GetType()));
+                CALocalAccountIdentificationJsonConverter cALocalAccountIdentificationJsonConverter = (CALocalAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.CALocalAccountIdentification.GetType());
                 cALocalAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.CALocalAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.CZLocalAccountIdentification != null)
             {
-                CZLocalAccountIdentificationJsonConverter cZLocalAccountIdentificationJsonConverter = (CZLocalAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.CZLocalAccountIdentification.GetType()));
+                CZLocalAccountIdentificationJsonConverter cZLocalAccountIdentificationJsonConverter = (CZLocalAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.CZLocalAccountIdentification.GetType());
                 cZLocalAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.CZLocalAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.DKLocalAccountIdentification != null)
             {
-                DKLocalAccountIdentificationJsonConverter dKLocalAccountIdentificationJsonConverter = (DKLocalAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.DKLocalAccountIdentification.GetType()));
+                DKLocalAccountIdentificationJsonConverter dKLocalAccountIdentificationJsonConverter = (DKLocalAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.DKLocalAccountIdentification.GetType());
                 dKLocalAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.DKLocalAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.HKLocalAccountIdentification != null)
             {
-                HKLocalAccountIdentificationJsonConverter hKLocalAccountIdentificationJsonConverter = (HKLocalAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.HKLocalAccountIdentification.GetType()));
+                HKLocalAccountIdentificationJsonConverter hKLocalAccountIdentificationJsonConverter = (HKLocalAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.HKLocalAccountIdentification.GetType());
                 hKLocalAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.HKLocalAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.HULocalAccountIdentification != null)
             {
-                HULocalAccountIdentificationJsonConverter hULocalAccountIdentificationJsonConverter = (HULocalAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.HULocalAccountIdentification.GetType()));
+                HULocalAccountIdentificationJsonConverter hULocalAccountIdentificationJsonConverter = (HULocalAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.HULocalAccountIdentification.GetType());
                 hULocalAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.HULocalAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.IbanAccountIdentification != null)
             {
-                IbanAccountIdentificationJsonConverter ibanAccountIdentificationJsonConverter = (IbanAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.IbanAccountIdentification.GetType()));
+                IbanAccountIdentificationJsonConverter ibanAccountIdentificationJsonConverter = (IbanAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.IbanAccountIdentification.GetType());
                 ibanAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.IbanAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.NOLocalAccountIdentification != null)
             {
-                NOLocalAccountIdentificationJsonConverter nOLocalAccountIdentificationJsonConverter = (NOLocalAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.NOLocalAccountIdentification.GetType()));
+                NOLocalAccountIdentificationJsonConverter nOLocalAccountIdentificationJsonConverter = (NOLocalAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.NOLocalAccountIdentification.GetType());
                 nOLocalAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.NOLocalAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.NZLocalAccountIdentification != null)
             {
-                NZLocalAccountIdentificationJsonConverter nZLocalAccountIdentificationJsonConverter = (NZLocalAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.NZLocalAccountIdentification.GetType()));
+                NZLocalAccountIdentificationJsonConverter nZLocalAccountIdentificationJsonConverter = (NZLocalAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.NZLocalAccountIdentification.GetType());
                 nZLocalAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.NZLocalAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.NumberAndBicAccountIdentification != null)
             {
-                NumberAndBicAccountIdentificationJsonConverter numberAndBicAccountIdentificationJsonConverter = (NumberAndBicAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.NumberAndBicAccountIdentification.GetType()));
+                NumberAndBicAccountIdentificationJsonConverter numberAndBicAccountIdentificationJsonConverter = (NumberAndBicAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.NumberAndBicAccountIdentification.GetType());
                 numberAndBicAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.NumberAndBicAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.PLLocalAccountIdentification != null)
             {
-                PLLocalAccountIdentificationJsonConverter pLLocalAccountIdentificationJsonConverter = (PLLocalAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.PLLocalAccountIdentification.GetType()));
+                PLLocalAccountIdentificationJsonConverter pLLocalAccountIdentificationJsonConverter = (PLLocalAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.PLLocalAccountIdentification.GetType());
                 pLLocalAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.PLLocalAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.SELocalAccountIdentification != null)
             {
-                SELocalAccountIdentificationJsonConverter sELocalAccountIdentificationJsonConverter = (SELocalAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.SELocalAccountIdentification.GetType()));
+                SELocalAccountIdentificationJsonConverter sELocalAccountIdentificationJsonConverter = (SELocalAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.SELocalAccountIdentification.GetType());
                 sELocalAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.SELocalAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.SGLocalAccountIdentification != null)
             {
-                SGLocalAccountIdentificationJsonConverter sGLocalAccountIdentificationJsonConverter = (SGLocalAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.SGLocalAccountIdentification.GetType()));
+                SGLocalAccountIdentificationJsonConverter sGLocalAccountIdentificationJsonConverter = (SGLocalAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.SGLocalAccountIdentification.GetType());
                 sGLocalAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.SGLocalAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.UKLocalAccountIdentification != null)
             {
-                UKLocalAccountIdentificationJsonConverter uKLocalAccountIdentificationJsonConverter = (UKLocalAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.UKLocalAccountIdentification.GetType()));
+                UKLocalAccountIdentificationJsonConverter uKLocalAccountIdentificationJsonConverter = (UKLocalAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.UKLocalAccountIdentification.GetType());
                 uKLocalAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.UKLocalAccountIdentification, jsonSerializerOptions);
             }
 
             if (bankAccountV3AccountIdentification.USLocalAccountIdentification != null)
             {
-                USLocalAccountIdentificationJsonConverter uSLocalAccountIdentificationJsonConverter = (USLocalAccountIdentificationJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(bankAccountV3AccountIdentification.USLocalAccountIdentification.GetType()));
+                USLocalAccountIdentificationJsonConverter uSLocalAccountIdentificationJsonConverter = (USLocalAccountIdentificationJsonConverter) jsonSerializerOptions.GetConverter(bankAccountV3AccountIdentification.USLocalAccountIdentification.GetType());
                 uSLocalAccountIdentificationJsonConverter.WriteProperties(writer, bankAccountV3AccountIdentification.USLocalAccountIdentification, jsonSerializerOptions);
             }
 

--- a/Adyen/Transfers/Models/TransferCategoryData.cs
+++ b/Adyen/Transfers/Models/TransferCategoryData.cs
@@ -381,25 +381,25 @@ namespace Adyen.Transfers.Models
             
             if (transferCategoryData.BankCategoryData != null)
             {
-                BankCategoryDataJsonConverter bankCategoryDataJsonConverter = (BankCategoryDataJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferCategoryData.BankCategoryData.GetType()));
+                BankCategoryDataJsonConverter bankCategoryDataJsonConverter = (BankCategoryDataJsonConverter) jsonSerializerOptions.GetConverter(transferCategoryData.BankCategoryData.GetType());
                 bankCategoryDataJsonConverter.WriteProperties(writer, transferCategoryData.BankCategoryData, jsonSerializerOptions);
             }
 
             if (transferCategoryData.InternalCategoryData != null)
             {
-                InternalCategoryDataJsonConverter internalCategoryDataJsonConverter = (InternalCategoryDataJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferCategoryData.InternalCategoryData.GetType()));
+                InternalCategoryDataJsonConverter internalCategoryDataJsonConverter = (InternalCategoryDataJsonConverter) jsonSerializerOptions.GetConverter(transferCategoryData.InternalCategoryData.GetType());
                 internalCategoryDataJsonConverter.WriteProperties(writer, transferCategoryData.InternalCategoryData, jsonSerializerOptions);
             }
 
             if (transferCategoryData.IssuedCard != null)
             {
-                IssuedCardJsonConverter issuedCardJsonConverter = (IssuedCardJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferCategoryData.IssuedCard.GetType()));
+                IssuedCardJsonConverter issuedCardJsonConverter = (IssuedCardJsonConverter) jsonSerializerOptions.GetConverter(transferCategoryData.IssuedCard.GetType());
                 issuedCardJsonConverter.WriteProperties(writer, transferCategoryData.IssuedCard, jsonSerializerOptions);
             }
 
             if (transferCategoryData.PlatformPayment != null)
             {
-                PlatformPaymentJsonConverter platformPaymentJsonConverter = (PlatformPaymentJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferCategoryData.PlatformPayment.GetType()));
+                PlatformPaymentJsonConverter platformPaymentJsonConverter = (PlatformPaymentJsonConverter) jsonSerializerOptions.GetConverter(transferCategoryData.PlatformPayment.GetType());
                 platformPaymentJsonConverter.WriteProperties(writer, transferCategoryData.PlatformPayment, jsonSerializerOptions);
             }
 

--- a/Adyen/Transfers/Models/TransferDataTracking.cs
+++ b/Adyen/Transfers/Models/TransferDataTracking.cs
@@ -346,19 +346,19 @@ namespace Adyen.Transfers.Models
             
             if (transferDataTracking.ConfirmationTrackingData != null)
             {
-                ConfirmationTrackingDataJsonConverter confirmationTrackingDataJsonConverter = (ConfirmationTrackingDataJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferDataTracking.ConfirmationTrackingData.GetType()));
+                ConfirmationTrackingDataJsonConverter confirmationTrackingDataJsonConverter = (ConfirmationTrackingDataJsonConverter) jsonSerializerOptions.GetConverter(transferDataTracking.ConfirmationTrackingData.GetType());
                 confirmationTrackingDataJsonConverter.WriteProperties(writer, transferDataTracking.ConfirmationTrackingData, jsonSerializerOptions);
             }
 
             if (transferDataTracking.EstimationTrackingData != null)
             {
-                EstimationTrackingDataJsonConverter estimationTrackingDataJsonConverter = (EstimationTrackingDataJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferDataTracking.EstimationTrackingData.GetType()));
+                EstimationTrackingDataJsonConverter estimationTrackingDataJsonConverter = (EstimationTrackingDataJsonConverter) jsonSerializerOptions.GetConverter(transferDataTracking.EstimationTrackingData.GetType());
                 estimationTrackingDataJsonConverter.WriteProperties(writer, transferDataTracking.EstimationTrackingData, jsonSerializerOptions);
             }
 
             if (transferDataTracking.InternalReviewTrackingData != null)
             {
-                InternalReviewTrackingDataJsonConverter internalReviewTrackingDataJsonConverter = (InternalReviewTrackingDataJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferDataTracking.InternalReviewTrackingData.GetType()));
+                InternalReviewTrackingDataJsonConverter internalReviewTrackingDataJsonConverter = (InternalReviewTrackingDataJsonConverter) jsonSerializerOptions.GetConverter(transferDataTracking.InternalReviewTrackingData.GetType());
                 internalReviewTrackingDataJsonConverter.WriteProperties(writer, transferDataTracking.InternalReviewTrackingData, jsonSerializerOptions);
             }
 

--- a/Adyen/Transfers/Models/TransferEventEventsDataInner.cs
+++ b/Adyen/Transfers/Models/TransferEventEventsDataInner.cs
@@ -346,19 +346,19 @@ namespace Adyen.Transfers.Models
             
             if (transferEventEventsDataInner.InterchangeData != null)
             {
-                InterchangeDataJsonConverter interchangeDataJsonConverter = (InterchangeDataJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferEventEventsDataInner.InterchangeData.GetType()));
+                InterchangeDataJsonConverter interchangeDataJsonConverter = (InterchangeDataJsonConverter) jsonSerializerOptions.GetConverter(transferEventEventsDataInner.InterchangeData.GetType());
                 interchangeDataJsonConverter.WriteProperties(writer, transferEventEventsDataInner.InterchangeData, jsonSerializerOptions);
             }
 
             if (transferEventEventsDataInner.IssuingTransactionData != null)
             {
-                IssuingTransactionDataJsonConverter issuingTransactionDataJsonConverter = (IssuingTransactionDataJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferEventEventsDataInner.IssuingTransactionData.GetType()));
+                IssuingTransactionDataJsonConverter issuingTransactionDataJsonConverter = (IssuingTransactionDataJsonConverter) jsonSerializerOptions.GetConverter(transferEventEventsDataInner.IssuingTransactionData.GetType());
                 issuingTransactionDataJsonConverter.WriteProperties(writer, transferEventEventsDataInner.IssuingTransactionData, jsonSerializerOptions);
             }
 
             if (transferEventEventsDataInner.MerchantPurchaseData != null)
             {
-                MerchantPurchaseDataJsonConverter merchantPurchaseDataJsonConverter = (MerchantPurchaseDataJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferEventEventsDataInner.MerchantPurchaseData.GetType()));
+                MerchantPurchaseDataJsonConverter merchantPurchaseDataJsonConverter = (MerchantPurchaseDataJsonConverter) jsonSerializerOptions.GetConverter(transferEventEventsDataInner.MerchantPurchaseData.GetType());
                 merchantPurchaseDataJsonConverter.WriteProperties(writer, transferEventEventsDataInner.MerchantPurchaseData, jsonSerializerOptions);
             }
 

--- a/Adyen/Transfers/Models/TransferEventTrackingData.cs
+++ b/Adyen/Transfers/Models/TransferEventTrackingData.cs
@@ -346,19 +346,19 @@ namespace Adyen.Transfers.Models
             
             if (transferEventTrackingData.ConfirmationTrackingData != null)
             {
-                ConfirmationTrackingDataJsonConverter confirmationTrackingDataJsonConverter = (ConfirmationTrackingDataJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferEventTrackingData.ConfirmationTrackingData.GetType()));
+                ConfirmationTrackingDataJsonConverter confirmationTrackingDataJsonConverter = (ConfirmationTrackingDataJsonConverter) jsonSerializerOptions.GetConverter(transferEventTrackingData.ConfirmationTrackingData.GetType());
                 confirmationTrackingDataJsonConverter.WriteProperties(writer, transferEventTrackingData.ConfirmationTrackingData, jsonSerializerOptions);
             }
 
             if (transferEventTrackingData.EstimationTrackingData != null)
             {
-                EstimationTrackingDataJsonConverter estimationTrackingDataJsonConverter = (EstimationTrackingDataJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferEventTrackingData.EstimationTrackingData.GetType()));
+                EstimationTrackingDataJsonConverter estimationTrackingDataJsonConverter = (EstimationTrackingDataJsonConverter) jsonSerializerOptions.GetConverter(transferEventTrackingData.EstimationTrackingData.GetType());
                 estimationTrackingDataJsonConverter.WriteProperties(writer, transferEventTrackingData.EstimationTrackingData, jsonSerializerOptions);
             }
 
             if (transferEventTrackingData.InternalReviewTrackingData != null)
             {
-                InternalReviewTrackingDataJsonConverter internalReviewTrackingDataJsonConverter = (InternalReviewTrackingDataJsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert(transferEventTrackingData.InternalReviewTrackingData.GetType()));
+                InternalReviewTrackingDataJsonConverter internalReviewTrackingDataJsonConverter = (InternalReviewTrackingDataJsonConverter) jsonSerializerOptions.GetConverter(transferEventTrackingData.InternalReviewTrackingData.GetType());
                 internalReviewTrackingDataJsonConverter.WriteProperties(writer, transferEventTrackingData.InternalReviewTrackingData, jsonSerializerOptions);
             }
 

--- a/templates-v7/csharp/libraries/generichost/JsonConverter.mustache
+++ b/templates-v7/csharp/libraries/generichost/JsonConverter.mustache
@@ -391,7 +391,7 @@
                 {{/isPrimitiveType}}
                 {{^isPrimitiveType}}
             {
-                {{baseType}}JsonConverter {{#lambda.camelcase_sanitize_param}}{{baseType}}JsonConverter{{/lambda.camelcase_sanitize_param}} = ({{baseType}}JsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert({{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}.GetType()));
+                {{baseType}}JsonConverter {{#lambda.camelcase_sanitize_param}}{{baseType}}JsonConverter{{/lambda.camelcase_sanitize_param}} = ({{baseType}}JsonConverter) jsonSerializerOptions.GetConverter({{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}.GetType());
                 {{#lambda.camelcase_sanitize_param}}{{baseType}}JsonConverter{{/lambda.camelcase_sanitize_param}}.WriteProperties(writer, {{#lambda.camelcase_sanitize_param}}{{classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}, jsonSerializerOptions);
             }
                 {{/isPrimitiveType}}
@@ -416,14 +416,14 @@
                 {{/isNumeric}}
                 {{#isEnum}}
             {
-                {{datatypeWithEnum}}JsonConverter {{#lambda.camelcase}}{{datatypeWithEnum}}{{/lambda.camelcase}}JsonConverter = ({{datatypeWithEnum}}JsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert({{#lambda.camelcase_sanitize_param}}{{model.classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}{{^required}}Option.Value{{/required}}.GetType()));
+                {{datatypeWithEnum}}JsonConverter {{#lambda.camelcase}}{{datatypeWithEnum}}{{/lambda.camelcase}}JsonConverter = ({{datatypeWithEnum}}JsonConverter) jsonSerializerOptions.GetConverter({{#lambda.camelcase_sanitize_param}}{{model.classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}{{^required}}Option.Value{{/required}}.GetType());
                 {{#lambda.camelcase}}{{datatypeWithEnum}}{{/lambda.camelcase}}JsonConverter.Write{{^isEnumRef}}Properties{{/isEnumRef}}(writer, {{#lambda.camelcase_sanitize_param}}{{model.classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}{{^required}}Option.Value{{#vendorExtensions.x-is-value-type}}.Value{{/vendorExtensions.x-is-value-type}}{{/required}}, jsonSerializerOptions);
             }
                 {{/isEnum}}
                 {{/isPrimitiveType}}
                 {{^isPrimitiveType}}
             {
-                {{datatypeWithEnum}}JsonConverter {{#lambda.camelcase}}{{datatypeWithEnum}}{{/lambda.camelcase}}JsonConverter = ({{datatypeWithEnum}}JsonConverter) jsonSerializerOptions.Converters.First(c => c.CanConvert({{#lambda.camelcase_sanitize_param}}{{model.classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}{{^required}}Option.Value{{/required}}.GetType()));
+                {{datatypeWithEnum}}JsonConverter {{#lambda.camelcase}}{{datatypeWithEnum}}{{/lambda.camelcase}}JsonConverter = ({{datatypeWithEnum}}JsonConverter) jsonSerializerOptions.GetConverter({{#lambda.camelcase_sanitize_param}}{{model.classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}{{^required}}Option.Value{{/required}}.GetType());
                 {{#lambda.camelcase}}{{datatypeWithEnum}}{{/lambda.camelcase}}JsonConverter.Write{{^isEnumRef}}Properties{{/isEnumRef}}(writer, {{#lambda.camelcase_sanitize_param}}{{model.classname}}{{/lambda.camelcase_sanitize_param}}.{{name}}{{^required}}Option.Value{{#vendorExtensions.x-is-value-type}}.Value{{/vendorExtensions.x-is-value-type}}{{/required}}, jsonSerializerOptions);
             }
                 {{/isPrimitiveType}}


### PR DESCRIPTION
**Description**
Bare serializer options do not contain explicitly registered converters. The converters exist through [JsonConverter] attributes, but are not present in options.Converters. Instead use GetConverters

**Tested scenarios**
Serialization of oneOf models
