### PR TITLE
Support RFC 3339 format in DateOnlyJsonConverter

### DIFF
--- a/Adyen.Test/Checkout/CheckoutTest.cs
+++ b/Adyen.Test/Checkout/CheckoutTest.cs
@@ -435,6 +435,19 @@ namespace Adyen.Test.Checkout
         }
 
         [TestMethod]
+        public void Given_PaymentLinkResponseWithCompactDateOfBirth_When_Deserialize_Then_ReturnsDate()
+        {
+            // Arrange
+            string json = """{"amount":{"currency":"EUR","value":1000},"dateOfBirth":"19900102","id":"PL1","url":"https://x"}""";
+
+            // Act
+            var response = JsonSerializer.Deserialize<PaymentLinkResponse>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.AreEqual(new DateOnly(1990, 1, 2), response.DateOfBirth);
+        }
+
+        [TestMethod]
         public void Given_Deserialize_When_Payments_PayPal_Result_CheckoutSDKAction_Is_Not_Null()
         {
             // Arrange

--- a/Adyen.Test/Checkout/CheckoutTest.cs
+++ b/Adyen.Test/Checkout/CheckoutTest.cs
@@ -396,6 +396,45 @@ namespace Adyen.Test.Checkout
         }
 
         [TestMethod]
+        public void Given_PaymentLinkResponseWithDateTimeDateOfBirth_When_Deserialize_Then_ReturnsDatePortion()
+        {
+            // Arrange
+            string json = """{"amount":{"currency":"EUR","value":1000},"dateOfBirth":"1990-01-02T00:00:00+02:00","id":"PL1","url":"https://x"}""";
+
+            // Act
+            var response = JsonSerializer.Deserialize<PaymentLinkResponse>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.AreEqual(new DateOnly(1990, 1, 2), response.DateOfBirth);
+        }
+
+        [TestMethod]
+        public void Given_PaymentLinkResponseWithNullDateOfBirth_When_Deserialize_Then_ReturnsNull()
+        {
+            // Arrange
+            string json = """{"amount":{"currency":"EUR","value":1000},"dateOfBirth":null,"id":"PL1","url":"https://x"}""";
+
+            // Act
+            var response = JsonSerializer.Deserialize<PaymentLinkResponse>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.IsNull(response.DateOfBirth);
+        }
+
+        [TestMethod]
+        public void Given_PaymentLinkResponseWithDateOnlyDateOfBirth_When_Deserialize_Then_ReturnsDate()
+        {
+            // Arrange
+            string json = """{"amount":{"currency":"EUR","value":1000},"dateOfBirth":"1990-01-02","id":"PL1","url":"https://x"}""";
+
+            // Act
+            var response = JsonSerializer.Deserialize<PaymentLinkResponse>(json, _jsonSerializerOptionsProvider.Options);
+
+            // Assert
+            Assert.AreEqual(new DateOnly(1990, 1, 2), response.DateOfBirth);
+        }
+
+        [TestMethod]
         public void Given_Deserialize_When_Payments_PayPal_Result_CheckoutSDKAction_Is_Not_Null()
         {
             // Arrange

--- a/Adyen.Test/Core/Converters/DateOnlyJsonConverterTest.cs
+++ b/Adyen.Test/Core/Converters/DateOnlyJsonConverterTest.cs
@@ -40,14 +40,14 @@ namespace Adyen.Test.Core.Converters
         }
         
         [TestMethod]
-        public void Given_WrongFormatDateOnlyString_When_Read_Then_ThrowsNotSupportedException()
+        public void Given_WrongFormatDateOnlyString_When_Read_Then_ThrowsJsonException()
         {
             // Arrange
             string json = "\"25-12-2025\""; // Incorrect format dd-MM-yyyy
             
             // Act
             // Assert
-            Assert.ThrowsException<NotSupportedException>(() =>
+            Assert.ThrowsExactly<JsonException>(() =>
             {
                 var reader = new Utf8JsonReader(System.Text.Encoding.UTF8.GetBytes(json));
                 reader.Read();
@@ -71,14 +71,14 @@ namespace Adyen.Test.Core.Converters
         }
         
         [TestMethod]
-        public void Given_NullToken_When_Read_Then_ThrowsNotSupportedException()
+        public void Given_NullToken_When_Read_Then_ThrowsJsonException()
         {
             // Arrange
             string json = "null";
             
             // Act
             // Assert
-            Assert.ThrowsException<NotSupportedException>(() => { 
+            Assert.ThrowsExactly<JsonException>(() => { 
                 Utf8JsonReader reader = new Utf8JsonReader(System.Text.Encoding.UTF8.GetBytes(json));
                 reader.Read();
                 _converter.Read(ref reader, typeof(DateOnly), new JsonSerializerOptions());

--- a/Adyen.Test/Core/Converters/DateOnlyJsonConverterTest.cs
+++ b/Adyen.Test/Core/Converters/DateOnlyJsonConverterTest.cs
@@ -38,6 +38,47 @@ namespace Adyen.Test.Core.Converters
             // Assert
             Assert.AreEqual(new DateOnly(2025, 12, 25), result);
         }
+
+        [TestMethod]
+        public void Given_Rfc3339DateTime_When_Deserialize_Then_ReturnsDatePortion()
+        {
+            // Arrange
+            string json = "\"2025-12-25T10:30:00+02:00\"";
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(_converter);
+
+            // Act
+            var result = JsonSerializer.Deserialize<DateOnly>(json, options);
+
+            // Assert
+            Assert.AreEqual(new DateOnly(2025, 12, 25), result);
+        }
+
+        [TestMethod]
+        public void Given_NullDate_When_Deserialize_Then_ThrowsJsonException()
+        {
+            // Arrange
+            string json = "null";
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(_converter);
+
+            // Act
+            // Assert
+            Assert.ThrowsExactly<JsonException>(() => JsonSerializer.Deserialize<DateOnly>(json, options));
+        }
+
+        [TestMethod]
+        public void Given_InvalidCalendarDate_When_Deserialize_Then_ThrowsJsonException()
+        {
+            // Arrange
+            string json = "\"2025-01-40\"";
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(_converter);
+
+            // Act
+            // Assert
+            Assert.ThrowsExactly<JsonException>(() => JsonSerializer.Deserialize<DateOnly>(json, options));
+        }
         
         [TestMethod]
         public void Given_WrongFormatDateOnlyString_When_Read_Then_ThrowsJsonException()

--- a/Adyen/Checkout/Models/BalanceCheckRequest.cs
+++ b/Adyen/Checkout/Models/BalanceCheckRequest.cs
@@ -1079,7 +1079,7 @@ namespace Adyen.Checkout.Models
                             captureDelayHours = new Option<int?>(utf8JsonReader.TokenType == JsonTokenType.Null ? (int?)null : utf8JsonReader.GetInt32());
                             break;
                         case "dateOfBirth":
-                            dateOfBirth = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly>(ref utf8JsonReader, jsonSerializerOptions));
+                            dateOfBirth = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly?>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "dccQuote":
                             dccQuote = new Option<ForexQuote?>(JsonSerializer.Deserialize<ForexQuote>(ref utf8JsonReader, jsonSerializerOptions)!);

--- a/Adyen/Checkout/Models/CreateCheckoutSessionRequest.cs
+++ b/Adyen/Checkout/Models/CreateCheckoutSessionRequest.cs
@@ -1916,7 +1916,7 @@ namespace Adyen.Checkout.Models
                             countryCode = new Option<string?>(utf8JsonReader.GetString()!);
                             break;
                         case "dateOfBirth":
-                            dateOfBirth = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly>(ref utf8JsonReader, jsonSerializerOptions));
+                            dateOfBirth = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly?>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "deliverAt":
                             deliverAt = new Option<DateTimeOffset?>(JsonSerializer.Deserialize<DateTimeOffset>(ref utf8JsonReader, jsonSerializerOptions));

--- a/Adyen/Checkout/Models/LevelTwoThree.cs
+++ b/Adyen/Checkout/Models/LevelTwoThree.cs
@@ -241,7 +241,7 @@ namespace Adyen.Checkout.Models
                             itemDetailLines = new Option<List<ItemDetailLine>?>(JsonSerializer.Deserialize<List<ItemDetailLine>>(ref utf8JsonReader, jsonSerializerOptions)!);
                             break;
                         case "orderDate":
-                            orderDate = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly>(ref utf8JsonReader, jsonSerializerOptions));
+                            orderDate = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly?>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "shipFromPostalCode":
                             shipFromPostalCode = new Option<string?>(utf8JsonReader.GetString()!);

--- a/Adyen/Checkout/Models/Lodging.cs
+++ b/Adyen/Checkout/Models/Lodging.cs
@@ -459,10 +459,10 @@ namespace Adyen.Checkout.Models
                     switch (jsonPropertyName)
                     {
                         case "checkInDate":
-                            checkInDate = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly>(ref utf8JsonReader, jsonSerializerOptions));
+                            checkInDate = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly?>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "checkOutDate":
-                            checkOutDate = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly>(ref utf8JsonReader, jsonSerializerOptions));
+                            checkOutDate = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly?>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "customerServicePhoneNumber":
                             customerServicePhoneNumber = new Option<string?>(utf8JsonReader.GetString()!);

--- a/Adyen/Checkout/Models/Passenger.cs
+++ b/Adyen/Checkout/Models/Passenger.cs
@@ -179,7 +179,7 @@ namespace Adyen.Checkout.Models
                     switch (jsonPropertyName)
                     {
                         case "dateOfBirth":
-                            dateOfBirth = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly>(ref utf8JsonReader, jsonSerializerOptions));
+                            dateOfBirth = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly?>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "firstName":
                             firstName = new Option<string?>(utf8JsonReader.GetString()!);

--- a/Adyen/Checkout/Models/PaymentLinkRequest.cs
+++ b/Adyen/Checkout/Models/PaymentLinkRequest.cs
@@ -1190,7 +1190,7 @@ namespace Adyen.Checkout.Models
                             countryCode = new Option<string?>(utf8JsonReader.GetString()!);
                             break;
                         case "dateOfBirth":
-                            dateOfBirth = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly>(ref utf8JsonReader, jsonSerializerOptions));
+                            dateOfBirth = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly?>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "deliverAt":
                             deliverAt = new Option<DateTimeOffset?>(JsonSerializer.Deserialize<DateTimeOffset>(ref utf8JsonReader, jsonSerializerOptions));

--- a/Adyen/Checkout/Models/PaymentLinkResponse.cs
+++ b/Adyen/Checkout/Models/PaymentLinkResponse.cs
@@ -1400,7 +1400,7 @@ namespace Adyen.Checkout.Models
                             countryCode = new Option<string?>(utf8JsonReader.GetString()!);
                             break;
                         case "dateOfBirth":
-                            dateOfBirth = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly>(ref utf8JsonReader, jsonSerializerOptions));
+                            dateOfBirth = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly?>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "deliverAt":
                             deliverAt = new Option<DateTimeOffset?>(JsonSerializer.Deserialize<DateTimeOffset>(ref utf8JsonReader, jsonSerializerOptions));

--- a/Adyen/Checkout/Models/PickupInfo.cs
+++ b/Adyen/Checkout/Models/PickupInfo.cs
@@ -169,7 +169,7 @@ namespace Adyen.Checkout.Models
                             countryCode = new Option<string?>(utf8JsonReader.GetString()!);
                             break;
                         case "date":
-                            date = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly>(ref utf8JsonReader, jsonSerializerOptions));
+                            date = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly?>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "stateOrProvince":
                             stateOrProvince = new Option<string?>(utf8JsonReader.GetString()!);

--- a/Adyen/Checkout/Models/ReturnInfo.cs
+++ b/Adyen/Checkout/Models/ReturnInfo.cs
@@ -185,7 +185,7 @@ namespace Adyen.Checkout.Models
                             countryCode = new Option<string?>(utf8JsonReader.GetString()!);
                             break;
                         case "date":
-                            date = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly>(ref utf8JsonReader, jsonSerializerOptions));
+                            date = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly?>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "locationId":
                             locationId = new Option<string?>(utf8JsonReader.GetString()!);

--- a/Adyen/Checkout/Models/TemporaryServices.cs
+++ b/Adyen/Checkout/Models/TemporaryServices.cs
@@ -219,7 +219,7 @@ namespace Adyen.Checkout.Models
                             employeeName = new Option<string?>(utf8JsonReader.GetString()!);
                             break;
                         case "endDate":
-                            endDate = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly>(ref utf8JsonReader, jsonSerializerOptions));
+                            endDate = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly?>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "hourRate":
                             hourRate = new Option<int?>(utf8JsonReader.TokenType == JsonTokenType.Null ? (int?)null : utf8JsonReader.GetInt32());
@@ -234,7 +234,7 @@ namespace Adyen.Checkout.Models
                             serviceRequestor = new Option<string?>(utf8JsonReader.GetString()!);
                             break;
                         case "startDate":
-                            startDate = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly>(ref utf8JsonReader, jsonSerializerOptions));
+                            startDate = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly?>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         default:
                             break;

--- a/Adyen/Checkout/Models/Ticket.cs
+++ b/Adyen/Checkout/Models/Ticket.cs
@@ -150,7 +150,7 @@ namespace Adyen.Checkout.Models
                             issueAddress = new Option<string?>(utf8JsonReader.GetString()!);
                             break;
                         case "issueDate":
-                            issueDate = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly>(ref utf8JsonReader, jsonSerializerOptions));
+                            issueDate = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly?>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "number":
                             number = new Option<string?>(utf8JsonReader.GetString()!);

--- a/Adyen/Core/Converters/DateOnlyJsonConverter.cs
+++ b/Adyen/Core/Converters/DateOnlyJsonConverter.cs
@@ -17,7 +17,6 @@ namespace Adyen.Core.Converters
         public static string[] Formats { get; } = {
             "yyyy'-'MM'-'dd",
             "yyyyMMdd"
-
         };
 
         /// <summary>
@@ -29,7 +28,7 @@ namespace Adyen.Core.Converters
         /// <returns><see cref="DateOnly"/>.</returns>
         public override DateOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
             if (reader.TokenType == JsonTokenType.Null)
-                throw new NotSupportedException();
+                throw new JsonException("Unable to convert null to DateOnly.");
 
             string value = reader.GetString()!;
 
@@ -37,7 +36,10 @@ namespace Adyen.Core.Converters
                 if (DateOnly.TryParseExact(value, format, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateOnly result))
                     return result;
 
-            throw new NotSupportedException();
+            if (reader.TryGetDateTimeOffset(out DateTimeOffset dateTimeOffset))
+                return DateOnly.FromDateTime(dateTimeOffset.Date);
+
+            throw new JsonException($"Unable to convert \"{value}\" to DateOnly. Expected yyyy-MM-dd, yyyyMMdd, or an RFC 3339 date-time.");
         }
 
         /// <summary>

--- a/Adyen/Core/Converters/DateOnlyNullableJsonConverter.cs
+++ b/Adyen/Core/Converters/DateOnlyNullableJsonConverter.cs
@@ -17,6 +17,7 @@ namespace Adyen.Core.Converters
         public static string[] Formats { get; } = {
             "yyyy'-'MM'-'dd",
             "yyyyMMdd"
+
         };
 
         /// <summary>
@@ -35,7 +36,10 @@ namespace Adyen.Core.Converters
             foreach(string format in Formats)
                 if (DateOnly.TryParseExact(value, format, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateOnly result))
                     return result;
-            
+
+            if (reader.TryGetDateTimeOffset(out DateTimeOffset dateTimeOffset))
+                return DateOnly.FromDateTime(dateTimeOffset.Date);
+
             return null;
         }
 

--- a/Adyen/LegalEntityManagement/Models/SourceOfFunds.cs
+++ b/Adyen/LegalEntityManagement/Models/SourceOfFunds.cs
@@ -556,10 +556,10 @@ namespace Adyen.LegalEntityManagement.Models
                             cryptocurrencyExchange = new Option<string?>(utf8JsonReader.GetString()!);
                             break;
                         case "dateOfFundsReceived":
-                            dateOfFundsReceived = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly>(ref utf8JsonReader, jsonSerializerOptions));
+                            dateOfFundsReceived = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly?>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "dateOfSourceEvent":
-                            dateOfSourceEvent = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly>(ref utf8JsonReader, jsonSerializerOptions));
+                            dateOfSourceEvent = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly?>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "description":
                             description = new Option<string?>(utf8JsonReader.GetString()!);

--- a/Adyen/Payment/Models/PaymentRequest.cs
+++ b/Adyen/Payment/Models/PaymentRequest.cs
@@ -1490,7 +1490,7 @@ namespace Adyen.Payment.Models
                             card = new Option<Card?>(JsonSerializer.Deserialize<Card>(ref utf8JsonReader, jsonSerializerOptions)!);
                             break;
                         case "dateOfBirth":
-                            dateOfBirth = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly>(ref utf8JsonReader, jsonSerializerOptions));
+                            dateOfBirth = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly?>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "dccQuote":
                             dccQuote = new Option<ForexQuote?>(JsonSerializer.Deserialize<ForexQuote>(ref utf8JsonReader, jsonSerializerOptions)!);

--- a/Adyen/Payment/Models/PaymentRequest3d.cs
+++ b/Adyen/Payment/Models/PaymentRequest3d.cs
@@ -1096,7 +1096,7 @@ namespace Adyen.Payment.Models
                             captureDelayHours = new Option<int?>(utf8JsonReader.TokenType == JsonTokenType.Null ? (int?)null : utf8JsonReader.GetInt32());
                             break;
                         case "dateOfBirth":
-                            dateOfBirth = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly>(ref utf8JsonReader, jsonSerializerOptions));
+                            dateOfBirth = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly?>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "dccQuote":
                             dccQuote = new Option<ForexQuote?>(JsonSerializer.Deserialize<ForexQuote>(ref utf8JsonReader, jsonSerializerOptions)!);

--- a/Adyen/Payment/Models/PaymentRequest3ds2.cs
+++ b/Adyen/Payment/Models/PaymentRequest3ds2.cs
@@ -1092,7 +1092,7 @@ namespace Adyen.Payment.Models
                             captureDelayHours = new Option<int?>(utf8JsonReader.TokenType == JsonTokenType.Null ? (int?)null : utf8JsonReader.GetInt32());
                             break;
                         case "dateOfBirth":
-                            dateOfBirth = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly>(ref utf8JsonReader, jsonSerializerOptions));
+                            dateOfBirth = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly?>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "dccQuote":
                             dccQuote = new Option<ForexQuote?>(JsonSerializer.Deserialize<ForexQuote>(ref utf8JsonReader, jsonSerializerOptions)!);

--- a/Adyen/Payout/Models/SubmitRequest.cs
+++ b/Adyen/Payout/Models/SubmitRequest.cs
@@ -434,7 +434,7 @@ namespace Adyen.Payout.Models
                             additionalData = new Option<Dictionary<string, string>?>(JsonSerializer.Deserialize<Dictionary<string, string>>(ref utf8JsonReader, jsonSerializerOptions)!);
                             break;
                         case "dateOfBirth":
-                            dateOfBirth = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly>(ref utf8JsonReader, jsonSerializerOptions));
+                            dateOfBirth = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly?>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "entityType":
                             string? entityTypeRawValue = utf8JsonReader.GetString();

--- a/Adyen/TransferWebhooks/Models/ExecutionDate.cs
+++ b/Adyen/TransferWebhooks/Models/ExecutionDate.cs
@@ -131,7 +131,7 @@ namespace Adyen.TransferWebhooks.Models
                     switch (jsonPropertyName)
                     {
                         case "date":
-                            date = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly>(ref utf8JsonReader, jsonSerializerOptions));
+                            date = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly?>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "timezone":
                             timezone = new Option<string?>(utf8JsonReader.GetString()!);

--- a/Adyen/TransferWebhooks/Models/PartyIdentification.cs
+++ b/Adyen/TransferWebhooks/Models/PartyIdentification.cs
@@ -378,7 +378,7 @@ namespace Adyen.TransferWebhooks.Models
                             address = new Option<Address?>(JsonSerializer.Deserialize<Address>(ref utf8JsonReader, jsonSerializerOptions)!);
                             break;
                         case "dateOfBirth":
-                            dateOfBirth = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly>(ref utf8JsonReader, jsonSerializerOptions));
+                            dateOfBirth = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly?>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "email":
                             email = new Option<string?>(utf8JsonReader.GetString()!);

--- a/Adyen/TransferWebhooks/Models/UltimatePartyIdentification.cs
+++ b/Adyen/TransferWebhooks/Models/UltimatePartyIdentification.cs
@@ -393,7 +393,7 @@ namespace Adyen.TransferWebhooks.Models
                             address = new Option<Address?>(JsonSerializer.Deserialize<Address>(ref utf8JsonReader, jsonSerializerOptions)!);
                             break;
                         case "dateOfBirth":
-                            dateOfBirth = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly>(ref utf8JsonReader, jsonSerializerOptions));
+                            dateOfBirth = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly?>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "email":
                             email = new Option<string?>(utf8JsonReader.GetString()!);

--- a/Adyen/Transfers/Models/ExecutionDate.cs
+++ b/Adyen/Transfers/Models/ExecutionDate.cs
@@ -131,7 +131,7 @@ namespace Adyen.Transfers.Models
                     switch (jsonPropertyName)
                     {
                         case "date":
-                            date = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly>(ref utf8JsonReader, jsonSerializerOptions));
+                            date = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly?>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "timezone":
                             timezone = new Option<string?>(utf8JsonReader.GetString()!);

--- a/Adyen/Transfers/Models/PartyIdentification.cs
+++ b/Adyen/Transfers/Models/PartyIdentification.cs
@@ -378,7 +378,7 @@ namespace Adyen.Transfers.Models
                             address = new Option<Address?>(JsonSerializer.Deserialize<Address>(ref utf8JsonReader, jsonSerializerOptions)!);
                             break;
                         case "dateOfBirth":
-                            dateOfBirth = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly>(ref utf8JsonReader, jsonSerializerOptions));
+                            dateOfBirth = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly?>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "email":
                             email = new Option<string?>(utf8JsonReader.GetString()!);

--- a/Adyen/Transfers/Models/UltimatePartyIdentification.cs
+++ b/Adyen/Transfers/Models/UltimatePartyIdentification.cs
@@ -393,7 +393,7 @@ namespace Adyen.Transfers.Models
                             address = new Option<Address?>(JsonSerializer.Deserialize<Address>(ref utf8JsonReader, jsonSerializerOptions)!);
                             break;
                         case "dateOfBirth":
-                            dateOfBirth = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly>(ref utf8JsonReader, jsonSerializerOptions));
+                            dateOfBirth = new Option<DateOnly?>(JsonSerializer.Deserialize<DateOnly?>(ref utf8JsonReader, jsonSerializerOptions));
                             break;
                         case "email":
                             email = new Option<string?>(utf8JsonReader.GetString()!);

--- a/templates-v7/csharp/libraries/generichost/DateOnlyJsonConverter.mustache
+++ b/templates-v7/csharp/libraries/generichost/DateOnlyJsonConverter.mustache
@@ -28,15 +28,18 @@ namespace {{packageName}}.{{clientPackage}}
         /// <returns><see cref="DateOnly"/>.</returns>
         public override DateOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {
             if (reader.TokenType == JsonTokenType.Null)
-                throw new NotSupportedException();
+                throw new JsonException("Unable to convert null to DateOnly.");
 
             string value = reader.GetString(){{nrt!}};
 
             foreach(string format in Formats)
-                if (DateOnly.TryParseExact(value, format, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal, out DateOnly result))
+                if (DateOnly.TryParseExact(value, format, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateOnly result))
                     return result;
 
-            return null;
+            if (reader.TryGetDateTimeOffset(out DateTimeOffset dateTimeOffset))
+                return DateOnly.FromDateTime(dateTimeOffset.Date);
+
+            throw new JsonException($"Unable to convert \"{value}\" to DateOnly. Expected yyyy-MM-dd, yyyyMMdd, or an RFC 3339 date-time.");
         }
 
         /// <summary>

--- a/templates-v7/csharp/libraries/generichost/DateOnlyNullableJsonConverter.mustache
+++ b/templates-v7/csharp/libraries/generichost/DateOnlyNullableJsonConverter.mustache
@@ -34,8 +34,11 @@ namespace {{packageName}}.{{clientPackage}}
             string value = reader.GetString(){{nrt!}};
 
             foreach(string format in Formats)
-                if (DateOnly.TryParseExact(value, format, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal, out DateOnly result))
+                if (DateOnly.TryParseExact(value, format, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateOnly result))
                     return result;
+
+            if (reader.TryGetDateTimeOffset(out DateTimeOffset dateTimeOffset))
+                return DateOnly.FromDateTime(dateTimeOffset.Date);
 
             return null;
         }

--- a/templates-v7/csharp/libraries/generichost/JsonConverter.mustache
+++ b/templates-v7/csharp/libraries/generichost/JsonConverter.mustache
@@ -224,7 +224,7 @@
                         {{/isEnum}}
                         {{/isNumeric}}
                         {{#isDate}}
-                            {{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}} = {{>OptionProperty}}JsonSerializer.Deserialize<{{#supportsDateOnly}}DateOnly{{/supportsDateOnly}}{{^supportsDateOnly}}DateTime{{/supportsDateOnly}}{{#isNullable}}?{{/isNullable}}>(ref utf8JsonReader, jsonSerializerOptions));
+                            {{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}} = {{>OptionProperty}}JsonSerializer.Deserialize<{{#supportsDateOnly}}DateOnly{{/supportsDateOnly}}{{^supportsDateOnly}}DateTime{{/supportsDateOnly}}{{>NullConditionalProperty}}>(ref utf8JsonReader, jsonSerializerOptions));
                         {{/isDate}}
                         {{#isDateTime}}
                             {{! Fix: Added support for DateTimeOffset, when `useDateTimeOffset=true` }}


### PR DESCRIPTION
**Description**
Support RFC 3339 format in DateOnlyJsonConverter.
Update converter templates and regenerated code.

**Tested scenarios**
```
// Both of these throw NotSupportedException:
JsonSerializer.Deserialize<PaymentLinkResponse>(
    """{"amount":{"currency":"EUR","value":1000},"dateOfBirth":"1990-01-02T00:00:00+02:00","id":"PL1","url":"https://x"}""", options);

JsonSerializer.Deserialize<PaymentLinkResponse>(
    """{"amount":{"currency":"EUR","value":1000},"dateOfBirth":null,"id":"PL1","url":"https://x"}""", options);

// This one works:
JsonSerializer.Deserialize<PaymentLinkResponse>(
    """{"amount":{"currency":"EUR","value":1000},"dateOfBirth":"1990-01-02","id":"PL1","url":"https://x"}""", options);
```

**Fixed issue**:  #1834
