### PR TITLE
Terminal API deserialization improve doc, comments add tests

### DIFF
--- a/Adyen.Test/TerminalApi/DeserializerTest.cs
+++ b/Adyen.Test/TerminalApi/DeserializerTest.cs
@@ -2,6 +2,7 @@
 using Adyen.Model.TerminalApi;
 using Adyen.Model.TerminalApi.Message;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 
 namespace Adyen.Test
 {
@@ -42,6 +43,47 @@ namespace Adyen.Test
             Assert.IsNotNull(result.MessageHeader);
             Assert.IsNotNull(result.MessagePayload);
             Assert.IsInstanceOfType(result.MessagePayload, typeof(EventNotification));
+        }
+
+        [TestMethod]
+        public void DeserializeNotification_WithMalformedJson_ShouldThrowJsonReaderException()
+        {
+            var serializer = new SaleToPoiMessageSerializer();
+
+            Assert.ThrowsExactly<JsonReaderException>(() => serializer.DeserializeNotification("{ invalid json }"));
+        }
+
+        [TestMethod]
+        public void DeserializeNotification_WithUnsupportedPayload_ShouldThrow()
+        {
+            var serializer = new SaleToPoiMessageSerializer();
+            const string json = @"{
+                ""SaleToPOIRequest"": {
+                    ""MessageHeader"": {
+                        ""MessageCategory"": ""Payment"",
+                        ""MessageClass"": ""Service"",
+                        ""MessageType"": ""Request""
+                    },
+                    ""PaymentRequest"": {}
+                }
+            }";
+
+            var exception = Assert.ThrowsExactly<System.Exception>(() => serializer.DeserializeNotification(json));
+
+            Assert.AreEqual("Json input is not a terminal notification.", exception.Message);
+        }
+
+        [TestMethod]
+        public void DeserializeNotification_WithoutMessageHeader_ShouldThrowNullReferenceException()
+        {
+            var serializer = new SaleToPoiMessageSerializer();
+            const string json = @"{
+                ""SaleToPOIRequest"": {
+                    ""DisplayRequest"": {}
+                }
+            }";
+
+            Assert.ThrowsExactly<System.NullReferenceException>(() => serializer.DeserializeNotification(json));
         }
 
         // Regression test for https://github.com/Adyen/adyen-dotnet-api-library/issues/1771

--- a/Adyen/TerminalApi/ApiSerialization/SaleToPoiMessageSerializer.cs
+++ b/Adyen/TerminalApi/ApiSerialization/SaleToPoiMessageSerializer.cs
@@ -7,6 +7,10 @@ using Newtonsoft.Json.Linq;
 
 namespace Adyen.ApiSerialization
 {
+    /// <summary>
+    /// Serializes Terminal API messages and deserializes responses and supported
+    /// terminal notifications.
+    /// </summary>
     public class SaleToPoiMessageSerializer
     {
         private readonly MessageHeaderSerializer _messageHeaderSerializer;
@@ -17,6 +21,11 @@ namespace Adyen.ApiSerialization
             _messageHeaderSerializer = new MessageHeaderSerializer();
             _messagePayloadSerializerFactory = new MessagePayloadSerializerFactory();
         }
+
+        /// <summary>
+        /// Deserializes a Terminal API response. Use <see cref="DeserializeNotification"/>
+        /// for notifications containing a DisplayRequest or EventNotification payload.
+        /// </summary>
         public SaleToPOIResponse Deserialize(string saleToPoiMessageDto)
         {
             var saleToPoiMessageJObject = JObject.Parse(saleToPoiMessageDto);
@@ -46,6 +55,10 @@ namespace Adyen.ApiSerialization
             return deserializedOutputMessage;
         }
 
+        /// <summary>
+        /// Deserializes a Terminal API notification containing a DisplayRequest or
+        /// EventNotification payload. Other message types are not supported.
+        /// </summary>
         public SaleToPOIRequest DeserializeNotification(string terminalNotificationJson)
         {
             // Parse JsonObject

--- a/README.md
+++ b/README.md
@@ -248,11 +248,28 @@ var config = new Config
 var client = new Client(config);
 ```
 
-To parse the terminal API notifications, you can use the following custom deserializer. This method will throw an exception for non-notification requests.
+Terminal API async responses and Terminal notifications can arrive at the same endpoint. In this case, choose the deserializer based on the message shape:
+
+- `SaleToPOIResponse` → `Deserialize()`
+- `SaleToPOIRequest` containing `DisplayRequest` or `EventNotification` → `DeserializeNotification()`
+
+For example:
 
 ```csharp
-SaleToPoiMessageSerializer serializer = new SaleToPoiMessageSerializer();
-SaleToPOIRequest saleToPoiRequest = serializer.DeserializeNotification(your_terminal_notification);
+using Newtonsoft.Json.Linq;
+
+var serializer = new SaleToPoiMessageSerializer();
+var message = JObject.Parse(payload);
+
+if (message["SaleToPOIRequest"]?["DisplayRequest"] != null
+    || message["SaleToPOIRequest"]?["EventNotification"] != null)
+{
+    SaleToPOIRequest notification = serializer.DeserializeNotification(payload);
+}
+else if (message["SaleToPOIResponse"] != null)
+{
+    SaleToPOIResponse response = serializer.Deserialize(payload);
+}
 ```
 
 ### Example Cloud Terminal API integration `/sync`-endpoint
@@ -385,7 +402,7 @@ PaymentResponse paymentResponse = response.MessagePayload as PaymentResponse;
 Console.WriteLine(paymentResponse?.Response?.Result);
 ```
 
-To parse the terminal API notifications, use the following custom deserializer. This method will throw an exception for non-notification requests.
+To parse a terminal API notification with a `SaleToPOIRequest` root property containing `DisplayRequest` or `EventNotification`, use the following custom deserializer. Use `Deserialize()` for messages with a `SaleToPOIResponse` root property.
 ```csharp
 var serializer = new SaleToPoiMessageSerializer();
 var saleToPoiRequest = serializer.DeserializeNotification(your_terminal_notification);


### PR DESCRIPTION
#1836 has raised an issue with the ambiguity of `SaleToPoiMessageSerializer` since the class includes 2 different functions:

- `Deserialize()` to process the async response `SaleToPOIResponse` 
- `DeserializeNotification()` to process Terminal notifications `EventNotification` or `DisplayRequest`

This PR improves README and comments, and adds some additional tests.